### PR TITLE
chore(lint): update pre-commit and lint config for consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,16 +18,19 @@ repos:
         entry: ./.venv/bin/pyright --warnings
         language: system
         types: [python]
+        pass_filenames: false
       - id: ruff-format
         name: ruff-format
         entry: ./.venv/bin/ruff format
         language: system
         types: [python]
+        pass_filenames: false
       - id: ruff-check
         name: ruff-check
         entry: ./.venv/bin/ruff check --fix
         language: system
         types: [python]
+        pass_filenames: false
       - id: yamllint
         name: yamllint
         entry: ./.venv/bin/yamllint --strict -c=.yamllint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ build-backend = "hatchling.build"
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-exclude = [".venv"]
+extend-exclude = ["docs/examples"]
 
 [tool.ruff.lint]
 extend-select = [
@@ -102,13 +102,13 @@ quote-style = "single"
 [tool.pyright]
 deprecateTypingAliases = true
 useLibraryCodeForTypes = true
-include = ["src"]
 exclude = [
     "__pycache__",
     ".venv",
     ".vscode",
     "build",
     "dist",
+    "docs/examples",
     "node_modules",
     "venv",
 ]


### PR DESCRIPTION
- Add pass_filenames: false to local pre-commit hooks for ruff and pyright
  - This ensures linters use their configured include/exclude rules, which only apply if no filenames are passed by pre-commit
- Use extend-exclude for ruff and add docs/examples to pyright exclude
- Ensure consistent linting and type checking configuration across the project