### PR TITLE
fix(backup): Resolve permission errors and deprecation warnings

### DIFF
--- a/services/backup/assets/backup.sh.j2
+++ b/services/backup/assets/backup.sh.j2
@@ -13,6 +13,7 @@ backup_volume() {
 
     export RESTIC_REPOSITORY="s3:${AWS_S3_ENDPOINT}/${BUCKET}"
     export RESTIC_PASSWORD_FILE="/secrets/restic-password"
+    export RESTIC_CACHE_DIR="/tmp/.cache/restic"
 
     # Initialize repository if it doesn't exist
     echo "Initializing repository if needed..."
@@ -27,7 +28,7 @@ backup_volume() {
 
     # Apply retention policy
     echo "Applying retention policy for $VOLUME_NAME..."
-    restic forget --tag "$VOLUME_NAME" \
+    restic forget --tag "$VOLUME_NAME" --host backup-service \
         --keep-daily {{ retention_daily }} \
         --keep-weekly {{ retention_weekly }} \
         --keep-monthly {{ retention_monthly }} \


### PR DESCRIPTION
The backup script was producing permission denied errors due to an incorrect cache directory and deprecation warnings for the --hostname flag.

This commit fixes these issues by:
- Setting RESTIC_CACHE_DIR to a writable location.
- Adding the --host flag to the 'restic forget' command.