### PR TITLE
feat(monitoring): Add HTTP TLS configuration for Alloy

### DIFF
--- a/services/monitoring/assets/alloy/http_tls.alloy
+++ b/services/monitoring/assets/alloy/http_tls.alloy
@@ -1,0 +1,8 @@
+http {
+	tls {
+		cert_file = "/etc/alloy/certs/tls.crt"
+		key_file  = "/etc/alloy/certs/tls.key"
+
+		min_version = "TLS12"
+	}
+}

--- a/services/monitoring/monitoring/alloy.py
+++ b/services/monitoring/monitoring/alloy.py
@@ -6,7 +6,7 @@ import utils.opnsense.unbound.host_override
 from monitoring.config import ComponentConfig
 from monitoring.utils import get_assets_path
 
-ALLOY_HTTP_PORT = 12345
+ALLOY_HTTP_PORT = 443
 ALLOY_OTEL_GRPC_PORT = 4317
 ALLOY_OTEL_HTTP_PORT = 4318
 


### PR DESCRIPTION
## Summary
- Add HTTP TLS configuration for Alloy service
- Configure secure HTTPS on port 443 with cert-manager certificates
- Enable TLS 1.2+ with proper certificate paths

## Changes
- **New file**: `services/monitoring/assets/alloy/http_tls.alloy` - TLS configuration block
- **Updated**: `services/monitoring/monitoring/alloy.py` - Changed HTTP port from 12345 to 443 for HTTPS

## Test plan
- [ ] Deploy to test environment and verify HTTPS endpoint is accessible
- [ ] Confirm TLS certificate is properly loaded from cert-manager
- [ ] Validate TLS version enforcement (min TLS 1.2)

🤖 Generated with [Claude Code](https://claude.ai/code)