### PR TITLE
docs: Add terminal usage instructions to prevent invalid terminal ID errors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -201,6 +201,11 @@ The project uses the following Pulumi providers:
    - Use subshells instead: `(cd foo && command)` to isolate directory changes
    - Alternatively, use explicit paths or tools that support working directory arguments
 
+7. **Terminal Usage**:
+   - Always use the `run_in_terminal` tool instead of trying to reference specific terminal IDs
+   - Avoid using `get_terminal_output` with specific IDs as they may become invalid
+   - Let VS Code manage terminal sessions automatically
+
 ## Common Commands
 
 ```bash


### PR DESCRIPTION
This PR adds specific terminal usage instructions to the GitHub Copilot instructions to prevent the frequent "invalid terminal ID" errors that appear in the logs.

## Problem

The logs frequently show errors like:
```
Error from tool get_terminal_output with args {"id": "123721"}: Invalid terminal ID
```

This happens when trying to reference specific terminal IDs that may no longer be valid.

## Solution

Added a new "Terminal Usage" section with clear instructions:

### New Terminal Usage Guidelines
- ✅ **Always use `run_in_terminal` tool** instead of trying to reference specific terminal IDs
- ✅ **Avoid using `get_terminal_output` with specific IDs** as they may become invalid
- ✅ **Let VS Code manage terminal sessions automatically**

## Benefits

- 🐛 **Prevents invalid terminal ID errors**
- 🔧 **Improves reliability** of terminal operations
- 📝 **Clear guidance** for future AI assistant interactions
- ⚡ **Better user experience** with fewer error interruptions

## Testing

Tested the new approach and confirmed it works correctly without generating invalid terminal ID errors.

This follows the established pattern in the instructions where we provide specific guidance for common issues (like the existing shell command guidance).