### PR TITLE
fix: restic-rclone version tag format

### DIFF
--- a/services/paperless/Pulumi.prod.yaml
+++ b/services/paperless/Pulumi.prod.yaml
@@ -25,8 +25,8 @@ config:
       consume-server: synology.tobiash.net
       consume-share: /volume2/paperless
     backup:
-      # renovate: datasource=docker packageName=ghcr.io/crashloopbackcoffee/restic-rclone versioning=loose
-      restic-rclone-version: 0.18.0_1.68.2
+      # renovate: datasource=docker packageName=ghcr.io/crashloopbackcoffee/restic-rclone versioning=docker
+      restic-rclone-version: 0.18.0-1.68.2
       # renovate: datasource=github-releases packageName=kubernetes/kubernetes versioning=semver
       kubectl-version: 1.33.3
       repository-path: paperless


### PR DESCRIPTION
Use dash instead of underscore in restic-rclone-version to match upstream image tags and allow Renovate to detect updates. This fixes version tracking for the backup image in paperless.