### PR TITLE
feat: optimize direnv by skipping 1password read if OP_SERVICE_ACCOUNT_TOKEN already set

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -58,7 +58,11 @@ fi
 
 # Handle ONE_PASSWORD_TOKEN if exists
 echo -e "Setting up 1Password CLI"
-export OP_SERVICE_ACCOUNT_TOKEN=$(op.exe read "${ONE_PASSWORD_TOKEN}")
+if [ -z "${OP_SERVICE_ACCOUNT_TOKEN}" ]; then
+  export OP_SERVICE_ACCOUNT_TOKEN=$(op.exe read "${ONE_PASSWORD_TOKEN}")
+else
+  echo "OP_SERVICE_ACCOUNT_TOKEN already set, skipping 1password read"
+fi
 
 if [ "${USE_S3_BACKEND:-false)}" = "true" ]; then
   echo "Using S3 backend for pulumi"


### PR DESCRIPTION
Skip reading OP_SERVICE_ACCOUNT_TOKEN from 1password if it's already set in the environment, improving performance by avoiding unnecessary calls.

Fixes #149

Generated with [Claude Code](https://claude.ai/code)