### PR TITLE
Fix pod logs after enabling rbac

### DIFF
--- a/services/monitoring/monitoring/alloy.py
+++ b/services/monitoring/monitoring/alloy.py
@@ -100,6 +100,7 @@ class Alloy(p.ComponentResource):
                     'api_groups': [''],
                     'resources': [
                         'pods',
+                        'pods/log',
                         'nodes',
                         'nodes/proxy',
                         'nodes/metrics',


### PR DESCRIPTION
The pod logs were missing due to a missing permission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod-level logging access in the monitoring system to ensure comprehensive log collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->