### PR TITLE
Improve terminal usage guidelines in copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -202,9 +202,10 @@ The project uses the following Pulumi providers:
    - Alternatively, use explicit paths or tools that support working directory arguments
 
 7. **Terminal Usage**:
-   - Always use the `run_in_terminal` tool instead of trying to reference specific terminal IDs
-   - Avoid using `get_terminal_output` with specific IDs as they may become invalid
-   - Let VS Code manage terminal sessions automatically
+   - **NEVER** use `get_terminal_output` with hardcoded terminal IDs as they frequently become invalid
+   - Always use the `run_in_terminal` tool for executing commands - it creates new terminal sessions as needed
+   - If you need to check terminal output, use `run_in_terminal` again rather than trying to reference old terminal IDs
+   - Let VS Code manage terminal sessions automatically - don't try to track or reuse specific terminal instances
 
 ## Common Commands
 


### PR DESCRIPTION
## Summary

This PR improves the terminal usage guidelines in the GitHub Copilot instructions to prevent terminal ID invalidation issues that have been occurring during development.

## Changes

- Add explicit warning against using `get_terminal_output` with hardcoded terminal IDs
- Emphasize always using `run_in_terminal` tool for command execution  
- Add guidance to use separate `run_in_terminal` calls rather than chaining commands across terminal sessions
- Clarify that VS Code should manage terminal sessions automatically

## Background

During development, we've encountered issues where terminal IDs become invalid, causing tool calls to fail. This update strengthens the existing guidelines to prevent these issues from occurring in the future.

## Testing

- [x] Updated instructions are clear and comprehensive
- [x] Guidelines follow best practices for VS Code terminal management
- [x] Changes committed and pushed to feature branch

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change