### PR TITLE
docs: add --non-interactive flag to all pulumi commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -229,6 +229,11 @@ The project uses the following Pulumi providers:
    - If you need to check terminal output, use `run_in_terminal` again rather than trying to reference old terminal IDs
    - Let VS Code manage terminal sessions automatically - don't try to track or reuse specific terminal instances
 
+8. **Pulumi Commands**:
+   - **ALWAYS** use `--non-interactive` flag with Pulumi commands to prevent interactive mode from breaking terminal integration
+   - This applies to `pulumi up`, `pulumi preview`, and other commands that might prompt for user input
+   - Interactive mode can cause VS Code terminal sessions to hang or become unresponsive
+
 ## Common Commands
 
 ```bash
@@ -242,13 +247,13 @@ uv run ./scripts/generate-config-schema
 uv run ./scripts/run-all-checks.sh
 
 # Deploy a service (using subshell to isolate directory change)
-(cd services/{service-name} && pulumi up --stack {stack-name})
+(cd services/{service-name} && pulumi up --stack {stack-name} --non-interactive)
 
 # Preview changes (using subshell to isolate directory change)
-(cd services/{service-name} && pulumi preview --stack {stack-name})
+(cd services/{service-name} && pulumi preview --stack {stack-name} --non-interactive)
 
 # Preview changes with diff to see actual modifications
-(cd services/{service-name} && pulumi preview -s {stack-name} --diff)
+(cd services/{service-name} && pulumi preview -s {stack-name} --diff --non-interactive)
 
 # List available stacks for a service
 (cd services/{service-name} && pulumi stack ls)


### PR DESCRIPTION
## Summary

This PR adds the `--non-interactive` flag to all Pulumi commands in the copilot instructions to prevent interactive mode from breaking VS Code terminal integration.

## Changes

- **Added new best practice section** for Pulumi commands with clear guidelines about using `--non-interactive`
- **Updated all Pulumi command examples** to include the `--non-interactive` flag:
  - `pulumi up --stack {stack-name} --non-interactive`
  - `pulumi preview --stack {stack-name} --non-interactive`
  - `pulumi preview -s {stack-name} --diff --non-interactive`
- **Added detailed explanation** of why this flag is critical for VS Code terminal integration

## Motivation

This change addresses a critical issue where Pulumi's interactive mode can cause VS Code terminal sessions to hang or become unresponsive. The `--non-interactive` flag ensures that:

1. Pulumi commands don't wait for user input that can't be provided in automated contexts
2. Terminal sessions remain responsive and don't hang
3. Commands can be safely executed through VS Code's terminal integration
4. Automated workflows and scripts work reliably

## Follow-up to PR #102

This builds on the improvements from PR #102 by addressing the specific issue of Pulumi interactive mode breaking terminal integration, as identified during testing.

## Testing

- [x] Verified all command examples include `--non-interactive` flag
- [x] Confirmed the new best practice section is clearly documented
- [x] Checked that the guidelines explain the importance of this flag
- [x] Validated markdown formatting