### PR TITLE
Revert "More precice terminal id instructions"

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -223,18 +223,10 @@ The project uses the following Pulumi providers:
    - Alternatively, use explicit paths or tools that support working directory arguments
 
 7. **Terminal Usage**:
-<<<<<<< Updated upstream
    - **NEVER** use `get_terminal_output` with hardcoded terminal IDs as they frequently become invalid
    - Always use the `run_in_terminal` tool for executing commands - it creates new terminal sessions as needed
    - If you need to check terminal output, use `run_in_terminal` again rather than trying to reference old terminal IDs
    - Let VS Code manage terminal sessions automatically - don't try to track or reuse specific terminal instances
-=======
-   - **CRITICAL**: ALWAYS use the `run_in_terminal` tool without any terminal ID parameters
-   - **NEVER** use `get_terminal_output` with specific terminal IDs - they become invalid quickly
-   - **NEVER** reference terminal IDs in any tool calls - let VS Code manage sessions automatically
-   - Use only the default terminal session that VS Code provides
-   - Terminal IDs are ephemeral and will cause errors when referenced
->>>>>>> Stashed changes
 
 ## Common Commands
 


### PR DESCRIPTION
Reverts CrashLoopBackCoffee/th-deploy-homelab#100