### PR TITLE
Fix synology logs service name and restructure OTEL pipeline

### DIFF
--- a/services/monitoring/assets/alloy_legacy/collect_loki.alloy
+++ b/services/monitoring/assets/alloy_legacy/collect_loki.alloy
@@ -68,6 +68,6 @@ loki.relabel "logs" {
 //===========================================================
 otelcol.receiver.loki "default" {
 	output {
-		logs = [otelcol.processor.transform.set_service_name_from_container.input]
+		logs = [otelcol.processor.resourcedetection.default.input]
 	}
 }

--- a/services/monitoring/assets/alloy_legacy/process_otel.alloy
+++ b/services/monitoring/assets/alloy_legacy/process_otel.alloy
@@ -1,10 +1,21 @@
 //===========================================================
 // Otel pipeline
 //===========================================================
-otelcol.processor.transform "set_service_name_from_container" {
-	// Map container log attribute to service.name resource attribute, or set synology for file logs
+otelcol.processor.resourcedetection "default" {
+	detectors = ["env", "system"]
+
+	output {
+		metrics = [otelcol.processor.transform.set_service_name.input]
+		logs    = [otelcol.processor.transform.set_service_name.input]
+		traces  = [otelcol.processor.transform.set_service_name.input]
+	}
+}
+
+otelcol.processor.transform "set_service_name" {
+	// Set appropriate service names for different telemetry types
 	error_mode = "ignore"
 
+	// For logs: use container name if available, otherwise synology
 	log_statements {
 		context    = "log"
 		statements = [
@@ -13,13 +24,21 @@ otelcol.processor.transform "set_service_name_from_container" {
 		]
 	}
 
-	output {
-		logs = [otelcol.processor.resourcedetection.default.input]
+	// For metrics: set to synology (all metrics come from synology system)
+	metric_statements {
+		context    = "resource"
+		statements = [
+			"set(attributes[\"service.name\"], \"synology\") where attributes[\"service.name\"] == nil",
+		]
 	}
-}
 
-otelcol.processor.resourcedetection "default" {
-	detectors = ["env", "system"]
+	// For traces: set to synology as fallback
+	trace_statements {
+		context    = "resource"
+		statements = [
+			"set(attributes[\"service.name\"], \"synology\") where attributes[\"service.name\"] == nil",
+		]
+	}
 
 	output {
 		metrics = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]


### PR DESCRIPTION
## Summary
- Fix Synology system logs showing `service_name=unknown_service` 
- Restructure OTEL processing pipeline for better consistency and architecture
- Ensure all telemetry data (logs, metrics, traces) gets proper service names

## Changes Made

### Service Name Fixes
- **Container logs**: Use actual container names (e.g., "alloy", "nginx")
- **Synology file logs**: Use "synology" service name  
- **Prometheus metrics**: Use "synology" service name (was unknown_service)
- **Traces**: Use "synology" as fallback

### Pipeline Restructuring
- Move `resourcedetection` as unified entry point for all telemetry data
- Service name detection now happens after resource detection (cleaner architecture)
- Consistent processing flow: `resourcedetection` → `set_service_name` → `cleanup` → `export`

## Technical Details
- Renamed processor to `set_service_name` for better clarity
- Added metric and trace statements for comprehensive coverage
- Both logs and metrics now flow through same processing pipeline
- Maintains backward compatibility with existing functionality

## Test Plan
- [x] Configuration validates with `alloy fmt`
- [x] All telemetry types handled consistently
- [x] Logical processor ordering maintained
- [x] Service name detection covers all data sources

🤖 Generated with [Claude Code](https://claude.ai/code)