### PR TITLE
Fix container name as service name in alloy legacy

### DIFF
--- a/services/monitoring/assets/alloy_legacy/collect_loki.alloy
+++ b/services/monitoring/assets/alloy_legacy/collect_loki.alloy
@@ -68,6 +68,6 @@ loki.relabel "logs" {
 //===========================================================
 otelcol.receiver.loki "default" {
 	output {
-		logs = [otelcol.processor.resourcedetection.default.input]
+		logs = [otelcol.processor.transform.set_service_name_from_container.input]
 	}
 }

--- a/services/monitoring/assets/alloy_legacy/process_otel.alloy
+++ b/services/monitoring/assets/alloy_legacy/process_otel.alloy
@@ -1,6 +1,22 @@
 //===========================================================
 // Otel pipeline
 //===========================================================
+otelcol.processor.transform "set_service_name_from_container" {
+	// Map container log attribute to service.name resource attribute
+	error_mode = "ignore"
+
+	log_statements {
+		context    = "log"
+		statements = [
+			"set(resource.attributes[\"service.name\"], attributes[\"container\"]) where attributes[\"container\"] != nil",
+		]
+	}
+
+	output {
+		logs = [otelcol.processor.resourcedetection.default.input]
+	}
+}
+
 otelcol.processor.resourcedetection "default" {
 	detectors = ["env", "system"]
 


### PR DESCRIPTION
## Summary
- Fix Docker container logs showing `service_name=unknown_service` instead of actual container names
- Add OTEL transform processor to map container log attribute to `service.name` resource attribute
- Update processing pipeline to include the new transform processor

## Technical Details
- Added `otelcol.processor.transform "set_service_name_from_container"` processor
- Uses OTTL statement with `log` context to access container attribute correctly
- Maps `attributes["container"]` → `resource.attributes["service.name"]`
- Only applies transformation when container attribute exists

## Test Plan
- [x] Alloy configuration validates with `alloy fmt`
- [x] Verified container attribute is present in log debug output
- [x] Transform processor correctly maps to service.name resource attribute

🤖 Generated with [Claude Code](https://claude.ai/code)