### PR TITLE
Enhance subshell command guidelines and fix common commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -197,8 +197,9 @@ The project uses the following Pulumi providers:
    - Include deployment and troubleshooting guides
 
 6. **Shell Commands**:
-   - Never use `cd foo && command` patterns as this changes the current working directory of the shell
-   - Use subshells instead: `(cd foo && command)` to isolate directory changes
+   - **NEVER** use `cd foo && command` patterns as this changes the current working directory of the shell
+   - **ALWAYS** use subshells instead: `(cd foo && command)` to isolate directory changes
+   - This is critical: `cd services/iot && pulumi stack ls` is WRONG, use `(cd services/iot && pulumi stack ls)` instead
    - Alternatively, use explicit paths or tools that support working directory arguments
 
 7. **Terminal Usage**:
@@ -219,12 +220,17 @@ uv run ./scripts/generate-config-schema
 # Run all checks
 uv run ./scripts/run-all-checks.sh
 
-# Deploy a service
-cd services/{service-name}
-pulumi up --stack {stack-name}
+# Deploy a service (using subshell to isolate directory change)
+(cd services/{service-name} && pulumi up --stack {stack-name})
 
-# Preview changes
-pulumi preview --stack {stack-name}
+# Preview changes (using subshell to isolate directory change)
+(cd services/{service-name} && pulumi preview --stack {stack-name})
+
+# List available stacks for a service
+(cd services/{service-name} && pulumi stack ls)
+
+# Check stack configuration
+(cd services/{service-name} && pulumi config --stack {stack-name})
 ```
 
 ## AI Assistant Guidelines


### PR DESCRIPTION
## Summary

This PR enhances the subshell command guidelines and fixes the common commands section to prevent shell working directory pollution and ensure commands execute in the correct context.

## Changes

### Enhanced Shell Command Guidelines:
- **Strengthened emphasis**: Changed "Never" to "**NEVER**" and "Use" to "**ALWAYS**" for stronger visual impact
- **Added concrete example**: Shows the wrong way `cd services/iot && pulumi stack ls` vs the right way `(cd services/iot && pulumi stack ls)`
- **Clear directive**: Makes it crystal clear what pattern to avoid and what to use instead

### Fixed Common Commands Section:
- **Updated all Pulumi commands** to use proper subshell pattern: `(cd services/{service-name} && command)`
- **Removed problematic pattern** of separate `cd` followed by commands that changes shell state
- **Added more examples**: Including `pulumi stack ls` and `pulumi config` commands
- **Added explanatory comments**: Each command includes "(using subshell to isolate directory change)"

## Testing

✅ **Verified subshell pattern works correctly**:
- `(cd services/iot && pulumi stack ls)` - Executed successfully
- `(cd services/kubernetes && pulumi config --stack prod)` - Executed successfully  
- `(cd services/iot && pulumi preview --stack prod)` - Executed successfully
- Working directory remained in repo root after all commands (confirmed with `pwd`)

## Background

This addresses the shell command issues we encountered during development where directory changes would persist and affect subsequent commands. The subshell pattern `(cd dir && command)` ensures directory changes are isolated and don't pollute the global shell state.

## Type of Change

- [x] Documentation improvement
- [x] Best practices enforcement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change