### PR TITLE
docs: enhance copilot instructions with shell command warnings and diff preview

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -221,6 +221,7 @@ The project uses the following Pulumi providers:
    - **ALWAYS** use subshells instead: `(cd foo && command)` to isolate directory changes
    - This is critical: `cd services/iot && pulumi stack ls` is WRONG, use `(cd services/iot && pulumi stack ls)` instead
    - Alternatively, use explicit paths or tools that support working directory arguments
+   - **VIOLATION OF THIS RULE IS CRITICAL** - changing working directory breaks the shell session for other commands
 
 7. **Terminal Usage**:
    - **NEVER** use `get_terminal_output` with hardcoded terminal IDs as they frequently become invalid
@@ -245,6 +246,9 @@ uv run ./scripts/run-all-checks.sh
 
 # Preview changes (using subshell to isolate directory change)
 (cd services/{service-name} && pulumi preview --stack {stack-name})
+
+# Preview changes with diff to see actual modifications
+(cd services/{service-name} && pulumi preview -s {stack-name} --diff)
 
 # List available stacks for a service
 (cd services/{service-name} && pulumi stack ls)


### PR DESCRIPTION
## Summary

This PR enhances the GitHub Copilot instructions with important clarifications around shell command usage and adds a useful command example.

## Changes

- **Added critical warning** about violating shell command directory change rules - emphasizes that changing working directory breaks the shell session for other commands
- **Added new command example** for `pulumi preview --diff` to show actual modifications when previewing changes
- **Improved clarity** on the importance of using subshells to isolate directory changes

## Motivation

These changes help prevent common mistakes when working with the homelab infrastructure:

1. The critical warning helps prevent shell session corruption that can occur when directory changes aren't properly isolated
2. The diff preview command is useful for seeing exactly what changes Pulumi will make before applying them

## Testing

- [x] Verified markdown formatting
- [x] Checked that the new command examples follow the established patterns
- [x] Confirmed the warnings are prominently displayed