### PR TITLE
feat(monitoring): Add comprehensive Kubernetes log collection to Alloy

### DIFF
--- a/services/monitoring/assets/alloy/collect_k8s_logs.alloy
+++ b/services/monitoring/assets/alloy/collect_k8s_logs.alloy
@@ -1,0 +1,171 @@
+//===========================================================
+// Kubernetes Log Collection
+//===========================================================
+
+//-----------------------------------------------------------
+// Kubernetes Pod Discovery
+//-----------------------------------------------------------
+discovery.kubernetes "pods" {
+	role = "pod"
+}
+
+discovery.relabel "pods" {
+	targets = discovery.kubernetes.pods.targets
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_phase"]
+		regex         = "Pending|Succeeded|Failed|Unknown"
+		action        = "drop"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_container_name"]
+		regex         = ""
+		action        = "drop"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_node_name"]
+		target_label  = "__host__"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_name"]
+		target_label  = "pod"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_namespace"]
+		target_label  = "namespace"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_container_name"]
+		target_label  = "container"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+		target_label  = "__path__"
+		separator     = "/"
+		regex         = "(.*)/(.*)"
+		replacement   = "/var/log/pods/*$1*/$2/*.log"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_label_app"]
+		target_label  = "app"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+		target_label  = "app"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_label_k8s_app"]
+		target_label  = "app"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_namespace"]
+		target_label  = "service_name"
+	}
+}
+
+//-----------------------------------------------------------
+// Pod Log Collection via Kubernetes API
+//-----------------------------------------------------------
+loki.source.kubernetes "pods" {
+	targets    = discovery.relabel.pods.output
+	forward_to = [otelcol.receiver.loki.k8s_pods.receiver]
+}
+
+//-----------------------------------------------------------
+// Kubernetes Events Collection
+//-----------------------------------------------------------
+loki.source.kubernetes_events "cluster_events" {
+	log_format = "logfmt"
+	forward_to = [loki.process.k8s_events.receiver]
+}
+
+loki.process "k8s_events" {
+	forward_to = [loki.relabel.k8s_events.receiver]
+
+	stage.logfmt {
+		mapping = {
+			"object_kind"         = "kind",
+			"object_name"         = "name",
+			"event_reason"        = "reason",
+			"event_type"          = "type",
+			"reporting_component" = "reportingComponent",
+			"message"             = "msg",
+		}
+	}
+
+	stage.labels {
+		values = {
+			"object_kind"  = "object_kind",
+			"pod"          = "object_name",
+			"event_reason" = "event_reason",
+			"event_type"   = "event_type",
+		}
+	}
+}
+
+loki.relabel "k8s_events" {
+	forward_to = [otelcol.receiver.loki.k8s_events.receiver]
+
+	rule {
+		target_label = "service_name"
+		replacement  = "kubernetes-events"
+	}
+}
+
+//-----------------------------------------------------------
+// System Log Discovery and Collection
+//-----------------------------------------------------------
+local.file_match "system_logs" {
+	path_targets = [
+		{__path__ = "/var/log/syslog", job = "syslog"},
+		{__path__ = "/var/log/kern.log", job = "kernlog"},
+		{__path__ = "/var/log/auth.log", job = "authlog"},
+		{__path__ = "/var/log/daemon.log", job = "daemonlog"},
+		{__path__ = "/var/log/messages", job = "messages"},
+	]
+}
+
+loki.source.file "system_logs" {
+	targets    = local.file_match.system_logs.targets
+	forward_to = [loki.relabel.system_logs.receiver]
+}
+
+loki.relabel "system_logs" {
+	forward_to = [otelcol.receiver.loki.system_logs.receiver]
+
+	rule {
+		target_label = "service_name"
+		replacement  = "kubernetes"
+	}
+}
+
+//-----------------------------------------------------------
+// Convert Loki logs to OpenTelemetry format
+//-----------------------------------------------------------
+otelcol.receiver.loki "k8s_pods" {
+	output {
+		logs = [otelcol.processor.resourcedetection.default.input]
+	}
+}
+
+otelcol.receiver.loki "k8s_events" {
+	output {
+		logs = [otelcol.processor.resourcedetection.default.input]
+	}
+}
+
+otelcol.receiver.loki "system_logs" {
+	output {
+		logs = [otelcol.processor.resourcedetection.default.input]
+	}
+}

--- a/services/monitoring/assets/alloy/process_otel.alloy
+++ b/services/monitoring/assets/alloy/process_otel.alloy
@@ -5,6 +5,34 @@ otelcol.processor.resourcedetection "default" {
 	detectors = ["env", "system"]
 
 	output {
+		metrics = [otelcol.processor.transform.k8s_service_name_mapping.input]
+		logs    = [otelcol.processor.transform.k8s_service_name_mapping.input]
+		traces  = [otelcol.processor.transform.k8s_service_name_mapping.input]
+	}
+}
+
+otelcol.processor.transform "k8s_service_name_mapping" {
+	error_mode = "ignore"
+
+	log_statements {
+		context    = "resource"
+		statements = [
+			// Map the service_name from resource attributes to service.name
+			"set(attributes[\"service.name\"], attributes[\"service_name\"]) where attributes[\"service_name\"] != nil",
+		]
+	}
+
+	log_statements {
+		context    = "log"
+		statements = [
+			// Move service_name from log attributes to resource attributes
+			"set(resource.attributes[\"service.name\"], attributes[\"service_name\"]) where attributes[\"service_name\"] != nil",
+			// Remove the original service_name attribute to avoid duplication
+			"delete_key(attributes, \"service_name\") where attributes[\"service_name\"] != nil",
+		]
+	}
+
+	output {
 		metrics = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]
 		logs    = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]
 		traces  = [otelcol.processor.transform.drop_unneeded_resource_attributes.input]


### PR DESCRIPTION
## Summary
This PR implements comprehensive Kubernetes log collection for the Alloy component in the monitoring service, enabling centralized logging for pod logs, system logs, and cluster events.

## Features Added

### RBAC Resources
- ServiceAccount for Alloy pods with required permissions
- ClusterRole with access to pods, nodes, events, and namespaces  
- ClusterRoleBinding to associate the role with the service account

### Log Collection Types
1. **Pod Logs**: API-based collection via `discovery.kubernetes` and `loki.source.kubernetes`
2. **System Logs**: File-based collection from `/var/log` (syslog, auth, kern, daemon, messages)
3. **Kubernetes Events**: Cluster event collection with structured parsing via `loki.process`

### Service Name Strategy
- **Pod logs**: `service_name` = namespace (e.g., "ollama", "kube-system")
- **K8s events**: `service_name` = "kubernetes-events"  
- **System logs**: `service_name` = "kubernetes"

### Configuration Changes
- **`collect_k8s_logs.alloy`**: New comprehensive K8s log collection configuration
- **`process_otel.alloy`**: Enhanced with service name mapping processor
- **`alloy.py`**: Updated deployment with RBAC and volume mounts

### OpenTelemetry Integration
- All logs flow through existing OpenTelemetry pipeline
- Service name mapping from Loki labels to OTel resource attributes
- Maintains existing export to Grafana Cloud
- Preserves all metadata (namespace, pod, container, event details)

## Test Plan
- [x] Verify RBAC resources are created successfully
- [x] Confirm pod logs are collected with correct service names (namespace-based)
- [x] Validate K8s events show proper metadata (pod, event_reason, object_kind)
- [x] Check system logs are collected with "kubernetes" service name
- [x] Ensure no `service_name_extracted` duplication in logs
- [x] Verify all logs flow through OpenTelemetry pipeline to Grafana Cloud

🤖 Generated with [Claude Code](https://claude.ai/code)