### PR TITLE
fix(paperless): use loose versioning for restic image to improve renovate tag recognition

### DIFF
--- a/services/paperless/Pulumi.prod.yaml
+++ b/services/paperless/Pulumi.prod.yaml
@@ -25,7 +25,7 @@ config:
       consume-server: synology.tobiash.net
       consume-share: /volume2/paperless
     backup:
-      # renovate: datasource=docker packageName=ghcr.io/crashloopbackcoffee/restic-rclone versioning=docker
+      # renovate: datasource=docker packageName=ghcr.io/crashloopbackcoffee/restic-rclone versioning=loose
       restic-rclone-version: restic-0.18.0-rclone-1.68.2
       # renovate: datasource=github-releases packageName=kubernetes/kubernetes versioning=semver
       kubectl-version: 1.33.3


### PR DESCRIPTION
The combined tag cannot match the docker versioning scheme, so we use loose versioning to give renovate more chances to recognize the tag as a version.