### PR TITLE
Add snmp metrics for draytek modem

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@ extends: default
 ignore: |
   .git
   .venv
+  services/monitoring/assets/snmp/snmp.yml
 
 rules:
   document-start:

--- a/services/monitoring/assets/alloy/collect_prometheus.alloy
+++ b/services/monitoring/assets/alloy/collect_prometheus.alloy
@@ -7,6 +7,7 @@ prometheus.scrape "default" {
 		discovery.relabel.blackbox.output,
 		discovery.relabel.static.output,
 		prometheus.exporter.self.default.targets,
+		prometheus.exporter.snmp.default.targets,
 	)
 
 	scrape_interval = "15s"

--- a/services/monitoring/assets/alloy/collect_snmp.alloy
+++ b/services/monitoring/assets/alloy/collect_snmp.alloy
@@ -1,0 +1,23 @@
+//===========================================================
+// SNMP Exporter Configuration
+//===========================================================
+
+prometheus.exporter.snmp "default" {
+	config_file = "/etc/alloy/snmp/snmp.yml"
+
+	target "draytek_vigor167" {
+		address     = "192.168.10.2"
+		module      = "draytek"
+		walk_params = "public"
+		labels      = {
+			"device" = "draytek_vigor167",
+			"type"   = "modem",
+			"host"   = "draytek.tobiash.net",
+		}
+	}
+
+	walk_param "public" {
+		retries = "2"
+		timeout = "10s"
+	}
+}

--- a/services/monitoring/assets/snmp/generate-config.sh
+++ b/services/monitoring/assets/snmp/generate-config.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+docker run --rm -v "$PWD":/opt prom/snmp-generator generate \
+  -m /opt/mibs \
+  -g /opt/generator.yaml \
+  -o /opt/snmp.yml \
+  --no-fail-on-parse-errors

--- a/services/monitoring/assets/snmp/generator.yaml
+++ b/services/monitoring/assets/snmp/generator.yaml
@@ -1,0 +1,34 @@
+auths:
+  public_v2:
+    community: public
+    version: 2
+modules:
+  draytek:
+    walk:
+      # VDSL2 actual/net sync rate (bps): xdsl2ChStatusActDataRate.{1|2}
+      - 1.3.6.1.2.1.10.251.1.2.2.1.2
+
+      # ADSL-LINE compatibility values the modem exposes (scalars)
+      # adslAtucCurrSnrMgn (down, tenth dB)
+      - 1.3.6.1.2.1.10.94.1.1.2.1.4
+      # adslAturCurrSnrMgn (up, tenth dB)
+      - 1.3.6.1.2.1.10.94.1.1.3.1.4
+      # adslAtucCurrAtn (down, tenth dB)
+      - 1.3.6.1.2.1.10.94.1.1.2.1.5
+      # adslAturCurrAtn (up, tenth dB)
+      - 1.3.6.1.2.1.10.94.1.1.3.1.5
+      # adslAtucCurrAttainableRate (down, bps)
+      - 1.3.6.1.2.1.10.94.1.1.2.1.8
+      # adslAturCurrAttainableRate (up, bps)
+      - 1.3.6.1.2.1.10.94.1.1.3.1.8
+      # VDSL2-LINE-MIB::xdsl2ChStatusPrevDataRate
+      - 1.3.6.1.2.1.10.251.1.2.2.1.3
+      # VDSL2-LINE-MIB::xdsl2ChStatusNFec
+      - 1.3.6.1.2.1.10.251.1.2.2.1.7
+      # VDSL2-LINE-MIB::xdsl2ChStatusRFec
+      - 1.3.6.1.2.1.10.251.1.2.2.1.8
+
+      # ADSL-LINE-MIB::adslAturCurrStatus
+      - 1.3.6.1.2.1.10.94.1.1.3.1.6
+      # SNMPv2-MIB::sysName
+      - 1.3.6.1.2.1.1.5

--- a/services/monitoring/assets/snmp/mibs/ADSL-LINE-MIB
+++ b/services/monitoring/assets/snmp/mibs/ADSL-LINE-MIB
@@ -1,0 +1,4327 @@
+ADSL-LINE-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    Counter32, Gauge32,
+    NOTIFICATION-TYPE,
+    transmission, Unsigned32          FROM SNMPv2-SMI
+    RowStatus,
+    TruthValue, VariablePointer       FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP                FROM SNMPv2-CONF
+    ifIndex                           FROM IF-MIB
+    PerfCurrentCount,
+    PerfIntervalCount                 FROM PerfHist-TC-MIB
+
+    SnmpAdminString                   FROM SNMP-FRAMEWORK-MIB
+    AdslPerfCurrDayCount,
+    AdslPerfPrevDayCount,
+    AdslPerfTimeElapsed,
+    AdslLineCodingType                FROM ADSL-TC-MIB
+    ;
+
+adslMIB MODULE-IDENTITY
+
+LAST-UPDATED "9908190000Z"
+
+ORGANIZATION "IETF ADSL MIB Working Group"
+
+CONTACT-INFO
+    "
+    Gregory Bathrick
+    AG Communication Systems
+    A Subsidiary of Lucent Technologies
+    2500 W Utopia Rd.
+    Phoenix, AZ 85027 USA
+    Tel: +1 602-582-7679
+    Fax: +1 602-582-7697
+    E-mail: bathricg@agcs.com
+
+    Faye Ly
+    Copper Mountain Networks
+    Norcal Office
+    2470 Embarcadero Way
+    Palo Alto, CA 94303
+    Tel: +1 650-858-8500
+    Fax: +1 650-858-8085
+    E-Mail: faye@coppermountain.com
+
+    (ADSL Forum input only)
+    John Burgess
+    Predictive Systems, Inc.
+    25A Vreeland Rd.
+    Florham Park, NJ 07932 USA
+    Tel: +1 973-301-5610
+    Fax: +1 973-301-5699
+    E-mail: jtburgess@predictive.com
+
+    IETF ADSL MIB Working Group (adsl@xlist.agcs.com)
+    "
+DESCRIPTION
+    "The MIB module defining objects for the management of a pair of
+    ADSL modems at each end of the ADSL line.  Each such line has
+
+    an entry in an ifTable which may include multiple modem lines.
+    An agent may reside at either end of the ADSL line however the
+    MIB is designed to require no management communication between
+    them beyond that inherent in the low-level ADSL line protocol.
+    The agent may monitor and control this protocol for its needs.
+
+    ADSL lines may support optional Fast or Interleaved channels.
+    If these are supported, additional entries corresponding to the
+    supported channels must be created in the ifTable. Thus an ADSL
+    line that supports both channels will have three entries in the
+    ifTable, one for each physical, fast, and interleaved, whose
+    ifType values are equal to adsl(94), fast(125), and
+    interleaved(124), respectively. The ifStackTable is used to
+    represent the relationship between the entries.
+
+    Naming Conventions:
+              Atuc -- (ATUC) modem at near (Central) end of line
+              Atur -- (ATUR) modem at Remote end of line
+              Curr -- Current
+              Prev -- Previous
+              Atn -- Attenuation
+              ES  -- Errored Second.
+              LCS -- Line Code Specific
+              Lof -- Loss of Frame
+              Lol -- Loss of Link
+              Los -- Loss of Signal
+              Lpr -- Loss of Power
+              xxxs-- interval of Seconds in which xxx occurs
+                      (e.g., xxx=Lof, Los, Lpr)
+              Max -- Maximum
+              Mgn -- Margin
+              Min -- Minimum
+              Psd -- Power Spectral Density
+              Snr -- Signal to Noise Ratio
+              Tx  -- Transmit
+              Blks-- Blocks, a data unit, see
+                     adslAtuXChanCrcBlockLength
+      "
+      --  Revision history
+      REVISION     "9908190000Z"  -- 19 August 1999, midnight
+      DESCRIPTION  "Initial Version, published as RFC 2662"
+::= { transmission 94 }
+
+adslLineMib OBJECT IDENTIFIER ::= { adslMIB 1 }
+
+adslMibObjects OBJECT IDENTIFIER ::= { adslLineMib 1 }
+
+-- objects
+      adslLineTable   OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslLineEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table includes common attributes describing
+              both ends of the line.  It is required for all ADSL
+              physical interfaces.  ADSL physical interfaces are
+              those ifEntries where ifType is equal to adsl(94)."
+      ::= { adslMibObjects 1 }
+
+      adslLineEntry   OBJECT-TYPE
+          SYNTAX          AdslLineEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in adslLineTable."
+          INDEX           { ifIndex }
+      ::= { adslLineTable 1 }
+
+      AdslLineEntry ::=
+          SEQUENCE {
+          adslLineCoding           AdslLineCodingType,
+          adslLineType             INTEGER,
+          adslLineSpecific         VariablePointer,
+          adslLineConfProfile      SnmpAdminString,
+          adslLineAlarmConfProfile SnmpAdminString
+          }
+
+      adslLineCoding OBJECT-TYPE
+          SYNTAX      AdslLineCodingType
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Specifies the ADSL coding type used on this
+              line."
+      ::= { adslLineEntry 1 }
+
+     adslLineType OBJECT-TYPE
+          SYNTAX      INTEGER {
+              noChannel (1),        -- no channels exist
+              fastOnly (2),         -- fast channel exists only
+              interleavedOnly (3),  -- interleaved channel exists
+                                    -- only
+              fastOrInterleaved (4),-- either fast or interleaved
+                                    -- channels can exist, but
+                                    -- only one at any time
+              fastAndInterleaved (5)-- both fast or interleaved
+
+                                    -- channels exist
+          }
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Defines the type of ADSL physical line
+              entity that exists, by defining whether and how
+              the line is channelized.  If the line is channelized,
+              the value will be other than noChannel(1).  This
+              object defines which channel type(s) are supported.
+
+              In the case that the line is channelized, the manager
+              can use the ifStackTable to determine the ifIndex for
+              the associated channel(s)."
+      ::= { adslLineEntry 2 }
+
+      adslLineSpecific OBJECT-TYPE
+          SYNTAX      VariablePointer
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "OID instance in vendor-specific MIB. The Instance may
+              be used to determine shelf/slot/port of the ATUC
+              interface in a DSLAM."
+      ::= { adslLineEntry 3 }
+
+     adslLineConfProfile OBJECT-TYPE
+          SYNTAX      SnmpAdminString (SIZE (1..32))
+          MAX-ACCESS  read-write
+          STATUS      current
+          DESCRIPTION
+              "The value of this object identifies the row
+              in the ADSL Line Configuration Profile Table,
+              (adslLineConfProfileTable), which applies for this
+              ADSL line, and channels if applicable.
+
+              For `dynamic' mode, in the case which the
+              configuration profile has not been set, the
+              value will be set to `DEFVAL'.
+
+              If the implementator of this MIB has chosen not
+              to implement `dynamic assignment' of profiles, this
+              object's MIN-ACCESS is read-only."
+      ::= { adslLineEntry 4 }
+
+     adslLineAlarmConfProfile OBJECT-TYPE
+          SYNTAX      SnmpAdminString (SIZE (1..32))
+          MAX-ACCESS  read-write
+          STATUS      current
+          DESCRIPTION
+              "The value of this object identifies the row
+              in the ADSL Line Alarm Configuration Profile Table,
+              (adslLineAlarmConfProfileTable), which applies to this
+              ADSL line, and channels if applicable.
+
+              For `dynamic' mode, in the case which the
+              alarm profile has not been set, the
+              value will be set to `DEFVAL'.
+
+              If the implementator of this MIB has chosen not
+              to implement `dynamic assignment' of profiles, this
+              object's MIN-ACCESS is read-only."
+      ::= { adslLineEntry 5 }
+
+      adslAtucPhysTable       OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAtucPhysEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUC.
+              Each row contains the Physical Layer Parameters
+              table for that ATUC. ADSL physical interfaces are
+              those ifEntries where ifType is equal to adsl(94)."
+      ::= { adslMibObjects 2 }
+
+      adslAtucPhysEntry       OBJECT-TYPE
+          SYNTAX          AdslAtucPhysEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in the adslAtucPhysTable."
+          INDEX           { ifIndex }
+      ::= { adslAtucPhysTable 1 }
+
+      AdslAtucPhysEntry ::=
+          SEQUENCE {
+          adslAtucInvSerialNumber         SnmpAdminString,
+          adslAtucInvVendorID             SnmpAdminString,
+          adslAtucInvVersionNumber        SnmpAdminString,
+          adslAtucCurrSnrMgn              INTEGER,
+          adslAtucCurrAtn                 Gauge32,
+          adslAtucCurrStatus              BITS,
+          adslAtucCurrOutputPwr           INTEGER,
+          adslAtucCurrAttainableRate      Gauge32
+          }
+
+      -- inventory group
+
+      --
+      -- These items should describe the lowest level identifiable
+      -- component, be it a stand-alone modem, a card in a rack,
+      -- a child-board, etc.
+      --
+      adslAtucInvSerialNumber OBJECT-TYPE
+          SYNTAX      SnmpAdminString (SIZE (0..32))
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The vendor specific string that identifies the
+              vendor equipment."
+      ::= { adslAtucPhysEntry 1 }
+
+      adslAtucInvVendorID OBJECT-TYPE
+          SYNTAX      SnmpAdminString (SIZE (0..16))
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The vendor ID code is a copy of the binary
+              vendor identification field defined by the
+              PHY[10] and expressed as readable characters."
+          REFERENCE "ANSI T1.413[10]"
+      ::= { adslAtucPhysEntry 2 }
+
+      adslAtucInvVersionNumber OBJECT-TYPE
+          SYNTAX      SnmpAdminString (SIZE (0..16))
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The vendor specific version number sent by this ATU
+              as part of the initialization messages.  It is a copy
+              of the binary version number field defined by the
+              PHY[10] and expressed as readable characters."
+          REFERENCE "ANSI T1.413[10]"
+      ::= { adslAtucPhysEntry 3 }
+
+      -- current status group
+      --
+      adslAtucCurrSnrMgn OBJECT-TYPE
+          SYNTAX      INTEGER (-640..640)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Noise Margin as seen by this ATU with respect to its
+              received signal in tenth dB."
+      ::= { adslAtucPhysEntry 4 }
+
+      adslAtucCurrAtn OBJECT-TYPE
+          SYNTAX      Gauge32(0..630)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Measured difference in the total power transmitted by
+              the peer ATU and the total power received by this ATU."
+      ::= { adslAtucPhysEntry 5 }
+
+     adslAtucCurrStatus OBJECT-TYPE
+          SYNTAX      BITS {
+                            noDefect(0),
+                            lossOfFraming(1),
+                            lossOfSignal(2),
+                            lossOfPower(3),
+                            lossOfSignalQuality(4),
+                            lossOfLink(5),
+                            dataInitFailure(6),
+                            configInitFailure(7),
+                            protocolInitFailure(8),
+                            noPeerAtuPresent(9)
+                           }
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Indicates current state of the ATUC line.  This is a
+              bit-map of possible conditions.  The various bit
+              positions are:
+
+       0      noDefect             There no defects on the line
+
+       1      lossOfFraming        ATUC failure due to not
+                                   receiving valid frame.
+
+       2      lossOfSignal         ATUC failure due to not
+                                   receiving signal.
+
+       3      lossOfPower          ATUC failure due to loss of
+                                   power.
+                                   Note: the Agent may still
+                                   function.
+
+       4      lossOfSignalQuality  Loss of Signal Quality is
+                                   declared when the Noise Margin
+                                   falls below the Minimum Noise
+
+                                   Margin, or the bit-error-rate
+                                   exceeds 10^-7.
+
+       5      lossOfLink           ATUC failure due to inability
+                                   to link with ATUR.
+
+       6      dataInitFailure      ATUC failure during
+                                   initialization due to bit
+                                   errors corrupting startup
+                                   exchange data.
+
+       7      configInitFailure    ATUC failure during
+                                   initialization due to peer
+                                   ATU not able to support
+                                   requested configuration
+
+       8      protocolInitFailure  ATUC failure during
+                                   initialization due to
+                                   incompatible protocol used by
+                                   the peer ATU.
+
+       9      noPeerAtuPresent     ATUC failure during
+                                   initialization due to no
+                                   activation sequence detected
+                                   from peer ATU.
+
+              This is intended to supplement ifOperStatus."
+      ::= { adslAtucPhysEntry 6 }
+
+      adslAtucCurrOutputPwr OBJECT-TYPE
+          SYNTAX      INTEGER (-310..310)
+          UNITS       "tenth dBm"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Measured total output power transmitted by this ATU.
+              This is the measurement that was reported during
+              the last activation sequence."
+      ::= { adslAtucPhysEntry 7 }
+
+      adslAtucCurrAttainableRate OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS       "bps"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Indicates the maximum currently attainable data rate
+              by the ATU.  This value will be equal or greater than
+
+              the current line rate."
+      ::= { adslAtucPhysEntry 8 }
+
+      adslAturPhysTable        OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAturPhysEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUR
+              Each row contains the Physical Layer Parameters
+              table for that ATUR. ADSL physical interfaces are
+              those ifEntries where ifType is equal to adsl(94)."
+      ::= { adslMibObjects 3 }
+
+      adslAturPhysEntry       OBJECT-TYPE
+          SYNTAX          AdslAturPhysEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in the adslAturPhysTable."
+          INDEX           { ifIndex }
+      ::= { adslAturPhysTable 1 }
+
+      AdslAturPhysEntry ::=
+          SEQUENCE {
+          adslAturInvSerialNumber         SnmpAdminString,
+          adslAturInvVendorID             SnmpAdminString,
+          adslAturInvVersionNumber        SnmpAdminString,
+          adslAturCurrSnrMgn              INTEGER,
+          adslAturCurrAtn                 Gauge32,
+          adslAturCurrStatus              BITS,
+          adslAturCurrOutputPwr           INTEGER,
+          adslAturCurrAttainableRate      Gauge32
+          }
+
+      -- inventory group
+      --
+      adslAturInvSerialNumber OBJECT-TYPE
+          SYNTAX      SnmpAdminString (SIZE (0..32))
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The vendor specific string that identifies the
+              vendor equipment."
+      ::= { adslAturPhysEntry 1 }
+
+      adslAturInvVendorID OBJECT-TYPE
+          SYNTAX      SnmpAdminString (SIZE (0..16))
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The vendor ID code is a copy of the binary
+              vendor identification field defined by the
+              PHY[10] and expressed as readable characters."
+          REFERENCE "ANSI T1.413"
+      ::= { adslAturPhysEntry 2 }
+
+      adslAturInvVersionNumber OBJECT-TYPE
+          SYNTAX      SnmpAdminString (SIZE (0..16))
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The vendor specific version number sent by this ATU
+              as part of the initialization messages.  It is a copy
+              of the binary version number field defined by the
+              PHY[10] and expressed as readable characters."
+          REFERENCE "ANSI T1.413"
+      ::= { adslAturPhysEntry 3 }
+
+      -- current status group
+      --
+      adslAturCurrSnrMgn OBJECT-TYPE
+          SYNTAX      INTEGER (-640..640)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Noise Margin as seen by this ATU with respect to its
+              received signal in tenth dB."
+      ::= { adslAturPhysEntry 4 }
+
+      adslAturCurrAtn OBJECT-TYPE
+          SYNTAX      Gauge32(0..630)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Measured difference in the total power transmitted by
+              the peer ATU and the total power received by this ATU."
+      ::= { adslAturPhysEntry 5 }
+
+     adslAturCurrStatus OBJECT-TYPE
+          SYNTAX     BITS {
+                           noDefect(0),
+                           lossOfFraming(1),
+                           lossOfSignal(2),
+                           lossOfPower(3),
+                           lossOfSignalQuality(4)
+                          }
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Indicates current state of the ATUR line.  This is a
+              bit-map of possible conditions.  Due to the isolation
+              of the ATUR when line problems occur, many state
+              conditions like loss of power, loss of quality signal,
+              and initialization errors,  can not be determined.
+              While trouble shooting ATUR, also use object,
+              adslAtucCurrStatus.  The various bit positions are:
+
+       0      noDefect             There no defects on the line
+
+       1      lossOfFraming        ATUR failure due to not
+                                   receiving valid frame
+
+       2      lossOfSignal         ATUR failure due to not
+                                   receiving signal
+
+       3      lossOfPower          ATUR failure due to loss of
+                                   power
+
+       4      lossOfSignalQuality  Loss of Signal Quality is
+                                   declared when the Noise Margin
+                                   falls below the Minimum Noise
+                                   Margin, or the
+                                   bit-error-rate exceeds 10^-7.
+
+              This is intended to supplement ifOperStatus."
+      ::= { adslAturPhysEntry 6 }
+
+      adslAturCurrOutputPwr OBJECT-TYPE
+          SYNTAX      INTEGER (-310..310)
+          UNITS       "tenth dBm"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Measured total output power transmitted by this ATU.
+              This is the measurement that was reported during
+              the last activation sequence."
+      ::= { adslAturPhysEntry 7 }
+
+      adslAturCurrAttainableRate OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS       "bps"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Indicates the maximum currently attainable data rate
+              by the ATU.  This value will be equal or greater than
+              the current line rate."
+      ::= { adslAturPhysEntry 8 }
+
+      adslAtucChanTable       OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAtucChanEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUC channel.
+              ADSL channel interfaces are those ifEntries
+              where ifType is equal to adslInterleave(124)
+              or adslFast(125)."
+      ::= { adslMibObjects 4 }
+
+      adslAtucChanEntry       OBJECT-TYPE
+          SYNTAX          AdslAtucChanEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in the adslAtucChanTable."
+          INDEX           { ifIndex }
+      ::= { adslAtucChanTable 1 }
+
+      AdslAtucChanEntry ::=
+          SEQUENCE {
+          adslAtucChanInterleaveDelay     Gauge32,
+          adslAtucChanCurrTxRate          Gauge32,
+          adslAtucChanPrevTxRate          Gauge32,
+          adslAtucChanCrcBlockLength      Gauge32
+          }
+
+      -- current group
+      --
+      adslAtucChanInterleaveDelay OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS       "milli-seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Interleave Delay for this channel.
+
+              Interleave delay applies only to the
+              interleave channel and defines the mapping
+              (relative spacing) between subsequent input
+              bytes at the interleaver input and their placement
+
+              in the bit stream at the interleaver output.
+              Larger numbers provide greater separation between
+              consecutive input bytes in the output bit stream
+              allowing for improved impulse noise immunity at
+              the expense of payload latency.
+
+              In the case where the ifType is Fast(125), use
+              noSuchObject."
+      ::= { adslAtucChanEntry 1 }
+
+      adslAtucChanCurrTxRate  OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS       "bps"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Actual transmit rate on this channel."
+      ::= { adslAtucChanEntry 2 }
+
+      adslAtucChanPrevTxRate OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS        "bps"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The rate at the time of the last
+              adslAtucRateChangeTrap event. It is also set at
+              initialization to prevent a trap being sent.
+
+              Rate changes less than adslAtucThresh(*)RateDown
+              or less than adslAtucThresh(*)RateUp will not
+              cause a trap or cause this object to change.
+              (*) == Fast or Interleave.
+              See AdslLineAlarmConfProfileEntry."
+      ::= { adslAtucChanEntry 3 }
+
+      adslAtucChanCrcBlockLength OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS        "byte"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Indicates the length of the channel data-block
+              on which the CRC operates.  Refer to Line Code
+              Specific MIBs, [11] and [12] for more
+              information."
+      ::= { adslAtucChanEntry 4 }
+
+     adslAturChanTable       OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAturChanEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUR channel.
+              ADSL channel interfaces are those ifEntries
+              where ifType is equal to adslInterleave(124)
+              or adslFast(125)."
+      ::= { adslMibObjects 5 }
+
+      adslAturChanEntry       OBJECT-TYPE
+          SYNTAX          AdslAturChanEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in the adslAturChanTable."
+          INDEX           { ifIndex }
+      ::= { adslAturChanTable 1 }
+
+      AdslAturChanEntry ::=
+          SEQUENCE {
+          adslAturChanInterleaveDelay     Gauge32,
+          adslAturChanCurrTxRate          Gauge32,
+          adslAturChanPrevTxRate          Gauge32,
+          adslAturChanCrcBlockLength      Gauge32
+          }
+
+      -- current group
+      --
+      adslAturChanInterleaveDelay OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS       "milli-seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Interleave Delay for this channel.
+
+              Interleave delay applies only to the
+              interleave channel and defines the mapping
+              (relative spacing) between subsequent input
+              bytes at the interleaver input and their placement
+              in the bit stream at the interleaver output.
+              Larger numbers provide greater separation between
+              consecutive input bytes in the output bit stream
+              allowing for improved impulse noise immunity at
+              the expense of payload latency.
+
+              In the case where the ifType is Fast(125), use
+
+              noSuchObject."
+      ::= { adslAturChanEntry 1 }
+
+      adslAturChanCurrTxRate  OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS       "bps"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Actual transmit rate on this channel."
+      ::= { adslAturChanEntry 2 }
+
+      adslAturChanPrevTxRate OBJECT-TYPE
+          SYNTAX      Gauge32
+          UNITS       "bps"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+             "The rate at the time of the last
+              adslAturRateChangeTrap event. It is also set at
+              initialization to prevent a trap being sent.
+              Rate changes less than adslAturThresh(*)RateDown
+              or less than adslAturThresh(*)RateUp will not
+              cause a trap or cause this object to change.
+              (*) == Fast or Interleave.
+              See AdslLineAlarmConfProfileEntry."
+      ::= { adslAturChanEntry 3 }
+
+      adslAturChanCrcBlockLength OBJECT-TYPE
+          SYNTAX      Gauge32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Indicates the length of the channel data-block
+              on which the CRC operates.  Refer to Line Code
+              Specific MIBs, [11] and [12] for more
+              information."
+      ::= { adslAturChanEntry 4 }
+
+      adslAtucPerfDataTable   OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAtucPerfDataEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUC.
+              ADSL physical interfaces are
+              those ifEntries where ifType is equal to adsl(94)."
+      ::= { adslMibObjects 6 }
+
+      adslAtucPerfDataEntry       OBJECT-TYPE
+          SYNTAX          AdslAtucPerfDataEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in adslAtucPerfDataTable."
+          INDEX           { ifIndex }
+      ::= { adslAtucPerfDataTable 1 }
+
+      AdslAtucPerfDataEntry ::=
+          SEQUENCE {
+          adslAtucPerfLofs                 Counter32,
+          adslAtucPerfLoss                 Counter32,
+          adslAtucPerfLols                 Counter32,
+          adslAtucPerfLprs                 Counter32,
+          adslAtucPerfESs                  Counter32,
+          adslAtucPerfInits                Counter32,
+          adslAtucPerfValidIntervals       INTEGER,
+          adslAtucPerfInvalidIntervals     INTEGER,
+          adslAtucPerfCurr15MinTimeElapsed AdslPerfTimeElapsed,
+          adslAtucPerfCurr15MinLofs        PerfCurrentCount,
+          adslAtucPerfCurr15MinLoss        PerfCurrentCount,
+          adslAtucPerfCurr15MinLols        PerfCurrentCount,
+          adslAtucPerfCurr15MinLprs        PerfCurrentCount,
+          adslAtucPerfCurr15MinESs         PerfCurrentCount,
+          adslAtucPerfCurr15MinInits       PerfCurrentCount,
+          adslAtucPerfCurr1DayTimeElapsed  AdslPerfTimeElapsed,
+          adslAtucPerfCurr1DayLofs         AdslPerfCurrDayCount,
+          adslAtucPerfCurr1DayLoss         AdslPerfCurrDayCount,
+          adslAtucPerfCurr1DayLols         AdslPerfCurrDayCount,
+          adslAtucPerfCurr1DayLprs         AdslPerfCurrDayCount,
+          adslAtucPerfCurr1DayESs          AdslPerfCurrDayCount,
+          adslAtucPerfCurr1DayInits        AdslPerfCurrDayCount,
+          adslAtucPerfPrev1DayMoniSecs     INTEGER,
+          adslAtucPerfPrev1DayLofs         AdslPerfPrevDayCount,
+          adslAtucPerfPrev1DayLoss         AdslPerfPrevDayCount,
+          adslAtucPerfPrev1DayLols         AdslPerfPrevDayCount,
+          adslAtucPerfPrev1DayLprs         AdslPerfPrevDayCount,
+          adslAtucPerfPrev1DayESs          AdslPerfPrevDayCount,
+          adslAtucPerfPrev1DayInits        AdslPerfPrevDayCount
+          }
+
+      -- Event Counters
+      --
+      -- Also see adslAtucIntervalTable for 15 minute interval
+      -- elapsed counters.
+      --
+      adslAtucPerfLofs OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Loss of Framing failures since
+              agent reset."
+      ::= { adslAtucPerfDataEntry 1 }
+
+      adslAtucPerfLoss  OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Loss of Signal failures since
+              agent reset."
+      ::= { adslAtucPerfDataEntry 2 }
+
+      adslAtucPerfLols OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Loss of Link failures since
+              agent reset."
+      ::= { adslAtucPerfDataEntry 3 }
+
+      adslAtucPerfLprs OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Loss of Power failures since
+              agent reset."
+      ::= { adslAtucPerfDataEntry 4 }
+
+      adslAtucPerfESs OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Errored Seconds since agent
+              reset.  The errored second parameter is a count of
+              one-second intervals containing one or more crc
+              anomalies, or one or more los or sef defects."
+      ::= { adslAtucPerfDataEntry 5 }
+
+      adslAtucPerfInits OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the line initialization attempts since
+              agent reset. Includes both successful and failed
+              attempts."
+      ::= { adslAtucPerfDataEntry 6 }
+
+      -- general 15 min interval information
+      --
+
+      adslAtucPerfValidIntervals OBJECT-TYPE
+          SYNTAX      INTEGER(0..96)
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The number of previous 15-minute intervals in the
+              interval table for which data was collected.  Given
+              that <n> is the maximum # of intervals supported.
+              The value will be <n> unless the measurement was
+              (re-)started within the last (<n>*15) minutes, in which
+              case the value will be the number of complete 15
+              minute intervals for which the agent has at least
+              some data. In certain cases (e.g., in the case
+              where the agent is a proxy) it is possible that some
+              intervals are unavailable.  In this case, this
+              interval is the maximum interval number for
+              which data is available."
+      ::= { adslAtucPerfDataEntry 7 }
+
+      adslAtucPerfInvalidIntervals OBJECT-TYPE
+          SYNTAX      INTEGER(0..96)
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The number of intervals in the range from
+              0 to the value of adslAtucPerfValidIntervals
+              for which no data is available. This object
+              will typically be zero except in cases where
+              the data for some intervals are not available
+              (e.g., in proxy situations)."
+      ::= { adslAtucPerfDataEntry 8 }
+
+      -- 15 min current performance group
+      --
+      adslAtucPerfCurr15MinTimeElapsed OBJECT-TYPE
+          SYNTAX      AdslPerfTimeElapsed(0..899)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Total elapsed seconds in this interval."
+      ::= { adslAtucPerfDataEntry 9 }
+
+      adslAtucPerfCurr15MinLofs OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the current 15 minute interval
+              when there was Loss of Framing."
+      ::= { adslAtucPerfDataEntry 10 }
+
+      adslAtucPerfCurr15MinLoss  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the current 15 minute interval
+              when there was Loss of Signal."
+      ::= { adslAtucPerfDataEntry 11 }
+
+      adslAtucPerfCurr15MinLols  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the current 15 minute interval
+              when there was Loss of Link."
+      ::= { adslAtucPerfDataEntry 12 }
+
+      adslAtucPerfCurr15MinLprs  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the current 15 minute interval
+              when there was Loss of Power."
+      ::= { adslAtucPerfDataEntry 13 }
+
+      adslAtucPerfCurr15MinESs OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of Errored Seconds in the current 15 minute
+              interval.  The errored second parameter is a count of
+              one-second intervals containing one or more crc
+              anomalies, or one or more los or sef defects."
+      ::= { adslAtucPerfDataEntry 14 }
+
+      adslAtucPerfCurr15MinInits  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the line initialization attempts in the
+              current 15 minute interval. Includes both successful
+              and failed attempts."
+      ::= { adslAtucPerfDataEntry 15 }
+
+      -- 1-day current and previous performance group
+      --
+      adslAtucPerfCurr1DayTimeElapsed OBJECT-TYPE
+          SYNTAX      AdslPerfTimeElapsed(0..86399)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Number of seconds that have elapsed since the
+              beginning of the current 1-day interval."
+      ::= { adslAtucPerfDataEntry 16 }
+
+      adslAtucPerfCurr1DayLofs  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of seconds when there was Loss of
+              Framing during the current day as measured by
+              adslAtucPerfCurr1DayTimeElapsed."
+      ::= { adslAtucPerfDataEntry 17 }
+
+      adslAtucPerfCurr1DayLoss  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of seconds when there was Loss of
+              Signal during the current day as measured by
+              adslAtucPerfCurr1DayTimeElapsed."
+      ::= { adslAtucPerfDataEntry 18 }
+
+      adslAtucPerfCurr1DayLols  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of seconds when there was Loss of
+              Link during the current day as measured by
+              adslAtucPerfCurr1DayTimeElapsed."
+      ::= { adslAtucPerfDataEntry 19 }
+
+      adslAtucPerfCurr1DayLprs  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of seconds when there was Loss of
+              Power during the current day as measured by
+              adslAtucPerfCurr1DayTimeElapsed."
+      ::= { adslAtucPerfDataEntry 20 }
+
+      adslAtucPerfCurr1DayESs OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of Errored Seconds during the current day as
+              measured by adslAtucPerfCurr1DayTimeElapsed.
+              The errored second parameter is a count of
+              one-second intervals containing one or more crc
+              anomalies, or one or more los or sef defects."
+      ::= { adslAtucPerfDataEntry 21 }
+
+      adslAtucPerfCurr1DayInits  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the line initialization attempts in the
+              day as measured by adslAtucPerfCurr1DayTimeElapsed.
+              Includes both successful and failed attempts."
+      ::= { adslAtucPerfDataEntry 22 }
+
+      adslAtucPerfPrev1DayMoniSecs OBJECT-TYPE
+          SYNTAX      INTEGER(0..86400)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The amount of time in the previous 1-day interval
+              over which the performance monitoring information
+              is actually counted. This value will be the same as
+              the interval duration except in a situation where
+              performance monitoring data could not be collected
+              for any reason."
+      ::= { adslAtucPerfDataEntry 23 }
+
+      adslAtucPerfPrev1DayLofs  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Framing within the most recent previous
+              1-day period."
+      ::= { adslAtucPerfDataEntry 24 }
+
+      adslAtucPerfPrev1DayLoss  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Signal within the most recent previous
+              1-day period."
+      ::= { adslAtucPerfDataEntry 25 }
+
+      adslAtucPerfPrev1DayLols  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Link within the most recent previous
+              1-day period."
+      ::= { adslAtucPerfDataEntry 26 }
+
+      adslAtucPerfPrev1DayLprs  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Power within the most recent previous
+              1-day period."
+      ::= { adslAtucPerfDataEntry 27 }
+
+      adslAtucPerfPrev1DayESs OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of Errored Seconds within the most recent
+              previous 1-day period. The errored second parameter is
+              a count of one-second intervals containing one or more
+              crc anomalies, or one or more los or sef defects."
+      ::= { adslAtucPerfDataEntry 28 }
+
+      adslAtucPerfPrev1DayInits  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the line initialization attempts in the most
+              recent previous 1-day period. Includes both successful
+              and failed attempts."
+      ::= { adslAtucPerfDataEntry 29 }
+
+      adslAturPerfDataTable   OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAturPerfDataEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUR.
+              ADSL physical interfaces are
+              those ifEntries where ifType is equal to adsl(94)."
+      ::= { adslMibObjects 7 }
+
+      adslAturPerfDataEntry       OBJECT-TYPE
+          SYNTAX          AdslAturPerfDataEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in adslAturPerfDataTable."
+          INDEX           { ifIndex }
+      ::= { adslAturPerfDataTable 1 }
+
+      AdslAturPerfDataEntry ::=
+          SEQUENCE {
+          adslAturPerfLofs                 Counter32,
+          adslAturPerfLoss                 Counter32,
+          adslAturPerfLprs                 Counter32,
+          adslAturPerfESs                  Counter32,
+          adslAturPerfValidIntervals       INTEGER,
+          adslAturPerfInvalidIntervals     INTEGER,
+          adslAturPerfCurr15MinTimeElapsed AdslPerfTimeElapsed,
+          adslAturPerfCurr15MinLofs        PerfCurrentCount,
+          adslAturPerfCurr15MinLoss        PerfCurrentCount,
+          adslAturPerfCurr15MinLprs        PerfCurrentCount,
+          adslAturPerfCurr15MinESs         PerfCurrentCount,
+          adslAturPerfCurr1DayTimeElapsed  AdslPerfTimeElapsed,
+          adslAturPerfCurr1DayLofs         AdslPerfCurrDayCount,
+          adslAturPerfCurr1DayLoss         AdslPerfCurrDayCount,
+          adslAturPerfCurr1DayLprs         AdslPerfCurrDayCount,
+          adslAturPerfCurr1DayESs          AdslPerfCurrDayCount,
+          adslAturPerfPrev1DayMoniSecs     INTEGER,
+          adslAturPerfPrev1DayLofs         AdslPerfPrevDayCount,
+          adslAturPerfPrev1DayLoss         AdslPerfPrevDayCount,
+          adslAturPerfPrev1DayLprs         AdslPerfPrevDayCount,
+          adslAturPerfPrev1DayESs          AdslPerfPrevDayCount
+          }
+
+      -- Event (Raw) Counters
+      --
+      -- Also see adslAturIntervalTable for 15 minute interval
+      -- elapsed counters.
+      --
+      adslAturPerfLofs OBJECT-TYPE
+          SYNTAX      Counter32
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Loss of Framing failures since
+              agent reset."
+      ::= { adslAturPerfDataEntry 1 }
+
+      adslAturPerfLoss  OBJECT-TYPE
+          SYNTAX      Counter32
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Loss of Signal failures since
+              agent reset."
+      ::= { adslAturPerfDataEntry 2 }
+
+     adslAturPerfLprs  OBJECT-TYPE
+          SYNTAX      Counter32
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Loss of Power failures since
+              agent reset."
+      ::= { adslAturPerfDataEntry 3 }
+
+      adslAturPerfESs  OBJECT-TYPE
+          SYNTAX      Counter32
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of Errored Seconds since agent
+              reset.  The errored second parameter is a count of
+              one-second intervals containing one or more crc
+              anomalies, or one or more los or sef defects."
+      ::= { adslAturPerfDataEntry 4 }
+
+      -- general 15 min interval information
+      --
+      adslAturPerfValidIntervals OBJECT-TYPE
+          SYNTAX      INTEGER(0..96)
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The number of previous 15-minute intervals in the
+              interval table for which data was collected.  Given
+              that <n> is the maximum # of intervals supported.
+              The value will be <n> unless the measurement was
+              (re-)started within the last (<n>*15) minutes, in which
+              case the value will be the number of complete 15
+              minute intervals for which the agent has at least
+              some data. In certain cases (e.g., in the case
+              where the agent is a proxy) it is possible that some
+              intervals are unavailable.  In this case, this
+              interval is the maximum interval number for
+              which data is available."
+      ::= { adslAturPerfDataEntry 5 }
+
+      adslAturPerfInvalidIntervals OBJECT-TYPE
+          SYNTAX      INTEGER(0..96)
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The number of intervals in the range from
+              0 to the value of adslAturPerfValidIntervals
+              for which no data is available. This object
+              will typically be zero except in cases where
+              the data for some intervals are not available
+              (e.g., in proxy situations)."
+      ::= { adslAturPerfDataEntry 6 }
+
+      -- 15 min current performance group
+      --
+      adslAturPerfCurr15MinTimeElapsed OBJECT-TYPE
+          SYNTAX      AdslPerfTimeElapsed(0..899)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Total elapsed seconds in this interval."
+      ::= { adslAturPerfDataEntry 7 }
+
+      adslAturPerfCurr15MinLofs OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the current 15 minute interval
+              when there was Loss of Framing."
+      ::= { adslAturPerfDataEntry 8 }
+
+      adslAturPerfCurr15MinLoss  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the current 15 minute interval
+              when there was Loss of Signal."
+      ::= { adslAturPerfDataEntry 9 }
+
+      adslAturPerfCurr15MinLprs  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the current 15 minute interval
+              when there was Loss of Power."
+      ::= { adslAturPerfDataEntry 10 }
+
+      adslAturPerfCurr15MinESs OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+             "Count of Errored Seconds in the current 15 minute
+             interval.  The errored second parameter is a count of
+             one-second intervals containing one or more crc
+             anomalies, or one or more los or sef defects."
+      ::= { adslAturPerfDataEntry 11 }
+
+      -- 1-day current and previous performance group
+      --
+      adslAturPerfCurr1DayTimeElapsed OBJECT-TYPE
+          SYNTAX      AdslPerfTimeElapsed(0..86399)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Number of seconds that have elapsed since the
+              beginning of the current 1-day interval."
+      ::= { adslAturPerfDataEntry 12 }
+
+      adslAturPerfCurr1DayLofs  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of seconds when there was Loss
+              of Framing during the current day as measured by
+              adslAturPerfCurr1DayTimeElapsed."
+      ::= { adslAturPerfDataEntry 13 }
+
+      adslAturPerfCurr1DayLoss  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of seconds when there was Loss
+              of Signal during the current day as measured by
+              adslAturPerfCurr1DayTimeElapsed."
+      ::= { adslAturPerfDataEntry 14 }
+
+      adslAturPerfCurr1DayLprs  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the number of seconds when there was Loss
+              of Power during the current day as measured by
+              adslAturPerfCurr1DayTimeElapsed."
+      ::= { adslAturPerfDataEntry 15 }
+
+ adslAturPerfCurr1DayESs OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of Errored Seconds during the current day as
+              measured by adslAturPerfCurr1DayTimeElapsed.
+              The errored second parameter is a count of
+              one-second intervals containing one or more crc
+              anomalies, or one or more los or sef defects."
+      ::= { adslAturPerfDataEntry 16 }
+
+      adslAturPerfPrev1DayMoniSecs OBJECT-TYPE
+          SYNTAX      INTEGER(0..86400)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The amount of time in the previous 1-day interval
+              over which the performance monitoring information
+              is actually counted. This value will be the same as
+              the interval duration except in a situation where
+              performance monitoring data could not be collected
+              for any reason."
+      ::= { adslAturPerfDataEntry 17 }
+
+      adslAturPerfPrev1DayLofs  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Framing within the most recent previous
+              1-day period."
+      ::= { adslAturPerfDataEntry 18 }
+
+      adslAturPerfPrev1DayLoss  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Signal within the most recent previous
+              1-day period."
+      ::= { adslAturPerfDataEntry 19 }
+
+      adslAturPerfPrev1DayLprs  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Power within the most recent previous
+              1-day period."
+      ::= { adslAturPerfDataEntry 20 }
+
+      adslAturPerfPrev1DayESs OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of Errored Seconds within the most recent
+              previous 1-day period. The errored second parameter is
+              a count of one-second intervals containing one or more
+              crc anomalies, or one or more los or sef defects."
+      ::= { adslAturPerfDataEntry 21 }
+
+      adslAtucIntervalTable   OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAtucIntervalEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUC
+              performance data collection interval.
+              ADSL physical interfaces are
+
+              those ifEntries where ifType is equal to adsl(94)."
+      ::= { adslMibObjects 8 }
+
+      adslAtucIntervalEntry   OBJECT-TYPE
+          SYNTAX          AdslAtucIntervalEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in the adslAtucIntervalTable."
+          INDEX           { ifIndex, adslAtucIntervalNumber }
+      ::= { adslAtucIntervalTable 1 }
+
+      AdslAtucIntervalEntry ::=
+          SEQUENCE {
+          adslAtucIntervalNumber          INTEGER,
+          adslAtucIntervalLofs            PerfIntervalCount,
+          adslAtucIntervalLoss            PerfIntervalCount,
+          adslAtucIntervalLols            PerfIntervalCount,
+          adslAtucIntervalLprs            PerfIntervalCount,
+          adslAtucIntervalESs             PerfIntervalCount,
+          adslAtucIntervalInits           PerfIntervalCount,
+          adslAtucIntervalValidData       TruthValue
+          }
+
+      adslAtucIntervalNumber OBJECT-TYPE
+          SYNTAX      INTEGER(1..96)
+          MAX-ACCESS  not-accessible
+          STATUS      current
+          DESCRIPTION
+              "Performance Data Interval number 1 is the
+              the most recent previous interval; interval
+              96 is 24 hours ago.  Intervals 2..96 are
+              optional."
+      ::= { adslAtucIntervalEntry 1 }
+
+      adslAtucIntervalLofs OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was Loss
+              of Framing."
+      ::= { adslAtucIntervalEntry 2 }
+
+      adslAtucIntervalLoss  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was Loss
+              of Signal."
+      ::= { adslAtucIntervalEntry 3 }
+
+      adslAtucIntervalLols  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was Loss
+              of Link."
+      ::= { adslAtucIntervalEntry 4 }
+
+      adslAtucIntervalLprs  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was Loss
+              of Power."
+      ::= { adslAtucIntervalEntry 5 }
+
+      adslAtucIntervalESs OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of Errored Seconds in the interval.
+              The errored second parameter is a count of
+              one-second intervals containing one or more crc
+              anomalies, or one or more los or sef defects."
+      ::= { adslAtucIntervalEntry 6 }
+
+      adslAtucIntervalInits  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of the line initialization attempts
+              during the interval. Includes both successful
+              and failed attempts."
+      ::= { adslAtucIntervalEntry 7 }
+
+      adslAtucIntervalValidData OBJECT-TYPE
+          SYNTAX TruthValue
+          MAX-ACCESS read-only
+          STATUS current
+          DESCRIPTION
+              "This variable indicates if the data for this
+              interval is valid."
+      ::= { adslAtucIntervalEntry 8 }
+
+      adslAturIntervalTable   OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAturIntervalEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUR
+              performance data collection interval.
+              ADSL physical interfaces are those
+              ifEntries where ifType is equal to adsl(94)."
+      ::= { adslMibObjects 9 }
+
+      adslAturIntervalEntry   OBJECT-TYPE
+          SYNTAX          AdslAturIntervalEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in the adslAturIntervalTable."
+          INDEX           { ifIndex, adslAturIntervalNumber }
+      ::= { adslAturIntervalTable 1 }
+
+      AdslAturIntervalEntry ::=
+          SEQUENCE {
+          adslAturIntervalNumber          INTEGER,
+          adslAturIntervalLofs            PerfIntervalCount,
+          adslAturIntervalLoss            PerfIntervalCount,
+          adslAturIntervalLprs            PerfIntervalCount,
+          adslAturIntervalESs             PerfIntervalCount,
+          adslAturIntervalValidData       TruthValue
+          }
+
+      adslAturIntervalNumber OBJECT-TYPE
+          SYNTAX      INTEGER(1..96)
+          MAX-ACCESS  not-accessible
+          STATUS      current
+          DESCRIPTION
+              "Performance Data Interval number 1 is the
+              the most recent previous interval; interval
+              96 is 24 hours ago.  Intervals 2..96 are
+              optional."
+      ::= { adslAturIntervalEntry 1 }
+
+      adslAturIntervalLofs OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Framing."
+      ::= { adslAturIntervalEntry 2 }
+
+      adslAturIntervalLoss  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Signal."
+      ::= { adslAturIntervalEntry 3 }
+
+      adslAturIntervalLprs  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of seconds in the interval when there was
+              Loss of Power."
+      ::= { adslAturIntervalEntry 4 }
+
+      adslAturIntervalESs OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of Errored Seconds in the interval.
+              The errored second parameter is a count of
+              one-second intervals containing one or more crc
+              anomalies, or one or more los or sef defects."
+      ::= { adslAturIntervalEntry 5 }
+
+      adslAturIntervalValidData OBJECT-TYPE
+          SYNTAX TruthValue
+          MAX-ACCESS read-only
+          STATUS current
+          DESCRIPTION
+              "This variable indicates if the data for this
+
+              interval is valid."
+      ::= { adslAturIntervalEntry 6 }
+
+      adslAtucChanPerfDataTable       OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAtucChanPerfDataEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUC channel.
+              ADSL channel interfaces are those ifEntries
+              where ifType is equal to adslInterleave(124)
+              or adslFast(125)."
+      ::= { adslMibObjects 10 }
+
+      adslAtucChanPerfDataEntry       OBJECT-TYPE
+          SYNTAX          AdslAtucChanPerfDataEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in adslAtucChanPerfDataTable."
+          INDEX           { ifIndex }
+      ::= { adslAtucChanPerfDataTable 1 }
+
+      AdslAtucChanPerfDataEntry ::=
+       SEQUENCE {
+       adslAtucChanReceivedBlks                 Counter32,
+       adslAtucChanTransmittedBlks              Counter32,
+       adslAtucChanCorrectedBlks                Counter32,
+       adslAtucChanUncorrectBlks                Counter32,
+       adslAtucChanPerfValidIntervals           INTEGER,
+       adslAtucChanPerfInvalidIntervals         INTEGER,
+       adslAtucChanPerfCurr15MinTimeElapsed     AdslPerfTimeElapsed,
+       adslAtucChanPerfCurr15MinReceivedBlks    PerfCurrentCount,
+       adslAtucChanPerfCurr15MinTransmittedBlks PerfCurrentCount,
+       adslAtucChanPerfCurr15MinCorrectedBlks   PerfCurrentCount,
+       adslAtucChanPerfCurr15MinUncorrectBlks   PerfCurrentCount,
+       adslAtucChanPerfCurr1DayTimeElapsed      AdslPerfTimeElapsed,
+       adslAtucChanPerfCurr1DayReceivedBlks     AdslPerfCurrDayCount,
+       adslAtucChanPerfCurr1DayTransmittedBlks  AdslPerfCurrDayCount,
+       adslAtucChanPerfCurr1DayCorrectedBlks    AdslPerfCurrDayCount,
+       adslAtucChanPerfCurr1DayUncorrectBlks    AdslPerfCurrDayCount,
+       adslAtucChanPerfPrev1DayMoniSecs         INTEGER,
+       adslAtucChanPerfPrev1DayReceivedBlks     AdslPerfPrevDayCount,
+       adslAtucChanPerfPrev1DayTransmittedBlks  AdslPerfPrevDayCount,
+       adslAtucChanPerfPrev1DayCorrectedBlks    AdslPerfPrevDayCount,
+       adslAtucChanPerfPrev1DayUncorrectBlks    AdslPerfPrevDayCount
+      }
+      -- performance group
+
+      --
+      -- Note: block is intended to be the length of the channel
+      --       data-block on which the CRC operates. See
+      --       adslAtucChanCrcBlockLength for more information.
+      --
+      adslAtucChanReceivedBlks OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this channel
+              since agent reset."
+      ::= { adslAtucChanPerfDataEntry 1 }
+
+      adslAtucChanTransmittedBlks  OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel since agent reset."
+      ::= { adslAtucChanPerfDataEntry 2 }
+
+      adslAtucChanCorrectedBlks  OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected since agent reset.  These blocks are passed
+              on as good data."
+      ::= { adslAtucChanPerfDataEntry 3 }
+
+      adslAtucChanUncorrectBlks  OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors since agent reset."
+      ::= { adslAtucChanPerfDataEntry 4 }
+
+      -- general 15 min interval information
+      --
+      adslAtucChanPerfValidIntervals OBJECT-TYPE
+          SYNTAX      INTEGER(0..96)
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The number of previous 15-minute intervals in the
+              interval table for which data was collected.  Given
+              that <n> is the maximum # of intervals supported.
+              The value will be <n> unless the measurement was
+              (re-)started within the last (<n>*15) minutes, in which
+              case the value will be the number of complete 15
+              minute intervals for which the agent has at least
+              some data. In certain cases (e.g., in the case
+              where the agent is a proxy) it is possible that some
+              intervals are unavailable.  In this case, this
+              interval is the maximum interval number for
+              which data is available."
+      ::= { adslAtucChanPerfDataEntry 5 }
+
+      adslAtucChanPerfInvalidIntervals OBJECT-TYPE
+          SYNTAX      INTEGER(0..96)
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The number of intervals in the range from
+              0 to the value of adslAtucChanPerfValidIntervals
+              for which no data is available. This object
+              will typically be zero except in cases where
+              the data for some intervals are not available
+              (e.g., in proxy situations)."
+      ::= { adslAtucChanPerfDataEntry 6 }
+
+      -- 15 min current performance group
+      --
+      adslAtucChanPerfCurr15MinTimeElapsed OBJECT-TYPE
+          SYNTAX      AdslPerfTimeElapsed(0..899)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Total elapsed seconds in this interval."
+      ::= { adslAtucChanPerfDataEntry 7 }
+
+      adslAtucChanPerfCurr15MinReceivedBlks OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this channel
+              within the current 15 minute interval."
+      ::= { adslAtucChanPerfDataEntry 8 }
+
+      adslAtucChanPerfCurr15MinTransmittedBlks OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel within the current 15 minute interval."
+      ::= { adslAtucChanPerfDataEntry 9 }
+
+      adslAtucChanPerfCurr15MinCorrectedBlks  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected on this channel within the current 15 minute
+              interval."
+      ::= { adslAtucChanPerfDataEntry 10 }
+
+      adslAtucChanPerfCurr15MinUncorrectBlks  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors on this channel within the current 15 minute
+              interval."
+      ::= { adslAtucChanPerfDataEntry 11 }
+
+      -- 1-day current and previous performance group
+      --
+      adslAtucChanPerfCurr1DayTimeElapsed OBJECT-TYPE
+          SYNTAX      AdslPerfTimeElapsed(0..86399)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Number of seconds that have elapsed since the
+              beginning of the current 1-day interval."
+      ::= { adslAtucChanPerfDataEntry 12 }
+
+      adslAtucChanPerfCurr1DayReceivedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this
+              channel during the current day as measured by
+
+              adslAtucChanPerfCurr1DayTimeElapsed."
+      ::= { adslAtucChanPerfDataEntry 13 }
+
+      adslAtucChanPerfCurr1DayTransmittedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel during the current day as measured by
+              adslAtucChanPerfCurr1DayTimeElapsed."
+      ::= { adslAtucChanPerfDataEntry 14 }
+
+      adslAtucChanPerfCurr1DayCorrectedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected on this channel during the current day as
+              measured by adslAtucChanPerfCurr1DayTimeElapsed."
+      ::= { adslAtucChanPerfDataEntry 15 }
+
+      adslAtucChanPerfCurr1DayUncorrectBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors on this channel during the current day as
+              measured by adslAtucChanPerfCurr1DayTimeElapsed."
+      ::= { adslAtucChanPerfDataEntry 16 }
+
+      adslAtucChanPerfPrev1DayMoniSecs OBJECT-TYPE
+          SYNTAX      INTEGER(0..86400)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The amount of time in the previous 1-day interval
+              over which the performance monitoring information
+              is actually counted. This value will be the same as
+              the interval duration except in a situation where
+              performance monitoring data could not be collected
+              for any reason."
+      ::= { adslAtucChanPerfDataEntry 17 }
+
+      adslAtucChanPerfPrev1DayReceivedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this
+              channel within the most recent previous 1-day
+              period."
+      ::= { adslAtucChanPerfDataEntry 18 }
+
+      adslAtucChanPerfPrev1DayTransmittedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel within the most recent previous 1-day
+              period."
+      ::= { adslAtucChanPerfDataEntry 19 }
+
+      adslAtucChanPerfPrev1DayCorrectedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected on this channel within the most recent
+              previous 1-day period."
+      ::= { adslAtucChanPerfDataEntry 20 }
+
+      adslAtucChanPerfPrev1DayUncorrectBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors on this channel within the most recent previous
+              1-day period."
+      ::= { adslAtucChanPerfDataEntry 21 }
+
+      adslAturChanPerfDataTable       OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAturChanPerfDataEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUR channel.
+              ADSL channel interfaces are those ifEntries
+              where ifType is equal to adslInterleave(124)
+              or adslFast(125)."
+      ::= { adslMibObjects 11 }
+
+      adslAturChanPerfDataEntry       OBJECT-TYPE
+          SYNTAX          AdslAturChanPerfDataEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in adslAturChanPerfDataTable."
+          INDEX           { ifIndex }
+      ::= { adslAturChanPerfDataTable 1 }
+
+      AdslAturChanPerfDataEntry ::=
+       SEQUENCE {
+       adslAturChanReceivedBlks                 Counter32,
+       adslAturChanTransmittedBlks              Counter32,
+       adslAturChanCorrectedBlks                Counter32,
+       adslAturChanUncorrectBlks                Counter32,
+       adslAturChanPerfValidIntervals           INTEGER,
+       adslAturChanPerfInvalidIntervals         INTEGER,
+       adslAturChanPerfCurr15MinTimeElapsed     AdslPerfTimeElapsed,
+       adslAturChanPerfCurr15MinReceivedBlks    PerfCurrentCount,
+       adslAturChanPerfCurr15MinTransmittedBlks PerfCurrentCount,
+       adslAturChanPerfCurr15MinCorrectedBlks   PerfCurrentCount,
+       adslAturChanPerfCurr15MinUncorrectBlks   PerfCurrentCount,
+       adslAturChanPerfCurr1DayTimeElapsed      AdslPerfTimeElapsed,
+       adslAturChanPerfCurr1DayReceivedBlks     AdslPerfCurrDayCount,
+       adslAturChanPerfCurr1DayTransmittedBlks  AdslPerfCurrDayCount,
+       adslAturChanPerfCurr1DayCorrectedBlks    AdslPerfCurrDayCount,
+       adslAturChanPerfCurr1DayUncorrectBlks    AdslPerfCurrDayCount,
+       adslAturChanPerfPrev1DayMoniSecs         INTEGER,
+       adslAturChanPerfPrev1DayReceivedBlks     AdslPerfPrevDayCount,
+       adslAturChanPerfPrev1DayTransmittedBlks  AdslPerfPrevDayCount,
+       adslAturChanPerfPrev1DayCorrectedBlks    AdslPerfPrevDayCount,
+       adslAturChanPerfPrev1DayUncorrectBlks    AdslPerfPrevDayCount
+       }
+      -- performance group
+      --
+      -- Note: block is intended to be the length of the channel
+      --       data-block on which the CRC operates. See
+      --       adslAturChanCrcBlockLength for more information.
+      --
+      adslAturChanReceivedBlks OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this channel
+              since agent reset."
+      ::= { adslAturChanPerfDataEntry 1 }
+
+      adslAturChanTransmittedBlks  OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel since agent reset."
+      ::= { adslAturChanPerfDataEntry 2 }
+
+      adslAturChanCorrectedBlks  OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected since agent reset.  These blocks are passed
+              on as good data."
+      ::= { adslAturChanPerfDataEntry 3 }
+
+      adslAturChanUncorrectBlks  OBJECT-TYPE
+          SYNTAX      Counter32
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors since agent reset."
+      ::= { adslAturChanPerfDataEntry 4 }
+
+      -- general 15 min interval information
+      --
+      adslAturChanPerfValidIntervals OBJECT-TYPE
+          SYNTAX      INTEGER(0..96)
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The number of previous 15-minute intervals in the
+              interval table for which data was collected.  Given
+              that <n> is the maximum # of intervals supported.
+              The value will be <n> unless the measurement was
+              (re-)started within the last (<n>*15) minutes, in which
+              case the value will be the number of complete 15
+              minute intervals for which the agent has at least
+              some data. In certain cases (e.g., in the case
+              where the agent is a proxy) it is possible that some
+              intervals are unavailable.  In this case, this
+              interval is the maximum interval number for
+              which data is available."
+      ::= { adslAturChanPerfDataEntry 5 }
+
+      adslAturChanPerfInvalidIntervals OBJECT-TYPE
+          SYNTAX      INTEGER(0..96)
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The number of intervals in the range from
+              0 to the value of adslAturChanPerfValidIntervals
+              for which no data is available. This object
+              will typically be zero except in cases where
+              the data for some intervals are not available
+              (e.g., in proxy situations)."
+      ::= { adslAturChanPerfDataEntry 6 }
+
+      -- 15 min current performance group
+      --
+      adslAturChanPerfCurr15MinTimeElapsed OBJECT-TYPE
+          SYNTAX      AdslPerfTimeElapsed(0..899)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Total elapsed seconds in this interval.
+              A full interval is 900 seconds."
+      ::= { adslAturChanPerfDataEntry 7 }
+
+      adslAturChanPerfCurr15MinReceivedBlks OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this
+              channel within the current 15 minute interval."
+      ::= { adslAturChanPerfDataEntry 8 }
+
+      adslAturChanPerfCurr15MinTransmittedBlks OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel within the current 15 minute interval."
+      ::= { adslAturChanPerfDataEntry 9 }
+
+      adslAturChanPerfCurr15MinCorrectedBlks  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected on this channel within the current 15 minute
+              interval."
+      ::= { adslAturChanPerfDataEntry 10 }
+
+      adslAturChanPerfCurr15MinUncorrectBlks  OBJECT-TYPE
+          SYNTAX      PerfCurrentCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors on this channel within the current 15 minute
+              interval."
+      ::= { adslAturChanPerfDataEntry 11 }
+
+      -- 1-day current and previous performance group
+      --
+      adslAturChanPerfCurr1DayTimeElapsed OBJECT-TYPE
+          SYNTAX      AdslPerfTimeElapsed(0..86399)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Number of seconds that have elapsed since the
+              beginning of the current 1-day interval."
+      ::= { adslAturChanPerfDataEntry 12 }
+
+      adslAturChanPerfCurr1DayReceivedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this
+              channel during the current day as measured by
+              adslAturChanPerfCurr1DayTimeElapsed."
+      ::= { adslAturChanPerfDataEntry 13 }
+
+      adslAturChanPerfCurr1DayTransmittedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel during the current day as measured by
+              adslAturChanPerfCurr1DayTimeElapsed."
+      ::= { adslAturChanPerfDataEntry 14 }
+
+      adslAturChanPerfCurr1DayCorrectedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected on this channel during the current day as
+              measured by adslAturChanPerfCurr1DayTimeElapsed."
+      ::= { adslAturChanPerfDataEntry 15 }
+
+      adslAturChanPerfCurr1DayUncorrectBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfCurrDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors on this channel during the current day as
+              measured by adslAturChanPerfCurr1DayTimeElapsed."
+      ::= { adslAturChanPerfDataEntry 16 }
+
+      adslAturChanPerfPrev1DayMoniSecs OBJECT-TYPE
+          SYNTAX      INTEGER(0..86400)
+          UNITS       "seconds"
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "The amount of time in the previous 1-day interval
+              over which the performance monitoring information
+              is actually counted. This value will be the same as
+              the interval duration except in a situation where
+              performance monitoring data could not be collected
+              for any reason."
+      ::= { adslAturChanPerfDataEntry 17 }
+
+      adslAturChanPerfPrev1DayReceivedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this
+              channel within the most recent previous 1-day
+              period."
+      ::= { adslAturChanPerfDataEntry 18 }
+
+      adslAturChanPerfPrev1DayTransmittedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel within the most recent previous 1-day
+              period."
+      ::= { adslAturChanPerfDataEntry 19 }
+
+      adslAturChanPerfPrev1DayCorrectedBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected on this channel within the most recent
+              previous 1-day period."
+      ::= { adslAturChanPerfDataEntry 20 }
+
+      adslAturChanPerfPrev1DayUncorrectBlks  OBJECT-TYPE
+          SYNTAX      AdslPerfPrevDayCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors on this channel within the most recent previous
+              1-day period."
+      ::= { adslAturChanPerfDataEntry 21 }
+
+      adslAtucChanIntervalTable   OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAtucChanIntervalEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUC channel's
+              performance data collection interval.
+              ADSL channel interfaces are those ifEntries
+              where ifType is equal to adslInterleave(124)
+              or adslFast(125)."
+      ::= { adslMibObjects 12 }
+
+      adslAtucChanIntervalEntry   OBJECT-TYPE
+          SYNTAX          AdslAtucChanIntervalEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in the adslAtucIntervalTable."
+          INDEX           { ifIndex, adslAtucChanIntervalNumber }
+      ::= { adslAtucChanIntervalTable 1 }
+
+      AdslAtucChanIntervalEntry ::=
+          SEQUENCE {
+
+          adslAtucChanIntervalNumber          INTEGER,
+          adslAtucChanIntervalReceivedBlks    PerfIntervalCount,
+          adslAtucChanIntervalTransmittedBlks PerfIntervalCount,
+          adslAtucChanIntervalCorrectedBlks   PerfIntervalCount,
+          adslAtucChanIntervalUncorrectBlks   PerfIntervalCount,
+          adslAtucChanIntervalValidData       TruthValue
+          }
+      adslAtucChanIntervalNumber OBJECT-TYPE
+          SYNTAX      INTEGER(1..96)
+          MAX-ACCESS  not-accessible
+          STATUS      current
+          DESCRIPTION
+              "Performance Data Interval number 1 is the
+              the most recent previous interval; interval
+              96 is 24 hours ago.  Intervals 2..96 are
+              optional."
+      ::= { adslAtucChanIntervalEntry 1 }
+
+      adslAtucChanIntervalReceivedBlks OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this channel
+              during this interval."
+      ::= { adslAtucChanIntervalEntry 2 }
+
+      adslAtucChanIntervalTransmittedBlks  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel during this interval."
+      ::= { adslAtucChanIntervalEntry 3 }
+
+      adslAtucChanIntervalCorrectedBlks  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected on this channel during this interval."
+      ::= { adslAtucChanIntervalEntry 4 }
+
+      adslAtucChanIntervalUncorrectBlks  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors on this channel during this interval."
+      ::= { adslAtucChanIntervalEntry 5 }
+
+      adslAtucChanIntervalValidData OBJECT-TYPE
+          SYNTAX TruthValue
+          MAX-ACCESS read-only
+          STATUS current
+          DESCRIPTION
+              "This variable indicates if the data for this
+              interval is valid."
+      ::= { adslAtucChanIntervalEntry 6 }
+
+      adslAturChanIntervalTable   OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslAturChanIntervalEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table provides one row for each ATUR channel's
+              performance data collection interval.
+              ADSL channel interfaces are those ifEntries
+              where ifType is equal to adslInterleave(124)
+              or adslFast(125)."
+      ::= { adslMibObjects 13 }
+
+      adslAturChanIntervalEntry   OBJECT-TYPE
+          SYNTAX          AdslAturChanIntervalEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION     "An entry in the adslAturIntervalTable."
+          INDEX           { ifIndex, adslAturChanIntervalNumber }
+      ::= { adslAturChanIntervalTable 1 }
+
+      AdslAturChanIntervalEntry ::=
+          SEQUENCE {
+          adslAturChanIntervalNumber               INTEGER,
+          adslAturChanIntervalReceivedBlks         PerfIntervalCount,
+          adslAturChanIntervalTransmittedBlks      PerfIntervalCount,
+          adslAturChanIntervalCorrectedBlks        PerfIntervalCount,
+          adslAturChanIntervalUncorrectBlks        PerfIntervalCount,
+          adslAturChanIntervalValidData            TruthValue
+          }
+      adslAturChanIntervalNumber OBJECT-TYPE
+          SYNTAX      INTEGER(1..96)
+          MAX-ACCESS  not-accessible
+          STATUS      current
+          DESCRIPTION
+              "Performance Data Interval number 1 is the
+              the most recent previous interval; interval
+              96 is 24 hours ago.  Intervals 2..96 are
+              optional."
+      ::= { adslAturChanIntervalEntry 1 }
+
+      adslAturChanIntervalReceivedBlks OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks received on this channel
+              during this interval."
+      ::= { adslAturChanIntervalEntry 2 }
+
+      adslAturChanIntervalTransmittedBlks  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all encoded blocks transmitted on this
+              channel during this interval."
+      ::= { adslAturChanIntervalEntry 3 }
+
+      adslAturChanIntervalCorrectedBlks  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with errors that were
+              corrected on this channel during this interval."
+      ::= { adslAturChanIntervalEntry 4 }
+
+      adslAturChanIntervalUncorrectBlks  OBJECT-TYPE
+          SYNTAX      PerfIntervalCount
+          MAX-ACCESS  read-only
+          STATUS      current
+          DESCRIPTION
+              "Count of all blocks received with uncorrectable
+              errors on this channel during this interval."
+      ::= { adslAturChanIntervalEntry 5 }
+
+      adslAturChanIntervalValidData OBJECT-TYPE
+          SYNTAX TruthValue
+          MAX-ACCESS read-only
+          STATUS current
+          DESCRIPTION
+              "This variable indicates if the data for this
+              interval is valid."
+      ::= { adslAturChanIntervalEntry 6 }
+
+      -- Profile Group
+      --
+
+      adslLineConfProfileTable    OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslLineConfProfileEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table contains information on the ADSL line
+              configuration.  One entry in this table reflects a
+              profile defined by a manager which can be used to
+              configure the ADSL line."
+      ::= { adslMibObjects 14}
+
+      adslLineConfProfileEntry    OBJECT-TYPE
+          SYNTAX          AdslLineConfProfileEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "Each entry consists of a list of parameters that
+              represents the configuration of an ADSL modem.
+
+              When `dynamic' profiles are implemented, a default
+              profile will always exist.  This profile's name will
+              be set to `DEFVAL' and its parameters will be set
+              to vendor specific values, unless otherwise specified
+              in this document.
+
+              When `static' profiles are implemented, profiles
+              are automaticly created or destroyed as ADSL
+              physical lines are discovered and removed by
+              the system.  The name of the profile will be
+              equivalent to the decimal value of the line's
+              interface index.
+              "
+          INDEX { IMPLIED adslLineConfProfileName}
+      ::= { adslLineConfProfileTable 1}
+
+      AdslLineConfProfileEntry ::=
+          SEQUENCE {
+          adslLineConfProfileName               SnmpAdminString,
+          adslAtucConfRateMode                  INTEGER,
+          adslAtucConfRateChanRatio             INTEGER,
+          adslAtucConfTargetSnrMgn              INTEGER,
+          adslAtucConfMaxSnrMgn                 INTEGER,
+          adslAtucConfMinSnrMgn                 INTEGER,
+          adslAtucConfDownshiftSnrMgn           INTEGER,
+          adslAtucConfUpshiftSnrMgn             INTEGER,
+          adslAtucConfMinUpshiftTime            INTEGER,
+          adslAtucConfMinDownshiftTime          INTEGER,
+          adslAtucChanConfFastMinTxRate         Unsigned32,
+          adslAtucChanConfInterleaveMinTxRate   Unsigned32,
+          adslAtucChanConfFastMaxTxRate         Unsigned32,
+          adslAtucChanConfInterleaveMaxTxRate   Unsigned32,
+          adslAtucChanConfMaxInterleaveDelay    INTEGER,
+          adslAturConfRateMode                  INTEGER,
+          adslAturConfRateChanRatio             INTEGER,
+          adslAturConfTargetSnrMgn              INTEGER,
+          adslAturConfMaxSnrMgn                 INTEGER,
+          adslAturConfMinSnrMgn                 INTEGER,
+          adslAturConfDownshiftSnrMgn           INTEGER,
+          adslAturConfUpshiftSnrMgn             INTEGER,
+          adslAturConfMinUpshiftTime            INTEGER,
+          adslAturConfMinDownshiftTime          INTEGER,
+          adslAturChanConfFastMinTxRate         Unsigned32,
+          adslAturChanConfInterleaveMinTxRate   Unsigned32,
+          adslAturChanConfFastMaxTxRate         Unsigned32,
+          adslAturChanConfInterleaveMaxTxRate   Unsigned32,
+          adslAturChanConfMaxInterleaveDelay    INTEGER,
+          adslLineConfProfileRowStatus          RowStatus
+      }
+
+      adslLineConfProfileName    OBJECT-TYPE
+              SYNTAX          SnmpAdminString (SIZE (1..32))
+              MAX-ACCESS      not-accessible
+              STATUS          current
+              DESCRIPTION
+              "This object is used by the line configuration table
+              in order to identify a row of this table.
+
+              When `dynamic' profiles are implemented, the profile
+              name is user specified.  Also, the system will always
+              provide a default profile whose name is `DEFVAL'.
+
+              When `static' profiles are implemented, there is an
+              one-to-one relationship between each line and its
+              profile.  In which case, the profile name will
+              need to algorithmicly represent the Line's ifIndex.
+              Therefore, the profile's name is a decimalized string
+              of the ifIndex that is fixed-length (i.e., 10) with
+              leading zero(s).  For example, the profile name for
+              ifIndex which equals '15' will be '0000000015'."
+      ::= { adslLineConfProfileEntry 1 }
+
+      adslAtucConfRateMode OBJECT-TYPE
+          SYNTAX      INTEGER {
+              fixed (1),              -- no rate adaptation
+              adaptAtStartup (2),     -- perform rate adaptation
+                                      -- only at initialization
+              adaptAtRuntime (3)      -- perform rate adaptation at
+                                      -- any time
+          }
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Defines what form of transmit rate adaptation is
+              configured on this modem.  See ADSL Forum TR-005 [3]
+              for more information."
+      ::= { adslLineConfProfileEntry 2 }
+
+      adslAtucConfRateChanRatio OBJECT-TYPE
+          SYNTAX      INTEGER(0..100)
+          UNITS        "%"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured allocation ratio of excess transmit
+              bandwidth between fast and interleaved channels.  Only
+              applies when two channel mode and RADSL are supported.
+              Distribute bandwidth on each channel in excess of the
+              corresponding ChanConfMinTxRate so that:
+              adslAtucConfRateChanRatio =
+
+                      [Fast / (Fast + Interleaved)] * 100
+
+              In other words this value is the fast channel
+              percentage."
+      ::= { adslLineConfProfileEntry 3 }
+
+    adslAtucConfTargetSnrMgn OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Target Signal/Noise Margin.
+              This is the Noise Margin the modem must achieve
+              with a BER of 10-7 or better to successfully complete
+              initialization."
+      ::= { adslLineConfProfileEntry 4 }
+
+    adslAtucConfMaxSnrMgn OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Maximum acceptable Signal/Noise Margin.
+              If the Noise Margin is above this the modem should
+              attempt to reduce its power output to optimize its
+              operation."
+      ::= { adslLineConfProfileEntry 5 }
+
+      adslAtucConfMinSnrMgn  OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Minimum acceptable Signal/Noise Margin.
+              If the noise margin falls below this level, the modem
+              should attempt to increase its power output.  If that
+              is not possible the modem will attempt to
+              re-initialize or shut down."
+      ::= { adslLineConfProfileEntry 6 }
+
+      adslAtucConfDownshiftSnrMgn  OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Signal/Noise Margin for rate downshift.
+              If the noise margin falls below this level, the modem
+              should attempt to decrease its transmit rate.  In
+              the case that RADSL mode is not present,
+              the value will be `0'."
+      ::= { adslLineConfProfileEntry 7 }
+
+      adslAtucConfUpshiftSnrMgn  OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Signal/Noise Margin for rate upshift.
+              If the noise margin rises above this level, the modem
+              should attempt to increase its transmit rate.    In
+              the case that RADSL is not present, the value will
+
+              be `0'."
+      ::= { adslLineConfProfileEntry 8 }
+
+      adslAtucConfMinUpshiftTime OBJECT-TYPE
+          SYNTAX      INTEGER(0..16383)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Minimum time that the current margin is above
+              UpshiftSnrMgn before an upshift occurs.
+              In the case that RADSL is not present, the value will
+              be `0'."
+      ::= { adslLineConfProfileEntry 9 }
+     adslAtucConfMinDownshiftTime OBJECT-TYPE
+          SYNTAX      INTEGER(0..16383)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Minimum time that the current margin is below
+              DownshiftSnrMgn before a downshift occurs.
+              In the case that RADSL mode is not present,
+              the value will be `0'."
+      ::= { adslLineConfProfileEntry 10 }
+
+      adslAtucChanConfFastMinTxRate  OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Minimum Transmit rate for `Fast' channels,
+              in bps.  See adslAtucConfRateChanRatio for information
+              regarding RADSL mode and ATUR transmit rate for
+              ATUC receive rates."
+      ::= { adslLineConfProfileEntry 11 }
+
+      adslAtucChanConfInterleaveMinTxRate OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Minimum Transmit rate for `Interleave'
+              channels, in bps.  See adslAtucConfRateChanRatio for
+              information regarding RADSL mode and see
+              ATUR transmit rate for receive rates."
+      ::= { adslLineConfProfileEntry 12 }
+
+      adslAtucChanConfFastMaxTxRate  OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Maximum Transmit rate for `Fast' channels,
+              in bps.  See adslAtucConfRateChanRatio for information
+              regarding RADSL mode and see ATUR transmit rate for
+              ATUC receive rates."
+      ::= { adslLineConfProfileEntry 13 }
+
+      adslAtucChanConfInterleaveMaxTxRate OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Maximum Transmit rate for `Interleave'
+              channels, in bps.  See adslAtucConfRateChanRatio for
+              information regarding RADSL mode and ATUR transmit
+              rate for ATUC receive rates."
+      ::= { adslLineConfProfileEntry 14 }
+
+      adslAtucChanConfMaxInterleaveDelay OBJECT-TYPE
+          SYNTAX      INTEGER(0..255)
+          UNITS        "milli-seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured maximum Interleave Delay for this channel.
+
+              Interleave delay applies only to the interleave channel
+              and defines the mapping (relative spacing) between
+              subsequent input bytes at the interleaver input and
+              their placement in the bit stream at the interleaver
+              output.  Larger numbers provide greater separation
+              between consecutive input bytes in the output bit
+              stream allowing for improved impulse noise immunity
+              at the expense of payload latency."
+      ::= { adslLineConfProfileEntry 15 }
+
+      adslAturConfRateMode OBJECT-TYPE
+          SYNTAX      INTEGER {
+              fixed (1),              -- no rate adaptation
+              adaptAtStartup (2),     -- perform rate adaptation
+
+                                      -- only at initialization
+              adaptAtRuntime (3)      -- perform rate adaptation at
+                                      -- any time
+          }
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Defines what form of transmit rate adaptation is
+              configured on this modem.  See ADSL Forum TR-005 [3]
+              for more information."
+      ::= { adslLineConfProfileEntry 16 }
+
+      adslAturConfRateChanRatio OBJECT-TYPE
+          SYNTAX      INTEGER(0..100)
+          UNITS        "%"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured allocation ratio of excess transmit
+              bandwidth between fast and interleaved channels.  Only
+              applies when two channel mode and RADSL are supported.
+              Distribute bandwidth on each channel in excess of the
+              corresponding ChanConfMinTxRate so that:
+              adslAturConfRateChanRatio =
+
+                      [Fast / (Fast + Interleaved)] * 100
+
+              In other words this value is the fast channel
+              percentage."
+      ::= { adslLineConfProfileEntry 17 }
+
+    adslAturConfTargetSnrMgn OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Target Signal/Noise Margin.
+              This is the Noise Margin the modem must achieve
+              with a BER of 10-7 or better to successfully complete
+              initialization."
+      ::= { adslLineConfProfileEntry 18 }
+
+    adslAturConfMaxSnrMgn OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Maximum acceptable Signal/Noise Margin.
+              If the Noise Margin is above this the modem should
+              attempt to reduce its power output to optimize its
+              operation."
+      ::= { adslLineConfProfileEntry 19 }
+
+     adslAturConfMinSnrMgn  OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Minimum acceptable Signal/Noise Margin.
+              If the noise margin falls below this level, the modem
+              should attempt to increase its power output.  If that
+              is not possible the modem will attempt to
+              re-initialize or shut down."
+      ::= { adslLineConfProfileEntry 20 }
+
+      adslAturConfDownshiftSnrMgn  OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Signal/Noise Margin for rate downshift.
+              If the noise margin falls below this level, the modem
+              should attempt to decrease its transmit rate.
+              In the case that RADSL mode is not present,
+              the value will be `0'."
+      ::= { adslLineConfProfileEntry 21 }
+
+      adslAturConfUpshiftSnrMgn  OBJECT-TYPE
+          SYNTAX      INTEGER (0..310)
+          UNITS       "tenth dB"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Signal/Noise Margin for rate upshift.
+              If the noise margin rises above this level, the modem
+              should attempt to increase its transmit rate.
+              In the case that RADSL is not present,
+              the value will be `0'."
+      ::= { adslLineConfProfileEntry 22 }
+
+      adslAturConfMinUpshiftTime OBJECT-TYPE
+          SYNTAX      INTEGER(0..16383)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Minimum time that the current margin is above
+              UpshiftSnrMgn before an upshift occurs.
+              In the case that RADSL is not present, the value will
+              be `0'."
+      ::= { adslLineConfProfileEntry 23 }
+
+     adslAturConfMinDownshiftTime OBJECT-TYPE
+          SYNTAX      INTEGER(0..16383)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Minimum time that the current margin is below
+              DownshiftSnrMgn before a downshift occurs.
+              In the case that RADSL mode is not present,
+              the value will be `0'."
+      ::= { adslLineConfProfileEntry 24 }
+
+      adslAturChanConfFastMinTxRate  OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Minimum Transmit rate for `Fast' channels,
+              in bps.  See adslAturConfRateChanRatio for information
+              regarding RADSL mode and ATUC transmit rate
+              for ATUR receive rates."
+      ::= { adslLineConfProfileEntry 25 }
+
+      adslAturChanConfInterleaveMinTxRate OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Minimum Transmit rate for `Interleave'
+              channels, in bps.  See adslAturConfRateChanRatio for
+              information regarding RADSL mode and ATUC transmit rate
+              for ATUR receive rates."
+      ::= { adslLineConfProfileEntry 26 }
+
+      adslAturChanConfFastMaxTxRate  OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Maximum Transmit rate for `Fast' channels,
+              in bps.  See adslAturConfRateChanRatio for information
+              regarding RADSL mode and ATUC transmit rate
+              for ATUR receive rates."
+      ::= { adslLineConfProfileEntry 27 }
+
+      adslAturChanConfInterleaveMaxTxRate OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured Maximum Transmit rate for `Interleave'
+              channels, in bps.  See adslAturConfRateChanRatio for
+              information regarding RADSL mode and see
+              ATUC transmit rate for ATUR receive rates."
+      ::= { adslLineConfProfileEntry 28 }
+
+      adslAturChanConfMaxInterleaveDelay OBJECT-TYPE
+          SYNTAX      INTEGER(0..255)
+          UNITS        "milli-seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Configured maximum Interleave Delay for this channel.
+
+              Interleave delay applies only to the interleave channel
+              and defines the mapping (relative spacing) between
+              subsequent input bytes at the interleaver input and
+              their placement in the bit stream at the interleaver
+              output.  Larger numbers provide greater separation
+              between consecutive input bytes in the output bit
+              stream allowing for improved impulse noise immunity
+              at the expense of payload latency."
+      ::= { adslLineConfProfileEntry 29 }
+
+      adslLineConfProfileRowStatus OBJECT-TYPE
+          SYNTAX          RowStatus
+          MAX-ACCESS      read-create
+          STATUS          current
+          DESCRIPTION
+              "This object is used to create a new row or modify or
+              delete an existing row in this table.
+
+              A profile activated by setting this object to
+              `active'.  When `active' is set, the system
+              will validate the profile.
+
+              Before a profile can be deleted or taken out of
+              service, (by setting this object to `destroy' or
+              `outOfService') it must be first unreferenced
+              from all associated lines.
+
+              If the implementator of this MIB has chosen not
+              to implement `dynamic assignment' of profiles, this
+              object's MIN-ACCESS is read-only and its value
+              is always to be `active'."
+      ::= { adslLineConfProfileEntry 30 }
+
+      adslLineAlarmConfProfileTable    OBJECT-TYPE
+          SYNTAX          SEQUENCE OF AdslLineAlarmConfProfileEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This table contains information on the ADSL line
+              configuration.  One entry in this table reflects a
+              profile defined by a manager which can be used to
+              configure the modem for a physical line"
+      ::= { adslMibObjects 15}
+
+      adslLineAlarmConfProfileEntry    OBJECT-TYPE
+          SYNTAX          AdslLineAlarmConfProfileEntry
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "Each entry consists of a list of parameters that
+              represents the configuration of an ADSL modem.
+
+              When `dynamic' profiles are implemented, a default
+              profile will always exist.  This profile's name will
+              be set to `DEFVAL' and its parameters will be set to
+              vendor specific values, unless otherwise specified
+              in this document.
+
+              When `static' profiles are implemented, profiles
+              are automaticly created or destroyed as ADSL
+              physical lines are discovered and removed by
+              the system.  The name of the profile will be
+              equivalent to the decimal value of the line's
+              interface index.
+              "
+          INDEX { IMPLIED adslLineAlarmConfProfileName}
+      ::= { adslLineAlarmConfProfileTable 1}
+
+      AdslLineAlarmConfProfileEntry ::=
+          SEQUENCE {
+          adslLineAlarmConfProfileName          SnmpAdminString,
+          adslAtucThresh15MinLofs               INTEGER,
+          adslAtucThresh15MinLoss               INTEGER,
+          adslAtucThresh15MinLols               INTEGER,
+          adslAtucThresh15MinLprs               INTEGER,
+          adslAtucThresh15MinESs                INTEGER,
+          adslAtucThreshFastRateUp              Unsigned32,
+          adslAtucThreshInterleaveRateUp        Unsigned32,
+          adslAtucThreshFastRateDown            Unsigned32,
+          adslAtucThreshInterleaveRateDown      Unsigned32,
+          adslAtucInitFailureTrapEnable         INTEGER,
+          adslAturThresh15MinLofs               INTEGER,
+          adslAturThresh15MinLoss               INTEGER,
+          adslAturThresh15MinLprs               INTEGER,
+          adslAturThresh15MinESs                INTEGER,
+          adslAturThreshFastRateUp              Unsigned32,
+          adslAturThreshInterleaveRateUp        Unsigned32,
+          adslAturThreshFastRateDown            Unsigned32,
+          adslAturThreshInterleaveRateDown      Unsigned32,
+          adslLineAlarmConfProfileRowStatus     RowStatus
+          }
+
+      adslLineAlarmConfProfileName    OBJECT-TYPE
+          SYNTAX          SnmpAdminString (SIZE (1..32))
+          MAX-ACCESS      not-accessible
+          STATUS          current
+          DESCRIPTION
+              "This object is used by the line alarm configuration
+              table in order to identify a row of this table.
+
+              When `dynamic' profiles are implemented, the profile
+              name is user specified.  Also, the system will always
+              provide a default profile whose name is `DEFVAL'.
+
+              When `static' profiles are implemented, there is an
+              one-to-one relationship between each line and its
+              profile.  In which case, the profile name will
+              need to algorithmicly represent the Line's ifIndex.
+              Therefore, the profile's name is a decimalized string
+              of the ifIndex that is fixed-length (i.e., 10) with
+              leading zero(s).  For example, the profile name for
+              ifIndex which equals '15' will be '0000000015'."
+      ::= { adslLineAlarmConfProfileEntry 1}
+
+      adslAtucThresh15MinLofs OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Loss of Frame Seconds
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAtucPerfLofsThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 2}
+
+      adslAtucThresh15MinLoss  OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Loss of Signal Seconds
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAtucPerfLossThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 3}
+
+      adslAtucThresh15MinLols  OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Loss of Link Seconds
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAtucPerfLolsThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 4}
+
+      adslAtucThresh15MinLprs  OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Loss of Power Seconds
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAtucPerfLprsThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 5}
+
+      adslAtucThresh15MinESs  OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Errored Seconds
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAtucPerfESsThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 6}
+
+      adslAtucThreshFastRateUp OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Applies to `Fast' channels only.
+              Configured change in rate causing an
+              adslAtucRateChangeTrap. A trap is produced when:
+              ChanCurrTxRate >= ChanPrevTxRate plus the value of
+              this object. A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 7}
+
+      adslAtucThreshInterleaveRateUp OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Applies to `Interleave' channels only.
+              Configured change in rate causing an
+
+              adslAtucRateChangeTrap.  A trap is produced when:
+              ChanCurrTxRate >= ChanPrevTxRate plus the value of
+              this object. A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 8}
+
+      adslAtucThreshFastRateDown OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Applies to `Fast' channels only.
+              Configured change in rate causing an
+              adslAtucRateChangeTrap.  A trap is produced when:
+              ChanCurrTxRate <= ChanPrevTxRate minus the value of
+              this object. A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 9 }
+
+      adslAtucThreshInterleaveRateDown OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Applies to `Interleave' channels only.
+              Configured change in rate causing an
+              adslAtucRateChangeTrap.  A trap is produced when:
+              ChanCurrTxRate <= ChanPrevTxRate minus the value of
+              this object. A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 10 }
+
+      adslAtucInitFailureTrapEnable OBJECT-TYPE
+          SYNTAX      INTEGER {
+              enable (1),
+              disable (2)
+          }
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Enables and disables the InitFailureTrap.  This
+              object is defaulted disable(2)."
+      DEFVAL { disable }
+      ::= { adslLineAlarmConfProfileEntry 11 }
+
+      adslAturThresh15MinLofs OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Loss of Frame Seconds
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAturPerfLofsThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 12 }
+
+      adslAturThresh15MinLoss  OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Loss of Signal Seconds
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAturPerfLossThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 13 }
+
+      adslAturThresh15MinLprs  OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Loss of Power Seconds
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAturPerfLprsThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 14 }
+
+      adslAturThresh15MinESs  OBJECT-TYPE
+          SYNTAX      INTEGER(0..900)
+          UNITS       "seconds"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "The number of Errored Seconds
+
+              encountered by an ADSL interface within any given 15
+              minutes performance data collection period, which
+              causes the SNMP agent to send an
+              adslAturPerfESsThreshTrap.
+              One trap will be sent per interval per interface.
+              A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 15 }
+
+      adslAturThreshFastRateUp OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Applies to `Fast' channels only.
+              Configured change in rate causing an
+              adslAturRateChangeTrap.  A trap is produced when:
+              ChanCurrTxRate >= ChanPrevTxRate plus the value of
+              this object. A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 16 }
+
+      adslAturThreshInterleaveRateUp OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Applies to `Interleave' channels only.
+              configured change in rate causing an
+              adslAturRateChangeTrap.  A trap is produced when:
+              ChanCurrTxRate >= ChanPrevTxRate plus the value of
+              this object. A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 17 }
+
+      adslAturThreshFastRateDown OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Applies to `Fast' channels only.
+              Configured change in rate causing an
+              adslAturRateChangeTrap.  A trap is produced when:
+              ChanCurrTxRate <= ChanPrevTxRate minus the value of
+              this object. A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 18 }
+
+      adslAturThreshInterleaveRateDown OBJECT-TYPE
+          SYNTAX      Unsigned32
+          UNITS       "bps"
+          MAX-ACCESS  read-create
+          STATUS      current
+          DESCRIPTION
+              "Applies to `Interleave' channels only.
+              Configured change in rate causing an
+              adslAturRateChangeTrap.  A trap is produced when:
+              ChanCurrTxRate <= ChanPrevTxRate minus the value of
+              this object. A value of `0' will disable the trap."
+      ::= { adslLineAlarmConfProfileEntry 19 }
+
+      adslLineAlarmConfProfileRowStatus OBJECT-TYPE
+          SYNTAX          RowStatus
+          MAX-ACCESS      read-create
+          STATUS          current
+          DESCRIPTION
+              "This object is used to create a new row or modify or
+              delete an existing row in this table.
+
+              A profile activated by setting this object to
+              `active'.  When `active' is set, the system
+              will validate the profile.
+
+              Before a profile can be deleted or taken out of
+              service, (by setting this object to `destroy' or
+              `outOfService') it must be first unreferenced
+              from all associated lines.
+
+              If the implementator of this MIB has chosen not
+              to implement `dynamic assignment' of profiles, this
+              object's MIN-ACCESS is read-only and its value
+              is always to be `active'."
+      ::= { adslLineAlarmConfProfileEntry 20 }
+
+      -- Line Code Specific Tables
+
+      -- These are place holders for the Line Code Specific MIBs
+      -- once they become available.
+
+      adslLCSMib  OBJECT IDENTIFIER ::= { adslMibObjects 16 }
+
+-- trap definitions
+
+adslTraps OBJECT IDENTIFIER ::= { adslLineMib 2 }
+
+adslAtucTraps OBJECT IDENTIFIER ::= { adslTraps 1 }
+
+      adslAtucPerfLofsThreshTrap      NOTIFICATION-TYPE
+          OBJECTS { adslAtucPerfCurr15MinLofs,
+                    adslAtucThresh15MinLofs }
+          STATUS  current
+          DESCRIPTION
+              "Loss of Framing 15-minute interval threshold reached."
+      ::= { adslAtucTraps 0 1 }
+
+      adslAtucPerfLossThreshTrap      NOTIFICATION-TYPE
+          OBJECTS { adslAtucPerfCurr15MinLoss,
+                    adslAtucThresh15MinLoss }
+          STATUS  current
+          DESCRIPTION
+              "Loss of Signal 15-minute interval threshold reached."
+      ::= { adslAtucTraps 0 2 }
+
+      adslAtucPerfLprsThreshTrap      NOTIFICATION-TYPE
+          OBJECTS { adslAtucPerfCurr15MinLprs,
+                    adslAtucThresh15MinLprs }
+          STATUS  current
+          DESCRIPTION
+              "Loss of Power 15-minute interval threshold reached."
+      ::= { adslAtucTraps 0 3 }
+
+      adslAtucPerfESsThreshTrap       NOTIFICATION-TYPE
+          OBJECTS { adslAtucPerfCurr15MinESs,
+                    adslAtucThresh15MinESs }
+          STATUS  current
+          DESCRIPTION
+              "Errored Second 15-minute interval threshold reached."
+      ::= { adslAtucTraps 0 4 }
+
+      adslAtucRateChangeTrap  NOTIFICATION-TYPE
+          OBJECTS { adslAtucChanCurrTxRate,
+                    adslAtucChanPrevTxRate }
+          STATUS  current
+          DESCRIPTION
+              "The ATUCs transmit rate has changed (RADSL mode only)"
+      ::= { adslAtucTraps 0 5 }
+
+      adslAtucPerfLolsThreshTrap      NOTIFICATION-TYPE
+          OBJECTS { adslAtucPerfCurr15MinLols,
+                    adslAtucThresh15MinLols }
+          STATUS  current
+          DESCRIPTION
+              "Loss of Link 15-minute interval threshold reached."
+      ::= { adslAtucTraps 0 6 }
+
+      adslAtucInitFailureTrap NOTIFICATION-TYPE
+          OBJECTS { adslAtucCurrStatus }
+          STATUS  current
+          DESCRIPTION
+              "ATUC initialization failed. See adslAtucCurrStatus
+              for potential reasons."
+      ::= { adslAtucTraps 0 7 }
+
+adslAturTraps OBJECT IDENTIFIER ::= { adslTraps 2 }
+
+      adslAturPerfLofsThreshTrap      NOTIFICATION-TYPE
+          OBJECTS { adslAturPerfCurr15MinLofs,
+                    adslAturThresh15MinLofs }
+          STATUS  current
+          DESCRIPTION
+              "Loss of Framing 15-minute interval threshold reached."
+      ::= { adslAturTraps 0 1 }
+
+      adslAturPerfLossThreshTrap      NOTIFICATION-TYPE
+          OBJECTS { adslAturPerfCurr15MinLoss,
+                    adslAturThresh15MinLoss }
+          STATUS  current
+          DESCRIPTION
+              "Loss of Signal 15-minute interval threshold reached."
+      ::= { adslAturTraps 0 2 }
+
+      adslAturPerfLprsThreshTrap      NOTIFICATION-TYPE
+          OBJECTS { adslAturPerfCurr15MinLprs,
+                    adslAturThresh15MinLprs }
+          STATUS  current
+          DESCRIPTION
+              "Loss of Power 15-minute interval threshold reached."
+      ::= { adslAturTraps 0 3 }
+
+      adslAturPerfESsThreshTrap       NOTIFICATION-TYPE
+          OBJECTS { adslAturPerfCurr15MinESs,
+                    adslAturThresh15MinESs }
+          STATUS  current
+          DESCRIPTION
+              "Errored Second 15-minute interval threshold reached."
+      ::= { adslAturTraps 0 4 }
+
+      adslAturRateChangeTrap  NOTIFICATION-TYPE
+          OBJECTS { adslAturChanCurrTxRate,
+                    adslAturChanPrevTxRate }
+          STATUS  current
+          DESCRIPTION
+              "The ATURs transmit rate has changed (RADSL mode only)"
+      ::= { adslAturTraps 0 5 }
+
+      -- no adslAturPerfLolsThreshTrap possible { 0 6 }
+
+      -- no adslAturInitFailureTrap possible { 0 7 }
+
+-- conformance information
+
+adslConformance OBJECT IDENTIFIER ::= { adslLineMib 3 }
+
+adslGroups OBJECT IDENTIFIER ::= { adslConformance 1 }
+adslCompliances OBJECT IDENTIFIER ::= { adslConformance 2 }
+
+      -- ATU-C agent compliance statements
+
+      adslLineMibAtucCompliance MODULE-COMPLIANCE
+          STATUS  current
+          DESCRIPTION
+              "The compliance statement for SNMP entities
+               which manage ADSL ATU-C interfaces."
+
+          MODULE  -- this module
+          MANDATORY-GROUPS
+             {
+             adslLineGroup, adslPhysicalGroup, adslChannelGroup,
+             adslAtucPhysPerfIntervalGroup,
+             adslAturPhysPerfIntervalGroup, adslLineConfProfileGroup,
+             adslLineAlarmConfProfileGroup,
+             adslLineConfProfileControlGroup
+             }
+
+          GROUP       adslAtucPhysPerfRawCounterGroup
+          DESCRIPTION
+              "This group is optional.  Implementations which
+               require continuous ATU-C physical event counters
+               should implement this group."
+
+          GROUP       adslAturPhysPerfRawCounterGroup
+          DESCRIPTION
+              "This group is optional.  Implementations which
+               require continuous ATU-R physical event counters
+               should implement this group."
+
+          GROUP       adslAtucChanPerformanceGroup
+          DESCRIPTION
+              "This group is optional.  Implementations which
+               require ATU-C channel block event counters should
+               implement this group."
+
+          GROUP       adslAturChanPerformanceGroup
+          DESCRIPTION
+              "This group is optional.  Implementations which
+               require ATU-R channel block event counters should
+               implement this group."
+
+          OBJECT      adslLineConfProfile
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Read-only access is applicable when static
+               profiles are implemented."
+
+          OBJECT      adslAtucConfRateMode
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucConfRateChanRatio
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucConfTargetSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucConfMaxSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucConfMinSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucConfDownshiftSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucConfUpshiftSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucConfMinUpshiftTime
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucConfMinDownshiftTime
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucChanConfFastMinTxRate
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucChanConfInterleaveMinTxRate
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucChanConfFastMaxTxRate
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucChanConfInterleaveMaxTxRate
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucChanConfMaxInterleaveDelay
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfRateMode
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfRateChanRatio
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfTargetSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfMaxSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfMinSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfDownshiftSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfUpshiftSnrMgn
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfMinUpshiftTime
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturConfMinDownshiftTime
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturChanConfFastMinTxRate
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturChanConfInterleaveMinTxRate
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturChanConfFastMaxTxRate
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturChanConfInterleaveMaxTxRate
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturChanConfMaxInterleaveDelay
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslLineConfProfileRowStatus
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Read-only access is applicable only when static
+               profiles are implemented."
+
+          OBJECT      adslLineAlarmConfProfile
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Read-only access is applicable only when static
+               profiles are implemented."
+
+          OBJECT      adslAtucThresh15MinLofs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThresh15MinLoss
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThresh15MinLols
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThresh15MinLprs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThresh15MinESs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThreshFastRateUp
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThreshInterleaveRateUp
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThreshFastRateDown
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThreshInterleaveRateDown
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucInitFailureTrapEnable
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThresh15MinLofs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThresh15MinLoss
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThresh15MinLprs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThresh15MinESs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThreshFastRateUp
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThreshInterleaveRateUp
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThreshFastRateDown
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThreshInterleaveRateDown
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslLineAlarmConfProfileRowStatus
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Read-only access is applicable only when static
+               profiles are implemented."
+      ::= { adslCompliances 1 }
+
+      -- ATU-R agent compliance statements
+
+      adslLineMibAturCompliance MODULE-COMPLIANCE
+          STATUS  current
+          DESCRIPTION
+              "The compliance statement for SNMP entities
+               which manage ADSL ATU-R interfaces."
+
+          MODULE  -- this module
+          MANDATORY-GROUPS
+              {
+              adslAturLineGroup, adslAturPhysicalGroup,
+              adslAturChannelGroup,
+              adslAturAtucPhysPerfIntervalGroup,
+              adslAturAturPhysPerfIntervalGroup,
+              adslAturLineAlarmConfProfileGroup,
+              adslAturLineConfProfileControlGroup
+              }
+
+          GROUP       adslAturAtucPhysPerfRawCounterGroup
+          DESCRIPTION
+              "This group is optional.  Implementations which
+               require continuous ATU-C physical event counters
+               should implement this group."
+
+          GROUP       adslAturAturPhysPerfRawCounterGroup
+          DESCRIPTION
+              "This group is optional.  Implementations which
+
+               require continuous ATU-R physical event counters
+               should implement this group."
+
+          GROUP       adslAturAtucChanPerformanceGroup
+          DESCRIPTION
+              "This group is optional.  Implementations which
+               require ATU-C channel block event counters should
+               implement this group."
+
+          GROUP       adslAturAturChanPerformanceGroup
+          DESCRIPTION
+              "This group is optional.  Implementations which
+               require ATU-R channel block event counters should
+               implement this group."
+
+          OBJECT      adslLineAlarmConfProfile
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Read-only access is applicable only when static
+               profiles are implemented."
+
+          OBJECT      adslAtucThresh15MinLofs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThresh15MinLoss
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThresh15MinESs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThreshFastRateUp
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThreshInterleaveRateUp
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucThreshFastRateDown
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAtucInitFailureTrapEnable
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThresh15MinLofs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThresh15MinLoss
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThresh15MinLprs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThresh15MinESs
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThreshFastRateUp
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThreshInterleaveRateUp
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThreshFastRateDown
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslAturThreshInterleaveRateDown
+          MIN-ACCESS  read-write
+          DESCRIPTION
+              "Read-write access is applicable when
+               static profiles are implemented."
+
+          OBJECT      adslLineAlarmConfProfileRowStatus
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Read-only access is applicable only when static
+               profiles are implemented."
+
+          OBJECT     adslAtucCurrStatus
+          SYNTAX   BITS {
+                         noDefect(0),
+                         lossOfFraming(1),
+                         lossOfSignal(2)
+                        }
+          DESCRIPTION
+              "It is allowable to implement only noDefect(0),
+              lossOfFraming(1) and lossOfSignal(2) by the ATU-R
+              agent."
+     ::= { adslCompliances 2 }
+
+      -- units of conformance
+      adslLineGroup    OBJECT-GROUP
+          OBJECTS {
+             adslLineCoding, adslLineType, adslLineSpecific
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing configuration
+              information about an ADSL Line."
+      ::= { adslGroups 1 }
+
+      adslPhysicalGroup    OBJECT-GROUP
+          OBJECTS {
+
+             adslAtucInvSerialNumber, adslAtucInvVendorID,
+             adslAtucInvVersionNumber, adslAtucCurrSnrMgn,
+             adslAtucCurrAtn, adslAtucCurrStatus,
+             adslAtucCurrOutputPwr, adslAtucCurrAttainableRate,
+             adslAturInvSerialNumber, adslAturInvVendorID,
+             adslAturInvVersionNumber, adslAturCurrSnrMgn,
+             adslAturCurrAtn, adslAturCurrStatus,
+             adslAturCurrOutputPwr, adslAturCurrAttainableRate
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing physical
+              configuration information of the ADSL Line."
+      ::= { adslGroups 2 }
+
+      adslChannelGroup    OBJECT-GROUP
+          OBJECTS {
+             adslAtucChanInterleaveDelay, adslAtucChanCurrTxRate,
+             adslAtucChanPrevTxRate, adslAtucChanCrcBlockLength,
+             adslAturChanInterleaveDelay, adslAturChanCurrTxRate,
+             adslAturChanPrevTxRate, adslAturChanCrcBlockLength
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing configuration
+              information about an ADSL channel."
+      ::= { adslGroups 3 }
+
+      adslAtucPhysPerfRawCounterGroup OBJECT-GROUP
+          OBJECTS {
+             adslAtucPerfLofs, adslAtucPerfLoss,
+             adslAtucPerfLols, adslAtucPerfLprs,
+             adslAtucPerfESs, adslAtucPerfInits
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing raw performance
+              counts on an ADSL Line (ATU-C end)."
+      ::= { adslGroups 4 }
+
+      adslAtucPhysPerfIntervalGroup OBJECT-GROUP
+          OBJECTS {
+             adslAtucPerfValidIntervals,
+             adslAtucPerfInvalidIntervals,
+             adslAtucPerfCurr15MinTimeElapsed,
+             adslAtucPerfCurr15MinLofs, adslAtucPerfCurr15MinLoss,
+             adslAtucPerfCurr15MinLols, adslAtucPerfCurr15MinLprs,
+             adslAtucPerfCurr15MinESs, adslAtucPerfCurr15MinInits,
+             adslAtucPerfCurr1DayLofs, adslAtucPerfCurr1DayLoss,
+             adslAtucPerfCurr1DayLols, adslAtucPerfCurr1DayLprs,
+             adslAtucPerfCurr1DayESs, adslAtucPerfCurr1DayInits,
+             adslAtucPerfPrev1DayMoniSecs,
+             adslAtucPerfPrev1DayLofs, adslAtucPerfPrev1DayLoss,
+             adslAtucPerfPrev1DayLols, adslAtucPerfPrev1DayLprs,
+             adslAtucPerfPrev1DayESs, adslAtucPerfPrev1DayInits,
+             adslAtucIntervalLofs, adslAtucIntervalLoss,
+             adslAtucIntervalLols, adslAtucIntervalLprs,
+             adslAtucIntervalESs, adslAtucIntervalInits,
+             adslAtucIntervalValidData
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing current 15-minute,
+              1-day; and previous 1-day performance counts on
+              ADSL Line (ATU-C end) ."
+      ::= { adslGroups 5 }
+
+      adslAturPhysPerfRawCounterGroup OBJECT-GROUP
+          OBJECTS {
+             adslAturPerfLofs, adslAturPerfLoss,
+             adslAturPerfLprs, adslAturPerfESs
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing raw performance
+              counts on an ADSL Line (ATU-R end)."
+      ::= { adslGroups 6 }
+
+      adslAturPhysPerfIntervalGroup OBJECT-GROUP
+          OBJECTS {
+             adslAturPerfValidIntervals,
+             adslAturPerfInvalidIntervals,
+             adslAturPerfCurr15MinTimeElapsed,
+             adslAturPerfCurr15MinLofs, adslAturPerfCurr15MinLoss,
+             adslAturPerfCurr15MinLprs, adslAturPerfCurr15MinESs,
+             adslAturPerfCurr1DayTimeElapsed,
+             adslAturPerfCurr1DayLofs, adslAturPerfCurr1DayLoss,
+             adslAturPerfCurr1DayLprs, adslAturPerfCurr1DayESs,
+             adslAturPerfPrev1DayMoniSecs,
+             adslAturPerfPrev1DayLofs, adslAturPerfPrev1DayLoss,
+             adslAturPerfPrev1DayLprs, adslAturPerfPrev1DayESs,
+             adslAturIntervalLofs,
+             adslAturIntervalLoss, adslAturIntervalLprs,
+             adslAturIntervalESs, adslAturIntervalValidData
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing current 15-minute,
+              1-day; and previous 1-day performance counts on
+              ADSL Line (ATU-R end)."
+      ::= { adslGroups 7 }
+
+      adslAtucChanPerformanceGroup OBJECT-GROUP
+          OBJECTS {
+             adslAtucChanReceivedBlks,
+             adslAtucChanTransmittedBlks,
+             adslAtucChanCorrectedBlks,
+             adslAtucChanUncorrectBlks,
+             adslAtucChanPerfValidIntervals,
+             adslAtucChanPerfInvalidIntervals,
+             adslAtucChanPerfCurr15MinTimeElapsed,
+             adslAtucChanPerfCurr15MinReceivedBlks,
+             adslAtucChanPerfCurr15MinTransmittedBlks,
+             adslAtucChanPerfCurr15MinCorrectedBlks,
+             adslAtucChanPerfCurr15MinUncorrectBlks,
+             adslAtucChanPerfCurr1DayTimeElapsed,
+             adslAtucChanPerfCurr1DayReceivedBlks,
+             adslAtucChanPerfCurr1DayTransmittedBlks,
+             adslAtucChanPerfCurr1DayCorrectedBlks,
+             adslAtucChanPerfCurr1DayUncorrectBlks,
+             adslAtucChanPerfPrev1DayMoniSecs,
+             adslAtucChanPerfPrev1DayReceivedBlks,
+             adslAtucChanPerfPrev1DayTransmittedBlks,
+             adslAtucChanPerfPrev1DayCorrectedBlks,
+             adslAtucChanPerfPrev1DayUncorrectBlks,
+             adslAtucChanIntervalReceivedBlks,
+             adslAtucChanIntervalTransmittedBlks,
+             adslAtucChanIntervalCorrectedBlks,
+             adslAtucChanIntervalUncorrectBlks,
+             adslAtucChanIntervalValidData
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing channel block
+              performance information on an ADSL channel
+              (ATU-C end)."
+      ::= { adslGroups 8 }
+
+      adslAturChanPerformanceGroup OBJECT-GROUP
+          OBJECTS {
+             adslAturChanReceivedBlks,
+             adslAturChanTransmittedBlks,
+             adslAturChanCorrectedBlks,
+             adslAturChanUncorrectBlks,
+             adslAturChanPerfValidIntervals,
+             adslAturChanPerfInvalidIntervals,
+             adslAturChanPerfCurr15MinTimeElapsed,
+             adslAturChanPerfCurr15MinReceivedBlks,
+             adslAturChanPerfCurr15MinTransmittedBlks,
+             adslAturChanPerfCurr15MinCorrectedBlks,
+             adslAturChanPerfCurr15MinUncorrectBlks,
+             adslAturChanPerfCurr1DayTimeElapsed,
+             adslAturChanPerfCurr1DayReceivedBlks,
+             adslAturChanPerfCurr1DayTransmittedBlks,
+             adslAturChanPerfCurr1DayCorrectedBlks,
+             adslAturChanPerfCurr1DayUncorrectBlks,
+             adslAturChanPerfPrev1DayMoniSecs,
+             adslAturChanPerfPrev1DayReceivedBlks,
+             adslAturChanPerfPrev1DayTransmittedBlks,
+             adslAturChanPerfPrev1DayCorrectedBlks,
+             adslAturChanPerfPrev1DayUncorrectBlks,
+             adslAturChanIntervalReceivedBlks,
+             adslAturChanIntervalTransmittedBlks,
+             adslAturChanIntervalCorrectedBlks,
+             adslAturChanIntervalUncorrectBlks,
+             adslAturChanIntervalValidData
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing channel block
+              performance information on an ADSL channel
+              (ATU-C end)."
+      ::= { adslGroups 9 }
+
+      adslLineConfProfileGroup OBJECT-GROUP
+          OBJECTS {
+             adslAtucConfRateMode, adslAtucConfRateChanRatio,
+             adslAtucConfTargetSnrMgn, adslAtucConfMaxSnrMgn,
+             adslAtucConfMinSnrMgn,
+             adslAtucConfDownshiftSnrMgn,
+             adslAtucConfUpshiftSnrMgn,
+             adslAtucConfMinUpshiftTime,
+             adslAtucConfMinDownshiftTime,
+             adslAtucChanConfFastMinTxRate,
+             adslAtucChanConfInterleaveMinTxRate,
+             adslAtucChanConfFastMaxTxRate,
+             adslAtucChanConfInterleaveMaxTxRate,
+             adslAtucChanConfMaxInterleaveDelay,
+             adslAturConfRateMode, adslAturConfRateChanRatio,
+             adslAturConfTargetSnrMgn, adslAturConfMaxSnrMgn,
+             adslAturConfMinSnrMgn, adslAturConfDownshiftSnrMgn,
+             adslAturConfUpshiftSnrMgn,
+             adslAturConfMinUpshiftTime,
+             adslAturConfMinDownshiftTime,
+             adslAturChanConfFastMinTxRate,
+             adslAturChanConfInterleaveMinTxRate,
+             adslAturChanConfFastMaxTxRate,
+             adslAturChanConfInterleaveMaxTxRate,
+             adslAturChanConfMaxInterleaveDelay
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing provisioning
+              information about an ADSL Line."
+      ::= { adslGroups 10 }
+
+      adslLineAlarmConfProfileGroup OBJECT-GROUP
+          OBJECTS {
+             adslAtucThresh15MinLofs, adslAtucThresh15MinLoss,
+             adslAtucThresh15MinLols, adslAtucThresh15MinLprs,
+             adslAtucThresh15MinESs, adslAtucThreshFastRateUp,
+             adslAtucThreshInterleaveRateUp,
+             adslAtucThreshFastRateDown,
+             adslAtucThreshInterleaveRateDown,
+             adslAtucInitFailureTrapEnable,
+             adslAturThresh15MinLofs, adslAturThresh15MinLoss,
+             adslAturThresh15MinLprs, adslAturThresh15MinESs,
+             adslAturThreshFastRateUp,
+             adslAturThreshInterleaveRateUp,
+             adslAturThreshFastRateDown,
+             adslAturThreshInterleaveRateDown
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing alarm provisioning
+              information about an ADSL Line."
+      ::= { adslGroups 11 }
+
+      adslLineConfProfileControlGroup OBJECT-GROUP
+          OBJECTS {
+             adslLineConfProfile, adslLineAlarmConfProfile,
+             adslLineConfProfileRowStatus,
+             adslLineAlarmConfProfileRowStatus
+             }
+          STATUS     current
+          DESCRIPTION
+              "A collection of objects providing profile
+              control for the ADSL system."
+      ::= { adslGroups 12 }
+
+      adslNotificationsGroup NOTIFICATION-GROUP
+          NOTIFICATIONS {
+             adslAtucPerfLofsThreshTrap,
+             adslAtucPerfLossThreshTrap,
+             adslAtucPerfLprsThreshTrap,
+             adslAtucPerfESsThreshTrap,
+             adslAtucRateChangeTrap,
+             adslAtucPerfLolsThreshTrap,
+             adslAtucInitFailureTrap,
+             adslAturPerfLofsThreshTrap,
+             adslAturPerfLossThreshTrap,
+             adslAturPerfLprsThreshTrap,
+             adslAturPerfESsThreshTrap,
+             adslAturRateChangeTrap
+             }
+          STATUS        current
+          DESCRIPTION
+              "The collection of adsl notifications."
+      ::= { adslGroups 13 }
+
+-- units of conformance for ATU-R agent
+
+         adslAturLineGroup    OBJECT-GROUP
+             OBJECTS {
+                adslLineCoding
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing configuration
+                 information about an ADSL Line on the ATU-R side."
+         ::= { adslGroups 14 }
+
+         adslAturPhysicalGroup    OBJECT-GROUP
+             OBJECTS {
+                adslAtucInvVendorID,
+                adslAtucInvVersionNumber,
+                adslAtucCurrOutputPwr, adslAtucCurrAttainableRate,
+                adslAturInvSerialNumber, adslAturInvVendorID,
+                adslAturInvVersionNumber, adslAturCurrSnrMgn,
+                adslAturCurrAtn, adslAturCurrStatus,
+                adslAturCurrOutputPwr, adslAturCurrAttainableRate,
+                adslAtucCurrStatus
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing physical
+                 configuration information of the ADSL Line on the
+                 ATU-R side."
+         ::= { adslGroups 15 }
+
+         adslAturChannelGroup    OBJECT-GROUP
+             OBJECTS {
+                adslAtucChanInterleaveDelay, adslAtucChanCurrTxRate,
+                adslAtucChanPrevTxRate,
+                adslAturChanInterleaveDelay, adslAturChanCurrTxRate,
+                adslAturChanPrevTxRate, adslAturChanCrcBlockLength
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing configuration
+                information about an ADSL channel on the ATU-R
+                side."
+         ::= { adslGroups 16 }
+
+         adslAturAtucPhysPerfRawCounterGroup OBJECT-GROUP
+             OBJECTS {
+                adslAtucPerfLofs, adslAtucPerfLoss,
+                adslAtucPerfESs, adslAtucPerfInits
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing raw performance
+                counts on an ADSL Line (ATU-C end) provided by the
+                ATU-R agent."
+         ::= { adslGroups 17 }
+
+         adslAturAtucPhysPerfIntervalGroup OBJECT-GROUP
+             OBJECTS {
+                adslAtucPerfValidIntervals,
+                adslAtucPerfInvalidIntervals,
+                adslAtucPerfCurr15MinTimeElapsed,
+                adslAtucPerfCurr15MinLofs, adslAtucPerfCurr15MinLoss,
+                adslAtucPerfCurr15MinESs, adslAtucPerfCurr15MinInits,
+                adslAtucPerfCurr1DayTimeElapsed,
+                adslAtucPerfCurr1DayLofs, adslAtucPerfCurr1DayLoss,
+                adslAtucPerfCurr1DayESs, adslAtucPerfCurr1DayInits,
+                adslAtucPerfPrev1DayMoniSecs,
+                adslAtucPerfPrev1DayLofs, adslAtucPerfPrev1DayLoss,
+                adslAtucPerfPrev1DayESs, adslAtucPerfPrev1DayInits,
+                adslAtucIntervalLofs, adslAtucIntervalLoss,
+                adslAtucIntervalESs, adslAtucIntervalInits,
+                adslAtucIntervalValidData
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing current
+
+                15-minute, 1-day; and previous 1-day performance
+                counts on ADSL Line (ATU-C end) provided by the
+                ATU-R agent."
+         ::= { adslGroups 18 }
+
+         adslAturAturPhysPerfRawCounterGroup OBJECT-GROUP
+             OBJECTS {
+                adslAturPerfLofs, adslAturPerfLoss,
+                adslAturPerfLprs, adslAturPerfESs
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing raw performance
+                counts on an ADSL Line (ATU-R end) provided by the
+                ATU-R agent."
+         ::= { adslGroups 19 }
+
+         adslAturAturPhysPerfIntervalGroup OBJECT-GROUP
+             OBJECTS {
+                adslAturPerfValidIntervals,
+                adslAturPerfInvalidIntervals,
+                adslAturPerfCurr15MinTimeElapsed,
+                adslAturPerfCurr15MinLofs, adslAturPerfCurr15MinLoss,
+                adslAturPerfCurr15MinLprs, adslAturPerfCurr15MinESs,
+                adslAturPerfCurr1DayTimeElapsed,
+                adslAturPerfCurr1DayLofs, adslAturPerfCurr1DayLoss,
+                adslAturPerfCurr1DayLprs, adslAturPerfCurr1DayESs,
+                adslAturPerfPrev1DayMoniSecs,
+                adslAturPerfPrev1DayLofs, adslAturPerfPrev1DayLoss,
+                adslAturPerfPrev1DayLprs, adslAturPerfPrev1DayESs,
+                adslAturIntervalLofs,
+                adslAturIntervalLoss, adslAturIntervalLprs,
+                adslAturIntervalESs, adslAturIntervalValidData
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing current
+                15-minute, 1-day; and previous 1-day performance
+                counts on ADSL Line (ATU-R end) provided by the
+                ATU-R agent."
+         ::= { adslGroups 20 }
+
+         adslAturAtucChanPerformanceGroup OBJECT-GROUP
+             OBJECTS {
+                adslAtucChanReceivedBlks,
+                adslAtucChanTransmittedBlks,
+                adslAtucChanCorrectedBlks,
+                adslAtucChanUncorrectBlks,
+                adslAtucChanPerfCurr15MinTimeElapsed,
+                adslAtucChanPerfCurr15MinReceivedBlks,
+                adslAtucChanPerfCurr15MinTransmittedBlks,
+                adslAtucChanPerfCurr15MinCorrectedBlks,
+                adslAtucChanPerfCurr15MinUncorrectBlks,
+                adslAtucChanPerfCurr1DayTimeElapsed,
+                adslAtucChanPerfCurr1DayReceivedBlks,
+                adslAtucChanPerfCurr1DayTransmittedBlks,
+                adslAtucChanPerfCurr1DayCorrectedBlks,
+                adslAtucChanPerfCurr1DayUncorrectBlks,
+                adslAtucChanPerfPrev1DayMoniSecs,
+                adslAtucChanPerfPrev1DayReceivedBlks,
+                adslAtucChanPerfPrev1DayTransmittedBlks,
+                adslAtucChanPerfPrev1DayCorrectedBlks,
+                adslAtucChanPerfPrev1DayUncorrectBlks,
+                adslAtucChanPerfValidIntervals,
+                adslAtucChanPerfInvalidIntervals,
+                adslAtucChanIntervalReceivedBlks,
+                adslAtucChanIntervalTransmittedBlks,
+                adslAtucChanIntervalCorrectedBlks,
+                adslAtucChanIntervalUncorrectBlks,
+                adslAtucChanIntervalValidData
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing channel block
+                 performance information on an ADSL channel
+                 (ATU-C end) provided by the ATU-R agent."
+         ::= { adslGroups 21 }
+
+         adslAturAturChanPerformanceGroup OBJECT-GROUP
+             OBJECTS {
+                adslAturChanReceivedBlks,
+                adslAturChanTransmittedBlks,
+                adslAturChanCorrectedBlks,
+                adslAturChanUncorrectBlks,
+                adslAturChanPerfValidIntervals,
+                adslAturChanPerfInvalidIntervals,
+                adslAturChanPerfCurr15MinTimeElapsed,
+                adslAturChanPerfCurr15MinReceivedBlks,
+                adslAturChanPerfCurr15MinTransmittedBlks,
+                adslAturChanPerfCurr15MinCorrectedBlks,
+                adslAturChanPerfCurr15MinUncorrectBlks,
+                adslAturChanPerfCurr1DayTimeElapsed,
+                adslAturChanPerfCurr1DayReceivedBlks,
+                adslAturChanPerfCurr1DayTransmittedBlks,
+                adslAturChanPerfCurr1DayCorrectedBlks,
+                adslAturChanPerfCurr1DayUncorrectBlks,
+                adslAturChanPerfPrev1DayMoniSecs,
+                adslAturChanPerfPrev1DayReceivedBlks,
+                adslAturChanPerfPrev1DayTransmittedBlks,
+                adslAturChanPerfPrev1DayCorrectedBlks,
+                adslAturChanPerfPrev1DayUncorrectBlks,
+                adslAturChanIntervalReceivedBlks,
+                adslAturChanIntervalTransmittedBlks,
+                adslAturChanIntervalCorrectedBlks,
+                adslAturChanIntervalUncorrectBlks,
+                adslAturChanIntervalValidData
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing channel block
+                 performance information on an ADSL channel
+                 (ATU-R end) provided by the ATU-R agent."
+         ::= { adslGroups 22 }
+
+         adslAturLineAlarmConfProfileGroup OBJECT-GROUP
+             OBJECTS {
+                adslAtucThresh15MinLofs, adslAtucThresh15MinLoss,
+                adslAtucThresh15MinESs, adslAtucThreshFastRateUp,
+                adslAtucThreshInterleaveRateUp,
+                adslAtucThreshFastRateDown,
+                adslAtucThreshInterleaveRateDown,
+                adslAtucInitFailureTrapEnable,
+                adslAturThresh15MinLofs, adslAturThresh15MinLoss,
+                adslAturThresh15MinLprs, adslAturThresh15MinESs,
+                adslAturThreshFastRateUp,
+                adslAturThreshInterleaveRateUp,
+                adslAturThreshFastRateDown,
+                adslAturThreshInterleaveRateDown
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing alarm
+provisioning
+                 information about an ADSL Line provided by the
+                 ATU-R agent."
+         ::= { adslGroups 23 }
+
+         adslAturLineConfProfileControlGroup OBJECT-GROUP
+             OBJECTS {
+                adslLineAlarmConfProfile,
+                adslLineAlarmConfProfileRowStatus
+                }
+             STATUS     current
+             DESCRIPTION
+                 "A collection of objects providing profile
+                 control for the ADSL system by the ATU-R agent."
+         ::= { adslGroups 24 }
+
+         adslAturNotificationsGroup NOTIFICATION-GROUP
+             NOTIFICATIONS {
+                 adslAtucPerfLofsThreshTrap,
+                 adslAtucPerfLossThreshTrap,
+                 adslAtucPerfESsThreshTrap,
+                 adslAtucRateChangeTrap,
+                 adslAturPerfLofsThreshTrap,
+                 adslAturPerfLossThreshTrap,
+                 adslAturPerfLprsThreshTrap,
+                 adslAturPerfESsThreshTrap,
+                 adslAturRateChangeTrap
+                 }
+             STATUS        current
+             DESCRIPTION
+                 "The collection of ADSL notifications implemented by
+                 the ATU-R agent."
+         ::= { adslGroups 25 }
+
+END

--- a/services/monitoring/assets/snmp/mibs/ADSL-TC-MIB
+++ b/services/monitoring/assets/snmp/mibs/ADSL-TC-MIB
@@ -1,0 +1,113 @@
+ADSL-TC-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    transmission,
+    MODULE-IDENTITY, Gauge32            FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION                  FROM SNMPv2-TC;
+
+adsltcmib MODULE-IDENTITY
+
+LAST-UPDATED "9908190000Z"
+
+ORGANIZATION "IETF ADSL MIB Working Group"
+
+CONTACT-INFO
+    "
+    Gregory Bathrick
+    AG Communication Systems
+    A Subsidiary of Lucent Technologies
+    2500 W Utopia Rd.
+    Phoenix, AZ 85027 USA
+    Tel: +1 602-582-7679
+    Fax: +1 602-582-7697
+    E-mail: bathricg@agcs.com
+
+    Faye Ly
+    Copper Mountain Networks
+    Norcal Office
+    2470 Embarcadero Way
+    Palo Alto, CA 94303
+    Tel: +1 650-858-8500
+    Fax: +1 650-858-8085
+    E-Mail: faye@coppermountain.com
+
+    IETF ADSL MIB Working Group (adsl@xlist.agcs.com)
+    "
+    DESCRIPTION
+        "The MIB module which provides a ADSL
+        Line Coding Textual Convention to be used
+        by ADSL Lines."
+
+    --  Revision history
+    REVISION     "9908190000Z"  -- 19 August 1999, midnight
+    DESCRIPTION  "Initial Version, published as RFC 2662"
+    ::= { transmission 94 2 } -- adslMIB 2
+
+    AdslLineCodingType ::= TEXTUAL-CONVENTION
+        STATUS       current
+        DESCRIPTION
+            "This data type is used as the syntax for the ADSL
+            Line Code."
+        SYNTAX  INTEGER {
+            other(1),-- none of the following
+            dmt (2), -- Discrete MultiTone
+            cap (3), -- Carrierless Amplitude & Phase modulation
+            qam (4)  -- Quadrature Amplitude Modulation
+        }
+
+    AdslPerfCurrDayCount ::= TEXTUAL-CONVENTION
+        STATUS  current
+        DESCRIPTION
+            "A counter associated with interface performance
+            measurements in a current 1-day (24 hour) measurement
+            interval.
+
+            The value of this counter starts at zero at the
+            beginning of an interval and is increased when
+            associated events occur, until the end of the
+            1-day interval.  At that time the value of the
+            counter is stored in the previous 1-day history
+            interval, if available, and the current interval
+            counter is restarted at zero.
+
+            In the case where the agent has no valid data available
+            for this interval the corresponding object
+            instance is not available and upon a retrieval
+            request a corresponding error message shall be
+            returned to indicate that this instance does
+            not exist (for example, a noSuchName error for
+            SNMPv1 and a noSuchInstance for SNMPv2 GET
+            operation)."
+         SYNTAX  Gauge32
+
+    AdslPerfPrevDayCount ::= TEXTUAL-CONVENTION
+        STATUS  current
+        DESCRIPTION
+            "A counter associated with interface performance
+            measurements during the most previous 1-day (24 hour)
+            measurement interval.  The value of this counter is
+            equal to the value of the current day counter at
+            the end of its most recent interval.
+
+            In the case where the agent has no valid data available
+            for this interval the corresponding object
+            instance is not available and upon a retrieval
+            request a corresponding error message shall be
+            returned to indicate that this instance does
+            not exist (for example, a noSuchName error for
+            SNMPv1 and a noSuchInstance for SNMPv2 GET
+            operation)."
+        SYNTAX  Gauge32
+
+    AdslPerfTimeElapsed ::= TEXTUAL-CONVENTION
+        STATUS current
+        DESCRIPTION
+            "The number of seconds that have elapsed since
+            the beginning of the current measurement period.
+            If, for some reason, such as an adjustment in the
+            system's time-of-day clock, the current interval
+            exceeds the maximum value, the agent will return
+            the maximum value."
+        SYNTAX  Gauge32
+
+END

--- a/services/monitoring/assets/snmp/mibs/HC-PerfHist-TC-MIB
+++ b/services/monitoring/assets/snmp/mibs/HC-PerfHist-TC-MIB
@@ -1,0 +1,222 @@
+HC-PerfHist-TC-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY,
+    Counter64,
+    Unsigned32,
+    Integer32,
+    mib-2                FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION   FROM SNMPv2-TC;
+
+hcPerfHistTCMIB MODULE-IDENTITY
+   LAST-UPDATED "200402030000Z" -- February 3, 2004
+   ORGANIZATION "ADSLMIB Working Group"
+   CONTACT-INFO "WG-email:  adslmib@ietf.org
+        Info:      https://www1.ietf.org/mailman/listinfo/adslmib
+
+        Chair:     Mike Sneed
+                   Sand Channel Systems
+        Postal:    P.O.  Box 37324
+                   Raleigh NC 27627-7324
+                   USA
+        Email:     sneedmike@hotmail.com
+        Phone:     +1 206 600 7022
+
+        Co-editor: Bob Ray
+                   PESA Switching Systems, Inc.
+        Postal:    330-A Wynn Drive
+                   Huntsville, AL 35805
+                   USA
+        Email:     rray@pesa.com
+        Phone:     +1 256 726 9200 ext.  142
+
+        Co-editor: Rajesh Abbi
+                   Alcatel USA
+        Postal:    2301 Sugar Bush Road
+                   Raleigh, NC 27612-3339
+                   USA
+        Email:     Rajesh.Abbi@alcatel.com
+        Phone:     +1 919 850 6194
+        "
+    DESCRIPTION
+        "This MIB Module provides Textual Conventions to be
+         used by systems supporting 15 minute based performance
+         history counts that require high-capacity counts.
+
+         Copyright (C) The Internet Society (2004).  This version
+         of this MIB module is part of RFC 3705: see the RFC
+         itself for full legal notices."
+
+        REVISION "200402030000Z" -- February 3, 2004
+        DESCRIPTION "Initial version, published as RFC 3705."
+        ::= { mib-2 107 }
+
+HCPerfValidIntervals ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+       "The number of near end intervals for which data was
+
+       collected.  The value of an object with an
+       HCPerfValidIntervals syntax will be 96 unless the
+       measurement was (re-)started within the last 1440 minutes,
+       in which case the value will be the number of complete 15
+       minute intervals for which the agent has at least some data.
+       In certain cases (e.g., in the case where the agent is a
+       proxy) it is possible that some intervals are unavailable.
+       In this case, this interval is the maximum interval number
+       for which data is available."
+    SYNTAX   Integer32 (0..96)
+
+HCPerfInvalidIntervals ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+       "The number of near end intervals for which no data is
+       available.  The value of an object with an
+       HCPerfInvalidIntervals syntax will typically be zero except
+       in cases where the data for some intervals are not available
+       (e.g., in proxy situations)."
+    SYNTAX   Integer32 (0..96)
+
+HCPerfTimeElapsed ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+       "The number of seconds that have elapsed since the beginning
+       of the current measurement period.  If, for some reason,
+       such as an adjustment in the system's time-of-day clock or
+       the addition of a leap second, the duration of the current
+       interval exceeds the maximum value, the agent will return
+       the maximum value.
+
+       For 15 minute intervals, the range is limited to (0..899).
+       For 24 hour intervals, the range is limited to (0..86399)."
+    SYNTAX   Integer32 (0..86399)
+
+HCPerfIntervalThreshold ::= TEXTUAL-CONVENTION
+    STATUS   current
+    DESCRIPTION
+        "This convention defines a range of values that may be set
+        in a fault threshold alarm control.  As the number of
+        seconds in a 15-minute interval numbers at most 900,
+        objects of this type may have a range of 0...900, where the
+        value of 0 disables the alarm."
+    SYNTAX   Unsigned32 (0..900)
+
+HCPerfCurrentCount ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+        "A gauge associated with a performance measurement in a
+         current 15 minute measurement interval.  The value of an
+         object with an HCPerfCurrentCount syntax starts from zero
+         and is increased when associated events occur, until the
+         end of the 15 minute interval.  At that time the value of
+         the gauge is stored in the first 15 minute history
+         interval, and the gauge is restarted at zero.  In the case
+         where the agent has no valid data available for the
+         current interval, the corresponding object instance is not
+         available and upon a retrieval request a corresponding
+         error message shall be returned to indicate that this
+         instance does not exist.
+
+         This count represents a non-negative integer, which
+         may increase or decrease, but shall never exceed 2^64-1
+         (18446744073709551615 decimal), nor fall below 0.  The
+         value of an object with HCPerfCurrentCount syntax
+         assumes its maximum value whenever the underlying count
+         exceeds 2^64-1.  If the underlying count subsequently
+         decreases below 2^64-1 (due, e.g., to a retroactive
+         adjustment as a result of entering or exiting unavailable
+         time), then the object's value also decreases.
+
+         Note that this TC is not strictly supported in SMIv2,
+         because the 'always increasing' and 'counter wrap'
+         semantics associated with the Counter64 base type are not
+         preserved.  It is possible that management applications
+         which rely solely upon the (Counter64) ASN.1 tag to
+         determine object semantics will mistakenly operate upon
+         objects of this type as they would for Counter64 objects.
+
+         This textual convention represents a limited and short-
+         term solution, and may be deprecated as a long term
+         solution is defined and deployed to replace it."
+    SYNTAX  Counter64
+
+HCPerfIntervalCount ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+        "A gauge associated with a performance measurement in
+         a previous 15 minute measurement interval.  In the case
+         where the agent has no valid data available for a
+         particular interval, the corresponding object instance is
+         not available and upon a retrieval request a corresponding
+         error message shall be returned to indicate that this
+         instance does not exist.
+
+         Let X be an object with HCPerfIntervalCount syntax.
+
+         Let Y be an object with HCPerfCurrentCount syntax.
+         Let Z be an object with HCPerfTotalCount syntax.
+         Then, in a system supporting a history of n intervals with
+         X(1) and X(n) the most and least recent intervals
+         respectively, the following applies at the end of a 15
+         minute interval:
+
+            - discard the value of X(n)
+            - the value of X(i) becomes that of X(i-1)
+              for n >= i > 1
+            - the value of X(1) becomes that of Y.
+            - the value of Z, if supported, is adjusted.
+
+         This count represents a non-negative integer, which
+         may increase or decrease, but shall never exceed 2^64-1
+         (18446744073709551615 decimal), nor fall below 0.  The
+         value of an object with HCPerfIntervalCount syntax
+         assumes its maximum value whenever the underlying count
+         exceeds 2^64-1.  If the underlying count subsequently
+         decreases below 2^64-1 (due, e.g., to a retroactive
+         adjustment as a result of entering or exiting unavailable
+         time), then the value of the object also decreases.
+
+         Note that this TC is not strictly supported in SMIv2,
+         because the 'always increasing' and 'counter wrap'
+         semantics associated with the Counter64 base type are not
+         preserved.  It is possible that management applications
+         which rely solely upon the (Counter64) ASN.1 tag to
+         determine object semantics will mistakenly operate upon
+         objects of this type as they would for Counter64 objects.
+
+         This textual convention represents a limited and short-
+         term solution, and may be deprecated as a long term
+         solution is defined and deployed to replace it."
+    SYNTAX  Counter64
+
+HCPerfTotalCount ::= TEXTUAL-CONVENTION
+    STATUS  current
+    DESCRIPTION
+        "A gauge representing the aggregate of previous valid 15
+         minute measurement intervals.  Intervals for which no
+         valid data was available are not counted.
+
+         This count represents a non-negative integer, which
+         may increase or decrease, but shall never exceed 2^64-1
+         (18446744073709551615 decimal), nor fall below 0.  The
+         value of an object with HCPerfTotalCount syntax
+         assumes its maximum value whenever the underlying count
+
+         exceeds 2^64-1.  If the underlying count subsequently
+         decreases below 2^64-1 (due, e.g., to a retroactive
+         adjustment as a result of entering or exiting unavailable
+         time), then the object's value also decreases.
+
+         Note that this TC is not strictly supported in SMIv2,
+         because the 'always increasing' and 'counter wrap'
+         semantics associated with the Counter64 base type are not
+         preserved.  It is possible that management applications
+         which rely solely upon the (Counter64) ASN.1 tag to
+         determine object semantics will mistakenly operate upon
+         objects of this type as they would for Counter64 objects.
+
+         This textual convention represents a limited and short-
+         term solution, and may be deprecated as a long term
+         solution is defined and deployed to replace it."
+    SYNTAX  Counter64
+END

--- a/services/monitoring/assets/snmp/mibs/IANAifType-MIB
+++ b/services/monitoring/assets/snmp/mibs/IANAifType-MIB
@@ -1,0 +1,771 @@
+   IANAifType-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, mib-2      FROM SNMPv2-SMI
+       TEXTUAL-CONVENTION          FROM SNMPv2-TC;
+
+   ianaifType MODULE-IDENTITY
+       LAST-UPDATED "202105170000Z" -- May 17, 2021
+       ORGANIZATION "IANA"
+       CONTACT-INFO "        Internet Assigned Numbers Authority
+
+                     Postal: ICANN
+                             12025 Waterfront Drive, Suite 300
+                             Los Angeles, CA 90094-2536
+
+                     Tel:    +1 310-301-5800
+                     E-Mail: iana@iana.org"
+       DESCRIPTION  "This MIB module defines the IANAifType Textual
+                     Convention, and thus the enumerated values of
+                     the ifType object defined in MIB-II's ifTable."
+
+       REVISION     "202105170000Z"  -- May 17, 2021
+       DESCRIPTION  "Registration of new IANAifType 303."
+
+       REVISION     "202104230000Z"  -- April 23, 2021
+       DESCRIPTION  "Registration of new tunnelType 19 and
+                     combined 2018-06-28 revision statements"
+
+       REVISION     "202104220000Z"  -- April 22, 2021
+       DESCRIPTION  "Registration of new IANAifType 302."
+
+       REVISION     "202102180000Z"  -- February 18, 2021
+       DESCRIPTION  "Registration of new IANAifType 301."
+
+       REVISION     "202008270000Z"  -- August 27, 2020
+       DESCRIPTION  "Updated Interface Types (ifType) registry name."
+
+       REVISION     "202007100000Z"  -- July 10, 2020
+       DESCRIPTION  "Registration of new IANAifType 300."
+
+       REVISION     "202004020000Z"  -- April 2, 2020
+       DESCRIPTION  "Added reference to ifType definitions registry."
+
+       REVISION     "202001100000Z"  -- January 10, 2020
+       DESCRIPTION  "Addition of IANAifType 299."
+
+       REVISION     "201912030000Z"  -- December 3, 2019
+       DESCRIPTION  "Updated email address for IANA"
+
+       REVISION     "201910160000Z"  -- October 16, 2019
+       DESCRIPTION  "Addition of IANAifTypes 297-298."
+
+       REVISION     "201902140000Z"  -- February 14, 2019
+       DESCRIPTION  "Registration of new tunnelType 18."
+
+       REVISION     "201902080000Z"  -- February 8, 2019
+       DESCRIPTION  "Added missing commas for 295-296."
+
+       REVISION     "201901310000Z"  -- January 31, 2019
+       DESCRIPTION  "Registration of new IANAifTypes 295-296."
+
+       REVISION     "201807040000Z"  -- July 4, 2018
+       DESCRIPTION  "Added missing commas for 291-293."
+
+       REVISION     "201806280000Z"  -- June 28, 2018
+       DESCRIPTION  "Registration of new IANAifTypes 293-294."
+
+       REVISION     "201806220000Z"  -- June 22, 2018
+       DESCRIPTION  "Registration of new IANAifType 292."
+
+       REVISION     "201806210000Z"  -- June 21, 2018
+       DESCRIPTION  "Registration of new IANAifType 291."
+
+       REVISION     "201703300000Z"  -- March 30, 2017
+       DESCRIPTION  "Registration of new IANAifType 290."
+
+       REVISION     "201701190000Z"  -- January 19, 2017
+       DESCRIPTION  "Registration of new IANAifType 289."
+
+       REVISION     "201611230000Z"  -- November 23, 2016
+       DESCRIPTION  "Registration of new IANAifTypes 283-288."
+
+       REVISION     "201606160000Z"  -- June 16, 2016
+       DESCRIPTION  "Updated IANAtunnelType DESCRIPTION per RFC 7870"
+
+       REVISION     "201606090000Z"  -- June 9, 2016
+       DESCRIPTION  "Registration of new IANAifType 282."
+
+       REVISION     "201606080000Z"  -- June 8, 2016
+       DESCRIPTION  "Updated description for tunnelType 17."
+
+       REVISION     "201605190000Z"  -- May 19, 2016
+       DESCRIPTION  "Updated description for tunnelType 16."
+
+       REVISION     "201605030000Z"  -- May 3, 2016
+       DESCRIPTION  "Registration of new IANAifType 281."
+
+       REVISION     "201604290000Z"  -- April 29, 2016
+       DESCRIPTION  "Registration of new tunnelTypes 16 and 17."
+
+       REVISION     "201409240000Z"  -- September 24, 2014
+       DESCRIPTION  "Registration of new IANAifType 280."
+
+       REVISION     "201409190000Z"  -- September 19, 2014
+       DESCRIPTION  "Registration of new IANAifType 279."
+
+       REVISION     "201407030000Z"  -- July 3, 2014
+       DESCRIPTION  "Registration of new IANAifTypes 277-278."
+
+       REVISION     "201405220000Z" -- May 22, 2014
+       DESCRIPTION  "Updated contact info."
+
+       REVISION     "201205170000Z"  -- May 17, 2012
+       DESCRIPTION  "Registration of new IANAifType 272."
+
+       REVISION     "201201110000Z"  -- January 11, 2012
+       DESCRIPTION  "Registration of new IANAifTypes 266-271."
+
+       REVISION     "201112180000Z"  -- December 18, 2011
+       DESCRIPTION  "Registration of new IANAifTypes 263-265."
+
+       REVISION     "201110260000Z"  -- October 26, 2011
+       DESCRIPTION  "Registration of new IANAifType 262."
+
+       REVISION     "201109070000Z"  -- September 7, 2011
+       DESCRIPTION  "Registration of new IANAifTypes 260 and 261."
+
+       REVISION     "201107220000Z"  -- July 22, 2011
+       DESCRIPTION  "Registration of new IANAifType 259."
+
+       REVISION     "201106030000Z"  -- June 03, 2011
+       DESCRIPTION  "Registration of new IANAifType 258."
+
+       REVISION     "201009210000Z"  -- September 21, 2010
+       DESCRIPTION  "Registration of new IANAifTypes 256 and 257."
+
+       REVISION     "201007210000Z"  -- July 21, 2010
+       DESCRIPTION  "Registration of new IANAifType 255."
+
+       REVISION     "201002110000Z"  -- February 11, 2010
+       DESCRIPTION  "Registration of new IANAifType 254."
+
+       REVISION     "201002080000Z"  -- February 08, 2010
+       DESCRIPTION  "Registration of new IANAifTypes 252 and 253."
+
+       REVISION     "200905060000Z"  -- May 06, 2009
+       DESCRIPTION  "Registration of new IANAifType 251."
+
+       REVISION     "200902060000Z"  -- February 06, 2009
+       DESCRIPTION  "Registration of new IANAtunnelType 15."
+
+       REVISION     "200810090000Z"  -- October 09, 2008
+       DESCRIPTION  "Registration of new IANAifType 250."
+
+       REVISION     "200808120000Z"  -- August 12, 2008
+       DESCRIPTION  "Registration of new IANAifType 249."
+
+       REVISION     "200807220000Z"  -- July 22, 2008
+       DESCRIPTION  "Registration of new IANAifTypes 247 and 248."
+
+       REVISION     "200806240000Z"  -- June 24, 2008
+       DESCRIPTION  "Registration of new IANAifType 246."
+
+       REVISION     "200805290000Z"  -- May 29, 2008
+       DESCRIPTION  "Registration of new IANAifType 245."
+
+       REVISION     "200709130000Z"  -- September 13, 2007
+       DESCRIPTION  "Registration of new IANAifTypes 243 and 244."
+
+       REVISION     "200705290000Z"  -- May 29, 2007
+       DESCRIPTION  "Changed the description for IANAifType 228."
+
+       REVISION     "200703080000Z"  -- March 08, 2007
+       DESCRIPTION  "Registration of new IANAifType 242."
+
+       REVISION     "200701230000Z"  -- January 23, 2007
+       DESCRIPTION  "Registration of new IANAifTypes 239, 240, and 241."
+
+       REVISION     "200610170000Z"  -- October 17, 2006
+       DESCRIPTION  "Deprecated/Obsoleted IANAifType 230.  Registration of
+                     IANAifType 238."
+
+       REVISION     "200609250000Z"  -- September 25, 2006
+       DESCRIPTION  "Changed the description for IANA ifType
+                     184 and added new IANA ifType 237."
+
+       REVISION     "200608170000Z"  -- August 17, 2006
+       DESCRIPTION  "Changed the descriptions for IANAifTypes
+                     20 and 21."
+
+       REVISION     "200608110000Z"  -- August 11, 2006
+       DESCRIPTION  "Changed the descriptions for IANAifTypes
+                     7, 11, 62, 69, and 117."
+
+       REVISION     "200607250000Z"  -- July 25, 2006
+       DESCRIPTION  "Registration of new IANA ifType 236."
+
+       REVISION     "200606140000Z"  -- June 14, 2006
+       DESCRIPTION  "Registration of new IANA ifType 235."
+
+       REVISION     "200603310000Z"  -- March 31, 2006
+       DESCRIPTION  "Registration of new IANA ifType 234."
+
+       REVISION     "200603300000Z"  -- March 30, 2006
+       DESCRIPTION  "Registration of new IANA ifType 233."
+
+       REVISION     "200512220000Z"  -- December 22, 2005
+       DESCRIPTION  "Registration of new IANA ifTypes 231 and 232."
+
+       REVISION     "200510100000Z"  -- October 10, 2005
+       DESCRIPTION  "Registration of new IANA ifType 230."
+
+       REVISION     "200509090000Z"  -- September 09, 2005
+       DESCRIPTION  "Registration of new IANA ifType 229."
+
+       REVISION     "200505270000Z"  -- May 27, 2005
+       DESCRIPTION  "Registration of new IANA ifType 228."
+
+       REVISION     "200503030000Z"  -- March 3, 2005
+       DESCRIPTION  "Added the IANAtunnelType TC and deprecated
+	                 IANAifType sixToFour (215) per RFC4087."
+
+       REVISION     "200411220000Z"  -- November 22, 2004
+       DESCRIPTION  "Registration of new IANA ifType 227 per RFC4631."
+
+       REVISION     "200406170000Z"  -- June 17, 2004
+       DESCRIPTION  "Registration of new IANA ifType 226."
+
+       REVISION     "200405120000Z"  -- May 12, 2004
+       DESCRIPTION  "Added description for IANAifType 6, and
+	                 changed the descriptions for IANAifTypes
+                     180, 181, and 182."
+
+       REVISION     "200405070000Z"  -- May 7, 2004
+       DESCRIPTION  "Registration of new IANAifType 225."
+
+       REVISION     "200308250000Z"  -- Aug 25, 2003
+       DESCRIPTION  "Deprecated IANAifTypes 7 and 11. Obsoleted
+                     IANAifTypes 62, 69, and 117.  ethernetCsmacd (6)
+                     should be used instead of these values"
+
+       REVISION     "200308180000Z"  -- Aug 18, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     224."
+
+       REVISION     "200308070000Z"  -- Aug 7, 2003
+       DESCRIPTION  "Registration of new IANAifTypes
+                     222 and 223."
+
+       REVISION     "200303180000Z"  -- Mar 18, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     221."
+
+       REVISION     "200301130000Z"  -- Jan 13, 2003
+       DESCRIPTION  "Registration of new IANAifType
+                     220."
+
+       REVISION     "200210170000Z"  -- Oct 17, 2002
+       DESCRIPTION  "Registration of new IANAifType
+                     219."
+
+       REVISION     "200207160000Z"  -- Jul 16, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     217 and 218."
+
+       REVISION     "200207100000Z"  -- Jul 10, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     215 and 216."
+
+       REVISION     "200206190000Z"  -- Jun 19, 2002
+       DESCRIPTION  "Registration of new IANAifType
+                     214."
+
+       REVISION     "200201040000Z"  -- Jan 4, 2002
+       DESCRIPTION  "Registration of new IANAifTypes
+                     211, 212 and 213."
+
+       REVISION     "200112200000Z"  -- Dec 20, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     209 and 210."
+
+       REVISION     "200111150000Z"  -- Nov 15, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     207 and 208."
+
+       REVISION     "200111060000Z"  -- Nov 6, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     206."
+
+       REVISION     "200111020000Z"  -- Nov 2, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     205."
+
+       REVISION     "200110160000Z"  -- Oct 16, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     199, 200, 201, 202, 203, and 204."
+
+       REVISION     "200109190000Z"  -- Sept 19, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     198."
+
+       REVISION     "200105110000Z"  -- May 11, 2001
+       DESCRIPTION  "Registration of new IANAifType
+                     197."
+
+       REVISION     "200101120000Z"  -- Jan 12, 2001
+       DESCRIPTION  "Registration of new IANAifTypes
+                     195 and 196."
+
+       REVISION     "200012190000Z"  -- Dec 19, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     193 and 194."
+
+       REVISION     "200012070000Z"  -- Dec 07, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     191 and 192."
+
+       REVISION     "200012040000Z"  -- Dec 04, 2000
+       DESCRIPTION  "Registration of new IANAifType
+                     190."
+
+       REVISION     "200010170000Z"  -- Oct 17, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     188 and 189."
+
+       REVISION     "200010020000Z"  -- Oct 02, 2000
+       DESCRIPTION  "Registration of new IANAifType 187."
+
+       REVISION     "200009010000Z"  -- Sept 01, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     184, 185, and 186."
+
+       REVISION     "200008240000Z"  -- Aug 24, 2000
+       DESCRIPTION  "Registration of new IANAifType 183."
+
+       REVISION     "200008230000Z"  -- Aug 23, 2000
+       DESCRIPTION  "Registration of new IANAifTypes
+                     174-182."
+
+       REVISION     "200008220000Z"  -- Aug 22, 2000
+       DESCRIPTION  "Registration of new IANAifTypes 170,
+                     171, 172 and 173."
+
+       REVISION     "200004250000Z"  -- Apr 25, 2000
+       DESCRIPTION  "Registration of new IANAifTypes 168 and 169."
+
+       REVISION     "200003060000Z"  -- Mar 6, 2000
+       DESCRIPTION  "Fixed a missing semi-colon in the IMPORT.
+                     Also cleaned up the REVISION log a bit.
+                     It is not complete, but from now on it will
+                     be maintained and kept up to date with each
+                     change to this MIB module."
+
+       REVISION     "199910081430Z"  -- Oct 08, 1999
+       DESCRIPTION  "Include new name assignments up to cnr(85).
+                     This is the first version available via the WWW
+                     at: ftp://ftp.isi.edu/mib/ianaiftype.mib"
+
+       REVISION     "199401310000Z"  -- Jan 31, 1994
+       DESCRIPTION  "Initial version of this MIB as published in
+                     RFC 1573."
+       ::= { mib-2 30 }
+
+   IANAifType ::= TEXTUAL-CONVENTION
+       STATUS       current
+       DESCRIPTION
+               "This data type is used as the syntax of the ifType
+               object in the (updated) definition of MIB-II's
+               ifTable.
+
+               The definition of this textual convention with the
+               addition of newly assigned values is published
+               periodically by the IANA, in either the Assigned
+               Numbers RFC, or some derivative of it specific to
+               Internet Network Management number assignments.  (The
+               latest arrangements can be obtained by contacting the
+               IANA.)
+
+               Interface types must not be directly added to the
+               IANAifType-MIB MIB module.  They must instead be added
+               to the 'Interface Types (ifType)' registry at
+               https://www.iana.org/assignments/smi-numbers.
+
+               The relationship between the assignment of ifType
+               values and of OIDs to particular media-specific MIBs
+               is solely the purview of IANA and is subject to change
+               without notice.  Quite often, a media-specific MIB's
+               OID-subtree assignment within MIB-II's 'transmission'
+               subtree will be the same as its ifType value.
+               However, in some circumstances this will not be the
+               case, and implementors must not pre-assume any
+               specific relationship between ifType values and
+               transmission subtree OIDs."
+       SYNTAX  INTEGER {
+                   other(1),          -- none of the following
+                   regular1822(2),
+                   hdh1822(3),
+                   ddnX25(4),
+                   rfc877x25(5),
+                   ethernetCsmacd(6), -- for all ethernet-like interfaces,
+                                      -- regardless of speed, as per RFC3635
+                   iso88023Csmacd(7), -- Deprecated via RFC3635
+                                      -- ethernetCsmacd (6) should be used instead
+                   iso88024TokenBus(8),
+                   iso88025TokenRing(9),
+                   iso88026Man(10),
+                   starLan(11), -- Deprecated via RFC3635
+                                -- ethernetCsmacd (6) should be used instead
+                   proteon10Mbit(12),
+                   proteon80Mbit(13),
+                   hyperchannel(14),
+                   fddi(15),
+                   lapb(16),
+                   sdlc(17),
+                   ds1(18),            -- DS1-MIB
+                   e1(19),             -- Obsolete see DS1-MIB
+                   basicISDN(20),              -- no longer used
+                                               -- see also RFC2127
+                   primaryISDN(21),            -- no longer used
+                                               -- see also RFC2127
+                   propPointToPointSerial(22), -- proprietary serial
+                   ppp(23),
+                   softwareLoopback(24),
+                   eon(25),            -- CLNP over IP
+                   ethernet3Mbit(26),
+                   nsip(27),           -- XNS over IP
+                   slip(28),           -- generic SLIP
+                   ultra(29),          -- ULTRA technologies
+                   ds3(30),            -- DS3-MIB
+                   sip(31),            -- SMDS, coffee
+                   frameRelay(32),     -- DTE only.
+                   rs232(33),
+                   para(34),           -- parallel-port
+                   arcnet(35),         -- arcnet
+                   arcnetPlus(36),     -- arcnet plus
+                   atm(37),            -- ATM cells
+                   miox25(38),
+                   sonet(39),          -- SONET or SDH
+                   x25ple(40),
+                   iso88022llc(41),
+                   localTalk(42),
+                   smdsDxi(43),
+                   frameRelayService(44),  -- FRNETSERV-MIB
+                   v35(45),
+                   hssi(46),
+                   hippi(47),
+                   modem(48),          -- Generic modem
+                   aal5(49),           -- AAL5 over ATM
+                   sonetPath(50),
+                   sonetVT(51),
+                   smdsIcip(52),       -- SMDS InterCarrier Interface
+                   propVirtual(53),    -- proprietary virtual/internal
+                   propMultiplexor(54),-- proprietary multiplexing
+                   ieee80212(55),      -- 100BaseVG
+                   fibreChannel(56),   -- Fibre Channel
+                   hippiInterface(57), -- HIPPI interfaces
+                   frameRelayInterconnect(58), -- Obsolete, use either
+                                       -- frameRelay(32) or
+                                       -- frameRelayService(44).
+                   aflane8023(59),     -- ATM Emulated LAN for 802.3
+                   aflane8025(60),     -- ATM Emulated LAN for 802.5
+                   cctEmul(61),        -- ATM Emulated circuit
+                   fastEther(62),      -- Obsoleted via RFC3635
+                                       -- ethernetCsmacd (6) should be used instead
+                   isdn(63),           -- ISDN and X.25
+                   v11(64),            -- CCITT V.11/X.21
+                   v36(65),            -- CCITT V.36
+                   g703at64k(66),      -- CCITT G703 at 64Kbps
+                   g703at2mb(67),      -- Obsolete see DS1-MIB
+                   qllc(68),           -- SNA QLLC
+                   fastEtherFX(69),    -- Obsoleted via RFC3635
+                                       -- ethernetCsmacd (6) should be used instead
+                   channel(70),        -- channel
+                   ieee80211(71),      -- radio spread spectrum
+                   ibm370parChan(72),  -- IBM System 360/370 OEMI Channel
+                   escon(73),          -- IBM Enterprise Systems Connection
+                   dlsw(74),           -- Data Link Switching
+                   isdns(75),          -- ISDN S/T interface
+                   isdnu(76),          -- ISDN U interface
+                   lapd(77),           -- Link Access Protocol D
+                   ipSwitch(78),       -- IP Switching Objects
+                   rsrb(79),           -- Remote Source Route Bridging
+                   atmLogical(80),     -- ATM Logical Port
+                   ds0(81),            -- Digital Signal Level 0
+                   ds0Bundle(82),      -- group of ds0s on the same ds1
+                   bsc(83),            -- Bisynchronous Protocol
+                   async(84),          -- Asynchronous Protocol
+                   cnr(85),            -- Combat Net Radio
+                   iso88025Dtr(86),    -- ISO 802.5r DTR
+                   eplrs(87),          -- Ext Pos Loc Report Sys
+                   arap(88),           -- Appletalk Remote Access Protocol
+                   propCnls(89),       -- Proprietary Connectionless Protocol
+                   hostPad(90),        -- CCITT-ITU X.29 PAD Protocol
+                   termPad(91),        -- CCITT-ITU X.3 PAD Facility
+                   frameRelayMPI(92),  -- Multiproto Interconnect over FR
+                   x213(93),           -- CCITT-ITU X213
+                   adsl(94),           -- Asymmetric Digital Subscriber Loop
+                   radsl(95),          -- Rate-Adapt. Digital Subscriber Loop
+                   sdsl(96),           -- Symmetric Digital Subscriber Loop
+                   vdsl(97),           -- Very H-Speed Digital Subscrib. Loop
+                   iso88025CRFPInt(98), -- ISO 802.5 CRFP
+                   myrinet(99),        -- Myricom Myrinet
+                   voiceEM(100),       -- voice recEive and transMit
+                   voiceFXO(101),      -- voice Foreign Exchange Office
+                   voiceFXS(102),      -- voice Foreign Exchange Station
+                   voiceEncap(103),    -- voice encapsulation
+                   voiceOverIp(104),   -- voice over IP encapsulation
+                   atmDxi(105),        -- ATM DXI
+                   atmFuni(106),       -- ATM FUNI
+                   atmIma (107),       -- ATM IMA
+                   pppMultilinkBundle(108), -- PPP Multilink Bundle
+                   ipOverCdlc (109),   -- IBM ipOverCdlc
+                   ipOverClaw (110),   -- IBM Common Link Access to Workstn
+                   stackToStack (111), -- IBM stackToStack
+                   virtualIpAddress (112), -- IBM VIPA
+                   mpc (113),          -- IBM multi-protocol channel support
+                   ipOverAtm (114),    -- IBM ipOverAtm
+                   iso88025Fiber (115), -- ISO 802.5j Fiber Token Ring
+                   tdlc (116),	       -- IBM twinaxial data link control
+                   gigabitEthernet (117), -- Obsoleted via RFC3635
+                                          -- ethernetCsmacd (6) should be used instead
+                   hdlc (118),         -- HDLC
+                   lapf (119),	       -- LAP F
+                   v37 (120),	       -- V.37
+                   x25mlp (121),       -- Multi-Link Protocol
+                   x25huntGroup (122), -- X25 Hunt Group
+                   transpHdlc (123),   -- Transp HDLC
+                   interleave (124),   -- Interleave channel
+                   fast (125),         -- Fast channel
+                   ip (126),	       -- IP (for APPN HPR in IP networks)
+                   docsCableMaclayer (127),  -- CATV Mac Layer
+                   docsCableDownstream (128), -- CATV Downstream interface
+                   docsCableUpstream (129),  -- CATV Upstream interface
+                   a12MppSwitch (130), -- Avalon Parallel Processor
+                   tunnel (131),       -- Encapsulation interface
+                   coffee (132),       -- coffee pot
+                   ces (133),          -- Circuit Emulation Service
+                   atmSubInterface (134), -- ATM Sub Interface
+                   l2vlan (135),       -- Layer 2 Virtual LAN using 802.1Q
+                   l3ipvlan (136),     -- Layer 3 Virtual LAN using IP
+                   l3ipxvlan (137),    -- Layer 3 Virtual LAN using IPX
+                   digitalPowerline (138), -- IP over Power Lines
+                   mediaMailOverIp (139), -- Multimedia Mail over IP
+                   dtm (140),        -- Dynamic syncronous Transfer Mode
+                   dcn (141),    -- Data Communications Network
+                   ipForward (142),    -- IP Forwarding Interface
+                   msdsl (143),       -- Multi-rate Symmetric DSL
+                   ieee1394 (144), -- IEEE1394 High Performance Serial Bus
+                   if-gsn (145),       --   HIPPI-6400
+                   dvbRccMacLayer (146), -- DVB-RCC MAC Layer
+                   dvbRccDownstream (147),  -- DVB-RCC Downstream Channel
+                   dvbRccUpstream (148),  -- DVB-RCC Upstream Channel
+                   atmVirtual (149),   -- ATM Virtual Interface
+                   mplsTunnel (150),   -- MPLS Tunnel Virtual Interface
+                   srp (151),	-- Spatial Reuse Protocol
+                   voiceOverAtm (152),  -- Voice Over ATM
+                   voiceOverFrameRelay (153),   -- Voice Over Frame Relay
+                   idsl (154),		-- Digital Subscriber Loop over ISDN
+                   compositeLink (155),  -- Avici Composite Link Interface
+                   ss7SigLink (156),     -- SS7 Signaling Link
+                   propWirelessP2P (157),  --  Prop. P2P wireless interface
+                   frForward (158),    -- Frame Forward Interface
+                   rfc1483 (159),	-- Multiprotocol over ATM AAL5
+                   usb (160),		-- USB Interface
+                   ieee8023adLag (161),  -- IEEE 802.3ad Link Aggregate
+                   bgppolicyaccounting (162), -- BGP Policy Accounting
+                   frf16MfrBundle (163), -- FRF .16 Multilink Frame Relay
+                   h323Gatekeeper (164), -- H323 Gatekeeper
+                   h323Proxy (165), -- H323 Voice and Video Proxy
+                   mpls (166), -- MPLS
+                   mfSigLink (167), -- Multi-frequency signaling link
+                   hdsl2 (168), -- High Bit-Rate DSL - 2nd generation
+                   shdsl (169), -- Multirate HDSL2
+                   ds1FDL (170), -- Facility Data Link 4Kbps on a DS1
+                   pos (171), -- Packet over SONET/SDH Interface
+                   dvbAsiIn (172), -- DVB-ASI Input
+                   dvbAsiOut (173), -- DVB-ASI Output
+                   plc (174), -- Power Line Communtications
+                   nfas (175), -- Non Facility Associated Signaling
+                   tr008 (176), -- TR008
+                   gr303RDT (177), -- Remote Digital Terminal
+                   gr303IDT (178), -- Integrated Digital Terminal
+                   isup (179), -- ISUP
+                   propDocsWirelessMaclayer (180), -- Cisco proprietary Maclayer
+                   propDocsWirelessDownstream (181), -- Cisco proprietary Downstream
+                   propDocsWirelessUpstream (182), -- Cisco proprietary Upstream
+                   hiperlan2 (183), -- HIPERLAN Type 2 Radio Interface
+                   propBWAp2Mp (184), -- PropBroadbandWirelessAccesspt2multipt
+                             -- use of this iftype for IEEE 802.16 WMAN
+                             -- interfaces as per IEEE Std 802.16f is
+                             -- deprecated and ifType 237 should be used instead.
+                   sonetOverheadChannel (185), -- SONET Overhead Channel
+                   digitalWrapperOverheadChannel (186), -- Digital Wrapper
+                   aal2 (187), -- ATM adaptation layer 2
+                   radioMAC (188), -- MAC layer over radio links
+                   atmRadio (189), -- ATM over radio links
+                   imt (190), -- Inter Machine Trunks
+                   mvl (191), -- Multiple Virtual Lines DSL
+                   reachDSL (192), -- Long Reach DSL
+                   frDlciEndPt (193), -- Frame Relay DLCI End Point
+                   atmVciEndPt (194), -- ATM VCI End Point
+                   opticalChannel (195), -- Optical Channel
+                   opticalTransport (196), -- Optical Transport
+                   propAtm (197), --  Proprietary ATM
+                   voiceOverCable (198), -- Voice Over Cable Interface
+                   infiniband (199), -- Infiniband
+                   teLink (200), -- TE Link
+                   q2931 (201), -- Q.2931
+                   virtualTg (202), -- Virtual Trunk Group
+                   sipTg (203), -- SIP Trunk Group
+                   sipSig (204), -- SIP Signaling
+                   docsCableUpstreamChannel (205), -- CATV Upstream Channel
+                   econet (206), -- Acorn Econet
+                   pon155 (207), -- FSAN 155Mb Symetrical PON interface
+                   pon622 (208), -- FSAN622Mb Symetrical PON interface
+                   bridge (209), -- Transparent bridge interface
+                   linegroup (210), -- Interface common to multiple lines
+                   voiceEMFGD (211), -- voice E&M Feature Group D
+                   voiceFGDEANA (212), -- voice FGD Exchange Access North American
+                   voiceDID (213), -- voice Direct Inward Dialing
+                   mpegTransport (214), -- MPEG transport interface
+                   sixToFour (215), -- 6to4 interface (DEPRECATED)
+                   gtp (216), -- GTP (GPRS Tunneling Protocol)
+                   pdnEtherLoop1 (217), -- Paradyne EtherLoop 1
+                   pdnEtherLoop2 (218), -- Paradyne EtherLoop 2
+                   opticalChannelGroup (219), -- Optical Channel Group
+                   homepna (220), -- HomePNA ITU-T G.989
+                   gfp (221), -- Generic Framing Procedure (GFP)
+                   ciscoISLvlan (222), -- Layer 2 Virtual LAN using Cisco ISL
+                   actelisMetaLOOP (223), -- Acteleis proprietary MetaLOOP High Speed Link
+                   fcipLink (224), -- FCIP Link
+                   rpr (225), -- Resilient Packet Ring Interface Type
+                   qam (226), -- RF Qam Interface
+                   lmp (227), -- Link Management Protocol
+                   cblVectaStar (228), -- Cambridge Broadband Networks Limited VectaStar
+                   docsCableMCmtsDownstream (229), -- CATV Modular CMTS Downstream Interface
+                   adsl2 (230), -- Asymmetric Digital Subscriber Loop Version 2
+                                -- (DEPRECATED/OBSOLETED - please use adsl2plus 238 instead)
+                   macSecControlledIF (231), -- MACSecControlled
+                   macSecUncontrolledIF (232), -- MACSecUncontrolled
+                   aviciOpticalEther (233), -- Avici Optical Ethernet Aggregate
+                   atmbond (234), -- atmbond
+                   voiceFGDOS (235), -- voice FGD Operator Services
+                   mocaVersion1 (236), -- MultiMedia over Coax Alliance (MoCA) Interface
+                             -- as documented in information provided privately to IANA
+                   ieee80216WMAN (237), -- IEEE 802.16 WMAN interface
+                   adsl2plus (238), -- Asymmetric Digital Subscriber Loop Version 2,
+                                   -- Version 2 Plus and all variants
+                   dvbRcsMacLayer (239), -- DVB-RCS MAC Layer
+                   dvbTdm (240), -- DVB Satellite TDM
+                   dvbRcsTdma (241), -- DVB-RCS TDMA
+                   x86Laps (242), -- LAPS based on ITU-T X.86/Y.1323
+                   wwanPP (243), -- 3GPP WWAN
+                   wwanPP2 (244), -- 3GPP2 WWAN
+                   voiceEBS (245), -- voice P-phone EBS physical interface
+                   ifPwType (246), -- Pseudowire interface type
+                   ilan (247), -- Internal LAN on a bridge per IEEE 802.1ap
+                   pip (248), -- Provider Instance Port on a bridge per IEEE 802.1ah PBB
+                   aluELP (249), -- Alcatel-Lucent Ethernet Link Protection
+                   gpon (250), -- Gigabit-capable passive optical networks (G-PON) as per ITU-T G.948
+                   vdsl2 (251), -- Very high speed digital subscriber line Version 2 (as per ITU-T Recommendation G.993.2)
+                   capwapDot11Profile (252), -- WLAN Profile Interface
+                   capwapDot11Bss (253), -- WLAN BSS Interface
+                   capwapWtpVirtualRadio (254), -- WTP Virtual Radio Interface
+                   bits (255), -- bitsport
+                   docsCableUpstreamRfPort (256), -- DOCSIS CATV Upstream RF Port
+                   cableDownstreamRfPort (257), -- CATV downstream RF port
+                   vmwareVirtualNic (258), -- VMware Virtual Network Interface
+                   ieee802154 (259), -- IEEE 802.15.4 WPAN interface
+                   otnOdu (260), -- OTN Optical Data Unit
+                   otnOtu (261), -- OTN Optical channel Transport Unit
+                   ifVfiType (262), -- VPLS Forwarding Instance Interface Type
+                   g9981 (263), -- G.998.1 bonded interface
+                   g9982 (264), -- G.998.2 bonded interface
+                   g9983 (265), -- G.998.3 bonded interface
+                   aluEpon (266), -- Ethernet Passive Optical Networks (E-PON)
+                   aluEponOnu (267), -- EPON Optical Network Unit
+                   aluEponPhysicalUni (268), -- EPON physical User to Network interface
+                   aluEponLogicalLink (269), -- The emulation of a point-to-point link over the EPON layer
+                   aluGponOnu (270), -- GPON Optical Network Unit
+                   aluGponPhysicalUni (271), -- GPON physical User to Network interface
+                   vmwareNicTeam (272), -- VMware NIC Team
+                   docsOfdmDownstream (277), -- CATV Downstream OFDM interface
+                   docsOfdmaUpstream (278), -- CATV Upstream OFDMA interface
+                   gfast (279), -- G.fast port
+                   sdci (280), -- SDCI (IO-Link)
+                   xboxWireless (281), -- Xbox wireless
+                   fastdsl (282), -- FastDSL
+                   docsCableScte55d1FwdOob (283), -- Cable SCTE 55-1 OOB Forward Channel
+                   docsCableScte55d1RetOob (284), -- Cable SCTE 55-1 OOB Return Channel
+                   docsCableScte55d2DsOob (285), -- Cable SCTE 55-2 OOB Downstream Channel
+                   docsCableScte55d2UsOob (286), -- Cable SCTE 55-2 OOB Upstream Channel
+                   docsCableNdf (287), -- Cable Narrowband Digital Forward
+                   docsCableNdr (288), -- Cable Narrowband Digital Return
+                   ptm (289), -- Packet Transfer Mode
+                   ghn (290), -- G.hn port
+                   otnOtsi (291), -- Optical Tributary Signal
+                   otnOtuc (292), -- OTN OTUCn
+                   otnOduc (293), -- OTN ODUC
+                   otnOtsig (294), -- OTN OTUC Signal
+                   microwaveCarrierTermination (295), -- air interface of a single microwave carrier
+                   microwaveRadioLinkTerminal (296), -- radio link interface for one or several aggregated microwave carriers
+                   ieee8021axDrni (297), -- IEEE 802.1AX Distributed Resilient Network Interface
+                   ax25 (298), -- AX.25 network interfaces
+                   ieee19061nanocom (299), -- Nanoscale and Molecular Communication
+                   cpri (300), -- Common Public Radio Interface
+                   omni (301), -- Overlay Multilink Network Interface (OMNI)
+                   roe (302), -- Radio over Ethernet Interface
+                   p2pOverLan (303) -- Point to Point over LAN interface
+                   }
+
+IANAtunnelType ::= TEXTUAL-CONVENTION
+    STATUS     current
+    DESCRIPTION
+            "The encapsulation method used by a tunnel. The value
+            direct indicates that a packet is encapsulated
+            directly within a normal IP header, with no
+            intermediate header, and unicast to the remote tunnel
+            endpoint (e.g., an RFC 2003 IP-in-IP tunnel, or an RFC
+            1933 IPv6-in-IPv4 tunnel). The value minimal indicates
+            that a Minimal Forwarding Header (RFC 2004) is
+            inserted between the outer header and the payload
+            packet. The value UDP indicates that the payload
+            packet is encapsulated within a normal UDP packet
+            (e.g., RFC 1234).
+
+            The values sixToFour, sixOverFour, and isatap
+            indicates that an IPv6 packet is encapsulated directly
+            within an IPv4 header, with no intermediate header,
+            and unicast to the destination determined by the 6to4,
+            6over4, or ISATAP protocol.
+
+            The remaining protocol-specific values indicate that a
+            header of the protocol of that name is inserted
+            between the outer header and the payload header.
+
+            The IP Tunnel MIB [RFC4087] is designed to manage
+            tunnels of any type over IPv4 and IPv6 networks;
+            therefore, it already supports IP-in-IP tunnels.
+            But in a DS-Lite scenario, the tunnel type is
+            point-to-multipoint IP-in-IP tunnels.  The direct(2)
+            defined in the IP Tunnel MIB only supports point-to-point
+            tunnels.  So, it needs to define a new tunnel type for
+            DS-Lite.
+
+            The assignment policy for IANAtunnelType values is
+            identical to the policy for assigning IANAifType
+            values."
+    SYNTAX     INTEGER {
+                   other(1),           -- none of the following
+                   direct(2),          -- no intermediate header
+                   gre(3),             -- GRE encapsulation
+                   minimal(4),         -- Minimal encapsulation
+                   l2tp(5),            -- L2TP encapsulation
+                   pptp(6),            -- PPTP encapsulation
+                   l2f(7),             -- L2F encapsulation
+                   udp(8),             -- UDP encapsulation
+                   atmp(9),            -- ATMP encapsulation
+                   msdp(10),           -- MSDP encapsulation
+                   sixToFour(11),      -- 6to4 encapsulation
+                   sixOverFour(12),    -- 6over4 encapsulation
+                   isatap(13),         -- ISATAP encapsulation
+                   teredo(14),         -- Teredo encapsulation
+                   ipHttps(15),        -- IPHTTPS
+                   softwireMesh(16),   -- softwire mesh tunnel
+                   dsLite(17),         -- DS-Lite tunnel
+                   aplusp(18),         -- A+P encapsulation
+                   ipsectunnelmode(19) -- IpSec tunnel mode encapsulation
+               }
+
+   END

--- a/services/monitoring/assets/snmp/mibs/IF-MIB
+++ b/services/monitoring/assets/snmp/mibs/IF-MIB
@@ -1,0 +1,1814 @@
+IF-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter32, Gauge32, Counter64,
+    Integer32, TimeTicks, mib-2,
+    NOTIFICATION-TYPE                        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DisplayString,
+    PhysAddress, TruthValue, RowStatus,
+    TimeStamp, AutonomousType, TestAndIncr   FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP,
+    NOTIFICATION-GROUP                       FROM SNMPv2-CONF
+    snmpTraps                                FROM SNMPv2-MIB
+    IANAifType                               FROM IANAifType-MIB;
+
+ifMIB MODULE-IDENTITY
+    LAST-UPDATED "200006140000Z"
+    ORGANIZATION "IETF Interfaces MIB Working Group"
+    CONTACT-INFO
+            "   Keith McCloghrie
+                Cisco Systems, Inc.
+                170 West Tasman Drive
+                San Jose, CA  95134-1706
+                US
+
+                408-526-5260
+                kzm@cisco.com"
+    DESCRIPTION
+            "The MIB module to describe generic objects for network
+            interface sub-layers.  This MIB is an updated version of
+            MIB-II's ifTable, and incorporates the extensions defined in
+            RFC 1229."
+
+    REVISION      "200006140000Z"
+    DESCRIPTION
+            "Clarifications agreed upon by the Interfaces MIB WG, and
+            published as RFC 2863."
+    REVISION      "199602282155Z"
+    DESCRIPTION
+            "Revisions made by the Interfaces MIB WG, and published in
+            RFC 2233."
+    REVISION      "199311082155Z"
+    DESCRIPTION
+            "Initial revision, published as part of RFC 1573."
+    ::= { mib-2 31 }
+
+ifMIBObjects OBJECT IDENTIFIER ::= { ifMIB 1 }
+
+interfaces   OBJECT IDENTIFIER ::= { mib-2 2 }
+
+--
+-- Textual Conventions
+--
+
+-- OwnerString has the same semantics as used in RFC 1271
+
+OwnerString ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "255a"
+    STATUS       deprecated
+    DESCRIPTION
+            "This data type is used to model an administratively
+            assigned name of the owner of a resource.  This information
+            is taken from the NVT ASCII character set.  It is suggested
+            that this name contain one or more of the following: ASCII
+            form of the manager station's transport address, management
+            station name (e.g., domain name), network management
+            personnel's name, location, or phone number.  In some cases
+            the agent itself will be the owner of an entry.  In these
+            cases, this string shall be set to a string starting with
+            'agent'."
+    SYNTAX       OCTET STRING (SIZE(0..255))
+
+-- InterfaceIndex contains the semantics of ifIndex and should be used
+-- for any objects defined in other MIB modules that need these semantics.
+
+InterfaceIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+            "A unique value, greater than zero, for each interface or
+            interface sub-layer in the managed system.  It is
+            recommended that values are assigned contiguously starting
+            from 1.  The value for each interface sub-layer must remain
+            constant at least from one re-initialization of the entity's
+            network management system to the next re-initialization."
+    SYNTAX       Integer32 (1..2147483647)
+
+InterfaceIndexOrZero ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION
+            "This textual convention is an extension of the
+            InterfaceIndex convention.  The latter defines a greater
+            than zero value used to identify an interface or interface
+            sub-layer in the managed system.  This extension permits the
+            additional value of zero.  the value zero is object-specific
+            and must therefore be defined as part of the description of
+            any object which uses this syntax.  Examples of the usage of
+            zero might include situations where interface was unknown,
+            or when none or all interfaces need to be referenced."
+    SYNTAX       Integer32 (0..2147483647)
+
+ifNumber  OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of network interfaces (regardless of their
+            current state) present on this system."
+    ::= { interfaces 1 }
+
+ifTableLastChange  OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of sysUpTime at the time of the last creation or
+            deletion of an entry in the ifTable.  If the number of
+            entries has been unchanged since the last re-initialization
+            of the local network management subsystem, then this object
+            contains a zero value."
+    ::= { ifMIBObjects 5 }
+
+-- the Interfaces table
+
+-- The Interfaces table contains information on the entity's
+
+-- interfaces.  Each sub-layer below the internetwork-layer
+-- of a network interface is considered to be an interface.
+
+ifTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IfEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A list of interface entries.  The number of entries is
+            given by the value of ifNumber."
+    ::= { interfaces 2 }
+
+ifEntry OBJECT-TYPE
+    SYNTAX      IfEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An entry containing management information applicable to a
+            particular interface."
+    INDEX   { ifIndex }
+    ::= { ifTable 1 }
+
+IfEntry ::=
+    SEQUENCE {
+        ifIndex                 InterfaceIndex,
+        ifDescr                 DisplayString,
+        ifType                  IANAifType,
+        ifMtu                   Integer32,
+        ifSpeed                 Gauge32,
+        ifPhysAddress           PhysAddress,
+        ifAdminStatus           INTEGER,
+        ifOperStatus            INTEGER,
+        ifLastChange            TimeTicks,
+        ifInOctets              Counter32,
+        ifInUcastPkts           Counter32,
+        ifInNUcastPkts          Counter32,  -- deprecated
+        ifInDiscards            Counter32,
+        ifInErrors              Counter32,
+        ifInUnknownProtos       Counter32,
+        ifOutOctets             Counter32,
+        ifOutUcastPkts          Counter32,
+        ifOutNUcastPkts         Counter32,  -- deprecated
+        ifOutDiscards           Counter32,
+        ifOutErrors             Counter32,
+        ifOutQLen               Gauge32,    -- deprecated
+        ifSpecific              OBJECT IDENTIFIER -- deprecated
+    }
+
+ifIndex OBJECT-TYPE
+    SYNTAX      InterfaceIndex
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A unique value, greater than zero, for each interface.  It
+            is recommended that values are assigned contiguously
+            starting from 1.  The value for each interface sub-layer
+            must remain constant at least from one re-initialization of
+            the entity's network management system to the next re-
+            initialization."
+    ::= { ifEntry 1 }
+
+ifDescr OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A textual string containing information about the
+            interface.  This string should include the name of the
+            manufacturer, the product name and the version of the
+            interface hardware/software."
+    ::= { ifEntry 2 }
+
+ifType OBJECT-TYPE
+    SYNTAX      IANAifType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The type of interface.  Additional values for ifType are
+            assigned by the Internet Assigned Numbers Authority (IANA),
+            through updating the syntax of the IANAifType textual
+            convention."
+    ::= { ifEntry 3 }
+
+ifMtu OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The size of the largest packet which can be sent/received
+            on the interface, specified in octets.  For interfaces that
+            are used for transmitting network datagrams, this is the
+            size of the largest network datagram that can be sent on the
+            interface."
+    ::= { ifEntry 4 }
+
+ifSpeed OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An estimate of the interface's current bandwidth in bits
+            per second.  For interfaces which do not vary in bandwidth
+            or for those where no accurate estimation can be made, this
+            object should contain the nominal bandwidth.  If the
+            bandwidth of the interface is greater than the maximum value
+            reportable by this object then this object should report its
+            maximum value (4,294,967,295) and ifHighSpeed must be used
+            to report the interace's speed.  For a sub-layer which has
+            no concept of bandwidth, this object should be zero."
+    ::= { ifEntry 5 }
+
+ifPhysAddress OBJECT-TYPE
+    SYNTAX      PhysAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The interface's address at its protocol sub-layer.  For
+            example, for an 802.x interface, this object normally
+            contains a MAC address.  The interface's media-specific MIB
+            must define the bit and byte ordering and the format of the
+            value of this object.  For interfaces which do not have such
+            an address (e.g., a serial line), this object should contain
+            an octet string of zero length."
+    ::= { ifEntry 6 }
+
+ifAdminStatus OBJECT-TYPE
+    SYNTAX  INTEGER {
+                up(1),       -- ready to pass packets
+                down(2),
+                testing(3)   -- in some test mode
+            }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "The desired state of the interface.  The testing(3) state
+            indicates that no operational packets can be passed.  When a
+            managed system initializes, all interfaces start with
+            ifAdminStatus in the down(2) state.  As a result of either
+            explicit management action or per configuration information
+            retained by the managed system, ifAdminStatus is then
+            changed to either the up(1) or testing(3) states (or remains
+            in the down(2) state)."
+    ::= { ifEntry 7 }
+
+ifOperStatus OBJECT-TYPE
+    SYNTAX  INTEGER {
+                up(1),        -- ready to pass packets
+                down(2),
+                testing(3),   -- in some test mode
+                unknown(4),   -- status can not be determined
+                              -- for some reason.
+                dormant(5),
+                notPresent(6),    -- some component is missing
+                lowerLayerDown(7) -- down due to state of
+                                  -- lower-layer interface(s)
+            }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The current operational state of the interface.  The
+            testing(3) state indicates that no operational packets can
+            be passed.  If ifAdminStatus is down(2) then ifOperStatus
+            should be down(2).  If ifAdminStatus is changed to up(1)
+            then ifOperStatus should change to up(1) if the interface is
+            ready to transmit and receive network traffic; it should
+            change to dormant(5) if the interface is waiting for
+            external actions (such as a serial line waiting for an
+            incoming connection); it should remain in the down(2) state
+            if and only if there is a fault that prevents it from going
+            to the up(1) state; it should remain in the notPresent(6)
+            state if the interface has missing (typically, hardware)
+            components."
+    ::= { ifEntry 8 }
+
+ifLastChange OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of sysUpTime at the time the interface entered
+            its current operational state.  If the current state was
+            entered prior to the last re-initialization of the local
+            network management subsystem, then this object contains a
+            zero value."
+    ::= { ifEntry 9 }
+
+ifInOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of octets received on the interface,
+            including framing characters.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 10 }
+
+ifInUcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were not addressed to a multicast
+            or broadcast address at this sub-layer.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 11 }
+
+ifInNUcastPkts OBJECT-TYPE
+    SYNTAX  Counter32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a multicast or
+            broadcast address at this sub-layer.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime.
+
+            This object is deprecated in favour of ifInMulticastPkts and
+            ifInBroadcastPkts."
+    ::= { ifEntry 12 }
+
+ifInDiscards OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of inbound packets which were chosen to be
+            discarded even though no errors had been detected to prevent
+
+            their being deliverable to a higher-layer protocol.  One
+            possible reason for discarding such a packet could be to
+            free up buffer space.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 13 }
+
+ifInErrors OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "For packet-oriented interfaces, the number of inbound
+            packets that contained errors preventing them from being
+            deliverable to a higher-layer protocol.  For character-
+            oriented or fixed-length interfaces, the number of inbound
+            transmission units that contained errors preventing them
+            from being deliverable to a higher-layer protocol.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 14 }
+
+ifInUnknownProtos OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "For packet-oriented interfaces, the number of packets
+            received via the interface which were discarded because of
+            an unknown or unsupported protocol.  For character-oriented
+            or fixed-length interfaces that support protocol
+            multiplexing the number of transmission units received via
+            the interface which were discarded because of an unknown or
+            unsupported protocol.  For any interface that does not
+            support protocol multiplexing, this counter will always be
+            0.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 15 }
+
+ifOutOctets OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of octets transmitted out of the
+            interface, including framing characters.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 16 }
+
+ifOutUcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were not addressed to a
+            multicast or broadcast address at this sub-layer, including
+            those that were discarded or not sent.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 17 }
+
+ifOutNUcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            multicast or broadcast address at this sub-layer, including
+            those that were discarded or not sent.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime.
+
+            This object is deprecated in favour of ifOutMulticastPkts
+            and ifOutBroadcastPkts."
+    ::= { ifEntry 18 }
+
+ifOutDiscards OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of outbound packets which were chosen to be
+            discarded even though no errors had been detected to prevent
+            their being transmitted.  One possible reason for discarding
+            such a packet could be to free up buffer space.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 19 }
+
+ifOutErrors OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "For packet-oriented interfaces, the number of outbound
+            packets that could not be transmitted because of errors.
+            For character-oriented or fixed-length interfaces, the
+            number of outbound transmission units that could not be
+            transmitted because of errors.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifEntry 20 }
+
+ifOutQLen OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "The length of the output packet queue (in packets)."
+    ::= { ifEntry 21 }
+
+ifSpecific OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-only
+    STATUS      deprecated
+    DESCRIPTION
+            "A reference to MIB definitions specific to the particular
+            media being used to realize the interface.  It is
+
+            recommended that this value point to an instance of a MIB
+            object in the media-specific MIB, i.e., that this object
+            have the semantics associated with the InstancePointer
+            textual convention defined in RFC 2579.  In fact, it is
+            recommended that the media-specific MIB specify what value
+            ifSpecific should/can take for values of ifType.  If no MIB
+            definitions specific to the particular media are available,
+            the value should be set to the OBJECT IDENTIFIER { 0 0 }."
+    ::= { ifEntry 22 }
+
+--
+--   Extension to the interface table
+--
+-- This table replaces the ifExtnsTable table.
+--
+
+ifXTable        OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IfXEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A list of interface entries.  The number of entries is
+            given by the value of ifNumber.  This table contains
+            additional objects for the interface table."
+    ::= { ifMIBObjects 1 }
+
+ifXEntry        OBJECT-TYPE
+    SYNTAX      IfXEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An entry containing additional management information
+            applicable to a particular interface."
+    AUGMENTS    { ifEntry }
+    ::= { ifXTable 1 }
+
+IfXEntry ::=
+    SEQUENCE {
+        ifName                  DisplayString,
+        ifInMulticastPkts       Counter32,
+        ifInBroadcastPkts       Counter32,
+        ifOutMulticastPkts      Counter32,
+        ifOutBroadcastPkts      Counter32,
+        ifHCInOctets            Counter64,
+        ifHCInUcastPkts         Counter64,
+        ifHCInMulticastPkts     Counter64,
+        ifHCInBroadcastPkts     Counter64,
+        ifHCOutOctets           Counter64,
+        ifHCOutUcastPkts        Counter64,
+        ifHCOutMulticastPkts    Counter64,
+        ifHCOutBroadcastPkts    Counter64,
+        ifLinkUpDownTrapEnable  INTEGER,
+        ifHighSpeed             Gauge32,
+        ifPromiscuousMode       TruthValue,
+        ifConnectorPresent      TruthValue,
+        ifAlias                 DisplayString,
+        ifCounterDiscontinuityTime TimeStamp
+    }
+
+ifName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The textual name of the interface.  The value of this
+            object should be the name of the interface as assigned by
+            the local device and should be suitable for use in commands
+            entered at the device's `console'.  This might be a text
+            name, such as `le0' or a simple port number, such as `1',
+            depending on the interface naming syntax of the device.  If
+            several entries in the ifTable together represent a single
+            interface as named by the device, then each will have the
+            same value of ifName.  Note that for an agent which responds
+            to SNMP queries concerning an interface on some other
+            (proxied) device, then the value of ifName for such an
+            interface is the proxied device's local name for it.
+
+            If there is no local name, or this object is otherwise not
+            applicable, then this object contains a zero-length string."
+    ::= { ifXEntry 1 }
+
+ifInMulticastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a multicast
+            address at this sub-layer.  For a MAC layer protocol, this
+            includes both Group and Functional addresses.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 2 }
+
+ifInBroadcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a broadcast
+            address at this sub-layer.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 3 }
+
+ifOutMulticastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            multicast address at this sub-layer, including those that
+            were discarded or not sent.  For a MAC layer protocol, this
+            includes both Group and Functional addresses.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 4 }
+
+ifOutBroadcastPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            broadcast address at this sub-layer, including those that
+            were discarded or not sent.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 5 }
+
+--
+-- High Capacity Counter objects.  These objects are all
+-- 64 bit versions of the "basic" ifTable counters.  These
+-- objects all have the same basic semantics as their 32-bit
+-- counterparts, however, their syntax has been extended
+-- to 64 bits.
+--
+
+ifHCInOctets OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of octets received on the interface,
+            including framing characters.  This object is a 64-bit
+            version of ifInOctets.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 6 }
+
+ifHCInUcastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were not addressed to a multicast
+            or broadcast address at this sub-layer.  This object is a
+            64-bit version of ifInUcastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 7 }
+
+ifHCInMulticastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a multicast
+            address at this sub-layer.  For a MAC layer protocol, this
+            includes both Group and Functional addresses.  This object
+            is a 64-bit version of ifInMulticastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 8 }
+
+ifHCInBroadcastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The number of packets, delivered by this sub-layer to a
+            higher (sub-)layer, which were addressed to a broadcast
+            address at this sub-layer.  This object is a 64-bit version
+            of ifInBroadcastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 9 }
+
+ifHCOutOctets OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of octets transmitted out of the
+            interface, including framing characters.  This object is a
+            64-bit version of ifOutOctets.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 10 }
+
+ifHCOutUcastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were not addressed to a
+            multicast or broadcast address at this sub-layer, including
+            those that were discarded or not sent.  This object is a
+            64-bit version of ifOutUcastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 11 }
+
+ifHCOutMulticastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            multicast address at this sub-layer, including those that
+            were discarded or not sent.  For a MAC layer protocol, this
+            includes both Group and Functional addresses.  This object
+            is a 64-bit version of ifOutMulticastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 12 }
+
+ifHCOutBroadcastPkts OBJECT-TYPE
+    SYNTAX      Counter64
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The total number of packets that higher-level protocols
+            requested be transmitted, and which were addressed to a
+            broadcast address at this sub-layer, including those that
+            were discarded or not sent.  This object is a 64-bit version
+            of ifOutBroadcastPkts.
+
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of
+            ifCounterDiscontinuityTime."
+    ::= { ifXEntry 13 }
+
+ifLinkUpDownTrapEnable  OBJECT-TYPE
+    SYNTAX      INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "Indicates whether linkUp/linkDown traps should be generated
+            for this interface.
+
+            By default, this object should have the value enabled(1) for
+            interfaces which do not operate on 'top' of any other
+            interface (as defined in the ifStackTable), and disabled(2)
+            otherwise."
+    ::= { ifXEntry 14 }
+
+ifHighSpeed OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An estimate of the interface's current bandwidth in units
+            of 1,000,000 bits per second.  If this object reports a
+            value of `n' then the speed of the interface is somewhere in
+            the range of `n-500,000' to `n+499,999'.  For interfaces
+            which do not vary in bandwidth or for those where no
+            accurate estimation can be made, this object should contain
+            the nominal bandwidth.  For a sub-layer which has no concept
+            of bandwidth, this object should be zero."
+    ::= { ifXEntry 15 }
+
+ifPromiscuousMode  OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object has a value of false(2) if this interface only
+            accepts packets/frames that are addressed to this station.
+            This object has a value of true(1) when the station accepts
+            all packets/frames transmitted on the media.  The value
+            true(1) is only legal on certain types of media.  If legal,
+            setting this object to a value of true(1) may require the
+            interface to be reset before becoming effective.
+
+            The value of ifPromiscuousMode does not affect the reception
+            of broadcast and multicast packets/frames by the interface."
+    ::= { ifXEntry 16 }
+
+ifConnectorPresent   OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "This object has the value 'true(1)' if the interface
+            sublayer has a physical connector and the value 'false(2)'
+            otherwise."
+    ::= { ifXEntry 17 }
+
+ifAlias   OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..64))
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "This object is an 'alias' name for the interface as
+            specified by a network manager, and provides a non-volatile
+            'handle' for the interface.
+
+            On the first instantiation of an interface, the value of
+            ifAlias associated with that interface is the zero-length
+            string.  As and when a value is written into an instance of
+            ifAlias through a network management set operation, then the
+            agent must retain the supplied value in the ifAlias instance
+            associated with the same interface for as long as that
+            interface remains instantiated, including across all re-
+            initializations/reboots of the network management system,
+            including those which result in a change of the interface's
+            ifIndex value.
+
+            An example of the value which a network manager might store
+            in this object for a WAN interface is the (Telco's) circuit
+            number/identifier of the interface.
+
+            Some agents may support write-access only for interfaces
+            having particular values of ifType.  An agent which supports
+            write access to this object is required to keep the value in
+            non-volatile storage, but it may limit the length of new
+            values depending on how much storage is already occupied by
+            the current values for other interfaces."
+    ::= { ifXEntry 18 }
+
+ifCounterDiscontinuityTime OBJECT-TYPE
+    SYNTAX      TimeStamp
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The value of sysUpTime on the most recent occasion at which
+            any one or more of this interface's counters suffered a
+            discontinuity.  The relevant counters are the specific
+            instances associated with this interface of any Counter32 or
+
+            Counter64 object contained in the ifTable or ifXTable.  If
+            no such discontinuities have occurred since the last re-
+            initialization of the local management subsystem, then this
+            object contains a zero value."
+    ::= { ifXEntry 19 }
+
+--           The Interface Stack Group
+--
+-- Implementation of this group is optional, but strongly recommended
+-- for all systems
+--
+
+ifStackTable  OBJECT-TYPE
+     SYNTAX        SEQUENCE OF IfStackEntry
+     MAX-ACCESS    not-accessible
+     STATUS        current
+     DESCRIPTION
+            "The table containing information on the relationships
+            between the multiple sub-layers of network interfaces.  In
+            particular, it contains information on which sub-layers run
+            'on top of' which other sub-layers, where each sub-layer
+            corresponds to a conceptual row in the ifTable.  For
+            example, when the sub-layer with ifIndex value x runs over
+            the sub-layer with ifIndex value y, then this table
+            contains:
+
+              ifStackStatus.x.y=active
+
+            For each ifIndex value, I, which identifies an active
+            interface, there are always at least two instantiated rows
+            in this table associated with I.  For one of these rows, I
+            is the value of ifStackHigherLayer; for the other, I is the
+            value of ifStackLowerLayer.  (If I is not involved in
+            multiplexing, then these are the only two rows associated
+            with I.)
+
+            For example, two rows exist even for an interface which has
+            no others stacked on top or below it:
+
+              ifStackStatus.0.x=active
+              ifStackStatus.x.0=active "
+     ::= { ifMIBObjects 2 }
+
+ifStackEntry  OBJECT-TYPE
+     SYNTAX        IfStackEntry
+     MAX-ACCESS    not-accessible
+     STATUS        current
+     DESCRIPTION
+            "Information on a particular relationship between two sub-
+            layers, specifying that one sub-layer runs on 'top' of the
+            other sub-layer.  Each sub-layer corresponds to a conceptual
+            row in the ifTable."
+     INDEX { ifStackHigherLayer, ifStackLowerLayer }
+     ::= { ifStackTable 1 }
+
+IfStackEntry ::=
+    SEQUENCE {
+        ifStackHigherLayer  InterfaceIndexOrZero,
+        ifStackLowerLayer   InterfaceIndexOrZero,
+        ifStackStatus       RowStatus
+     }
+
+ifStackHigherLayer  OBJECT-TYPE
+     SYNTAX        InterfaceIndexOrZero
+     MAX-ACCESS    not-accessible
+     STATUS        current
+     DESCRIPTION
+            "The value of ifIndex corresponding to the higher sub-layer
+            of the relationship, i.e., the sub-layer which runs on 'top'
+            of the sub-layer identified by the corresponding instance of
+            ifStackLowerLayer.  If there is no higher sub-layer (below
+            the internetwork layer), then this object has the value 0."
+     ::= { ifStackEntry 1 }
+
+ifStackLowerLayer  OBJECT-TYPE
+     SYNTAX        InterfaceIndexOrZero
+     MAX-ACCESS    not-accessible
+     STATUS        current
+     DESCRIPTION
+            "The value of ifIndex corresponding to the lower sub-layer
+            of the relationship, i.e., the sub-layer which runs 'below'
+            the sub-layer identified by the corresponding instance of
+            ifStackHigherLayer.  If there is no lower sub-layer, then
+            this object has the value 0."
+     ::= { ifStackEntry 2 }
+
+ifStackStatus  OBJECT-TYPE
+    SYNTAX         RowStatus
+    MAX-ACCESS     read-create
+    STATUS         current
+    DESCRIPTION
+            "The status of the relationship between two sub-layers.
+
+            Changing the value of this object from 'active' to
+            'notInService' or 'destroy' will likely have consequences up
+            and down the interface stack.  Thus, write access to this
+            object is likely to be inappropriate for some types of
+            interfaces, and many implementations will choose not to
+            support write-access for any type of interface."
+    ::= { ifStackEntry 3 }
+
+ifStackLastChange OBJECT-TYPE
+    SYNTAX         TimeTicks
+    MAX-ACCESS     read-only
+    STATUS         current
+    DESCRIPTION
+            "The value of sysUpTime at the time of the last change of
+            the (whole) interface stack.  A change of the interface
+            stack is defined to be any creation, deletion, or change in
+            value of any instance of ifStackStatus.  If the interface
+            stack has been unchanged since the last re-initialization of
+            the local network management subsystem, then this object
+            contains a zero value."
+    ::= { ifMIBObjects 6 }
+
+--   Generic Receive Address Table
+--
+-- This group of objects is mandatory for all types of
+-- interfaces which can receive packets/frames addressed to
+-- more than one address.
+--
+-- This table replaces the ifExtnsRcvAddr table.  The main
+-- difference is that this table makes use of the RowStatus
+-- textual convention, while ifExtnsRcvAddr did not.
+
+ifRcvAddressTable  OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IfRcvAddressEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "This table contains an entry for each address (broadcast,
+            multicast, or uni-cast) for which the system will receive
+            packets/frames on a particular interface, except as follows:
+
+            - for an interface operating in promiscuous mode, entries
+            are only required for those addresses for which the system
+            would receive frames were it not operating in promiscuous
+            mode.
+
+            - for 802.5 functional addresses, only one entry is
+            required, for the address which has the functional address
+            bit ANDed with the bit mask of all functional addresses for
+            which the interface will accept frames.
+
+            A system is normally able to use any unicast address which
+            corresponds to an entry in this table as a source address."
+    ::= { ifMIBObjects 4 }
+
+ifRcvAddressEntry  OBJECT-TYPE
+    SYNTAX      IfRcvAddressEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A list of objects identifying an address for which the
+            system will accept packets/frames on the particular
+            interface identified by the index value ifIndex."
+    INDEX  { ifIndex, ifRcvAddressAddress }
+    ::= { ifRcvAddressTable 1 }
+
+IfRcvAddressEntry ::=
+    SEQUENCE {
+        ifRcvAddressAddress   PhysAddress,
+        ifRcvAddressStatus    RowStatus,
+        ifRcvAddressType      INTEGER
+    }
+
+ifRcvAddressAddress OBJECT-TYPE
+    SYNTAX      PhysAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "An address for which the system will accept packets/frames
+            on this entry's interface."
+    ::= { ifRcvAddressEntry 1 }
+
+ifRcvAddressStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+            "This object is used to create and delete rows in the
+            ifRcvAddressTable."
+    ::= { ifRcvAddressEntry 2 }
+
+ifRcvAddressType OBJECT-TYPE
+    SYNTAX      INTEGER {
+
+                    other(1),
+                    volatile(2),
+                    nonVolatile(3)
+                }
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION
+            "This object has the value nonVolatile(3) for those entries
+            in the table which are valid and will not be deleted by the
+            next restart of the managed system.  Entries having the
+            value volatile(2) are valid and exist, but have not been
+            saved, so that will not exist after the next restart of the
+            managed system.  Entries having the value other(1) are valid
+            and exist but are not classified as to whether they will
+            continue to exist after the next restart."
+    DEFVAL  { volatile }
+    ::= { ifRcvAddressEntry 3 }
+
+-- definition of interface-related traps.
+
+linkDown NOTIFICATION-TYPE
+    OBJECTS { ifIndex, ifAdminStatus, ifOperStatus }
+    STATUS  current
+    DESCRIPTION
+            "A linkDown trap signifies that the SNMP entity, acting in
+            an agent role, has detected that the ifOperStatus object for
+            one of its communication links is about to enter the down
+            state from some other state (but not from the notPresent
+            state).  This other state is indicated by the included value
+            of ifOperStatus."
+    ::= { snmpTraps 3 }
+
+linkUp NOTIFICATION-TYPE
+    OBJECTS { ifIndex, ifAdminStatus, ifOperStatus }
+    STATUS  current
+    DESCRIPTION
+            "A linkUp trap signifies that the SNMP entity, acting in an
+            agent role, has detected that the ifOperStatus object for
+            one of its communication links left the down state and
+            transitioned into some other state (but not into the
+            notPresent state).  This other state is indicated by the
+            included value of ifOperStatus."
+    ::= { snmpTraps 4 }
+
+-- conformance information
+
+ifConformance OBJECT IDENTIFIER ::= { ifMIB 2 }
+
+ifGroups      OBJECT IDENTIFIER ::= { ifConformance 1 }
+ifCompliances OBJECT IDENTIFIER ::= { ifConformance 2 }
+
+-- compliance statements
+
+ifCompliance3 MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for SNMP entities which have
+            network interfaces."
+
+    MODULE  -- this module
+        MANDATORY-GROUPS { ifGeneralInformationGroup,
+                           linkUpDownNotificationsGroup }
+
+-- The groups:
+--        ifFixedLengthGroup
+--        ifHCFixedLengthGroup
+--        ifPacketGroup
+--        ifHCPacketGroup
+--        ifVHCPacketGroup
+-- are mutually exclusive; at most one of these groups is implemented
+-- for a particular interface.  When any of these groups is implemented
+-- for a particular interface, then ifCounterDiscontinuityGroup must
+-- also be implemented for that interface.
+
+        GROUP       ifFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory for those network interfaces which
+            are character-oriented or transmit data in fixed-length
+            transmission units, and for which the value of the
+            corresponding instance of ifSpeed is less than or equal to
+            20,000,000 bits/second."
+
+        GROUP       ifHCFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory for those network interfaces which
+            are character-oriented or transmit data in fixed-length
+            transmission units, and for which the value of the
+            corresponding instance of ifSpeed is greater than 20,000,000
+            bits/second."
+
+        GROUP       ifPacketGroup
+        DESCRIPTION
+            "This group is mandatory for those network interfaces which
+            are packet-oriented, and for which the value of the
+            corresponding instance of ifSpeed is less than or equal to
+            20,000,000 bits/second."
+
+        GROUP       ifHCPacketGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are packet-oriented and for which the value of the
+            corresponding instance of ifSpeed is greater than 20,000,000
+            bits/second but less than or equal to 650,000,000
+            bits/second."
+
+        GROUP       ifVHCPacketGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are packet-oriented and for which the value of the
+            corresponding instance of ifSpeed is greater than
+            650,000,000 bits/second."
+
+        GROUP       ifCounterDiscontinuityGroup
+        DESCRIPTION
+            "This group is mandatory for those network interfaces that
+            are required to maintain counters (i.e., those for which one
+            of the ifFixedLengthGroup, ifHCFixedLengthGroup,
+            ifPacketGroup, ifHCPacketGroup, or ifVHCPacketGroup is
+            mandatory)."
+
+        GROUP       ifRcvAddressGroup
+        DESCRIPTION
+            "The applicability of this group MUST be defined by the
+            media-specific MIBs.  Media-specific MIBs must define the
+            exact meaning, use, and semantics of the addresses in this
+            group."
+
+        OBJECT      ifLinkUpDownTrapEnable
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifPromiscuousMode
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT       ifAdminStatus
+        SYNTAX       INTEGER { up(1), down(2) }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support for the value
+            testing(3)."
+
+        OBJECT       ifAlias
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required."
+    ::= { ifCompliances 3 }
+
+-- units of conformance
+
+ifGeneralInformationGroup    OBJECT-GROUP
+    OBJECTS { ifIndex, ifDescr, ifType, ifSpeed, ifPhysAddress,
+              ifAdminStatus, ifOperStatus, ifLastChange,
+              ifLinkUpDownTrapEnable, ifConnectorPresent,
+              ifHighSpeed, ifName, ifNumber, ifAlias,
+              ifTableLastChange }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information applicable to
+            all network interfaces."
+    ::= { ifGroups 10 }
+
+-- the following five groups are mutually exclusive; at most
+-- one of these groups is implemented for any interface
+
+ifFixedLengthGroup    OBJECT-GROUP
+    OBJECTS { ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            non-high speed (non-high speed interfaces transmit and
+            receive at speeds less than or equal to 20,000,000
+            bits/second) character-oriented or fixed-length-transmission
+            network interfaces."
+    ::= { ifGroups 2 }
+
+ifHCFixedLengthGroup    OBJECT-GROUP
+    OBJECTS { ifHCInOctets, ifHCOutOctets,
+              ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            high speed (greater than 20,000,000 bits/second) character-
+            oriented or fixed-length-transmission network interfaces."
+    ::= { ifGroups 3 }
+
+ifPacketGroup    OBJECT-GROUP
+    OBJECTS { ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors,
+              ifMtu, ifInUcastPkts, ifInMulticastPkts,
+              ifInBroadcastPkts, ifInDiscards,
+              ifOutUcastPkts, ifOutMulticastPkts,
+              ifOutBroadcastPkts, ifOutDiscards,
+              ifPromiscuousMode }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            non-high speed (non-high speed interfaces transmit and
+            receive at speeds less than or equal to 20,000,000
+            bits/second) packet-oriented network interfaces."
+    ::= { ifGroups 4 }
+
+ifHCPacketGroup    OBJECT-GROUP
+    OBJECTS { ifHCInOctets, ifHCOutOctets,
+              ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors,
+              ifMtu, ifInUcastPkts, ifInMulticastPkts,
+              ifInBroadcastPkts, ifInDiscards,
+              ifOutUcastPkts, ifOutMulticastPkts,
+              ifOutBroadcastPkts, ifOutDiscards,
+              ifPromiscuousMode }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            high speed (greater than 20,000,000 bits/second but less
+            than or equal to 650,000,000 bits/second) packet-oriented
+            network interfaces."
+    ::= { ifGroups 5 }
+
+ifVHCPacketGroup    OBJECT-GROUP
+    OBJECTS { ifHCInUcastPkts, ifHCInMulticastPkts,
+              ifHCInBroadcastPkts, ifHCOutUcastPkts,
+              ifHCOutMulticastPkts, ifHCOutBroadcastPkts,
+              ifHCInOctets, ifHCOutOctets,
+              ifInOctets, ifOutOctets, ifInUnknownProtos,
+              ifInErrors, ifOutErrors,
+              ifMtu, ifInUcastPkts, ifInMulticastPkts,
+              ifInBroadcastPkts, ifInDiscards,
+              ifOutUcastPkts, ifOutMulticastPkts,
+              ifOutBroadcastPkts, ifOutDiscards,
+              ifPromiscuousMode }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            higher speed (greater than 650,000,000 bits/second) packet-
+            oriented network interfaces."
+    ::= { ifGroups 6 }
+
+ifRcvAddressGroup    OBJECT-GROUP
+    OBJECTS { ifRcvAddressStatus, ifRcvAddressType }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information on the
+            multiple addresses which an interface receives."
+    ::= { ifGroups 7 }
+
+ifStackGroup2    OBJECT-GROUP
+    OBJECTS { ifStackStatus, ifStackLastChange }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information on the
+            layering of MIB-II interfaces."
+    ::= { ifGroups 11 }
+
+ifCounterDiscontinuityGroup  OBJECT-GROUP
+    OBJECTS { ifCounterDiscontinuityTime }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing information specific to
+            interface counter discontinuities."
+    ::= { ifGroups 13 }
+
+linkUpDownNotificationsGroup  NOTIFICATION-GROUP
+    NOTIFICATIONS { linkUp, linkDown }
+    STATUS  current
+    DESCRIPTION
+            "The notifications which indicate specific changes in the
+            value of ifOperStatus."
+    ::= { ifGroups 14 }
+
+-- Deprecated Definitions - Objects
+
+--
+--    The Interface Test Table
+--
+-- This group of objects is optional.  However, a media-specific
+
+-- MIB may make implementation of this group mandatory.
+--
+-- This table replaces the ifExtnsTestTable
+--
+
+ifTestTable   OBJECT-TYPE
+    SYNTAX      SEQUENCE OF IfTestEntry
+    MAX-ACCESS  not-accessible
+    STATUS      deprecated
+    DESCRIPTION
+            "This table contains one entry per interface.  It defines
+            objects which allow a network manager to instruct an agent
+            to test an interface for various faults.  Tests for an
+            interface are defined in the media-specific MIB for that
+            interface.  After invoking a test, the object ifTestResult
+            can be read to determine the outcome.  If an agent can not
+            perform the test, ifTestResult is set to so indicate.  The
+            object ifTestCode can be used to provide further test-
+            specific or interface-specific (or even enterprise-specific)
+            information concerning the outcome of the test.  Only one
+            test can be in progress on each interface at any one time.
+            If one test is in progress when another test is invoked, the
+            second test is rejected.  Some agents may reject a test when
+            a prior test is active on another interface.
+
+            Before starting a test, a manager-station must first obtain
+            'ownership' of the entry in the ifTestTable for the
+            interface to be tested.  This is accomplished with the
+            ifTestId and ifTestStatus objects as follows:
+
+          try_again:
+              get (ifTestId, ifTestStatus)
+              while (ifTestStatus != notInUse)
+                  /*
+                   * Loop while a test is running or some other
+                   * manager is configuring a test.
+                   */
+                  short delay
+                  get (ifTestId, ifTestStatus)
+              }
+
+              /*
+               * Is not being used right now -- let's compete
+               * to see who gets it.
+               */
+              lock_value = ifTestId
+
+              if ( set(ifTestId = lock_value, ifTestStatus = inUse,
+                       ifTestOwner = 'my-IP-address') == FAILURE)
+                  /*
+                   * Another manager got the ifTestEntry -- go
+                   * try again
+                   */
+                  goto try_again;
+
+              /*
+               * I have the lock
+               */
+              set up any test parameters.
+
+              /*
+               * This starts the test
+               */
+              set(ifTestType = test_to_run);
+
+              wait for test completion by polling ifTestResult
+
+              when test completes, agent sets ifTestResult
+                   agent also sets ifTestStatus = 'notInUse'
+
+              retrieve any additional test results, and ifTestId
+
+              if (ifTestId == lock_value+1) results are valid
+
+            A manager station first retrieves the value of the
+            appropriate ifTestId and ifTestStatus objects, periodically
+            repeating the retrieval if necessary, until the value of
+            ifTestStatus is 'notInUse'.  The manager station then tries
+            to set the same ifTestId object to the value it just
+            retrieved, the same ifTestStatus object to 'inUse', and the
+            corresponding ifTestOwner object to a value indicating
+            itself.  If the set operation succeeds then the manager has
+            obtained ownership of the ifTestEntry, and the value of the
+            ifTestId object is incremented by the agent (per the
+            semantics of TestAndIncr).  Failure of the set operation
+            indicates that some other manager has obtained ownership of
+            the ifTestEntry.
+
+            Once ownership is obtained, any test parameters can be
+            setup, and then the test is initiated by setting ifTestType.
+            On completion of the test, the agent sets ifTestStatus to
+            'notInUse'.  Once this occurs, the manager can retrieve the
+            results.  In the (rare) event that the invocation of tests
+            by two network managers were to overlap, then there would be
+            a possibility that the first test's results might be
+            overwritten by the second test's results prior to the first
+
+            results being read.  This unlikely circumstance can be
+            detected by a network manager retrieving ifTestId at the
+            same time as retrieving the test results, and ensuring that
+            the results are for the desired request.
+
+            If ifTestType is not set within an abnormally long period of
+            time after ownership is obtained, the agent should time-out
+            the manager, and reset the value of the ifTestStatus object
+            back to 'notInUse'.  It is suggested that this time-out
+            period be 5 minutes.
+
+            In general, a management station must not retransmit a
+            request to invoke a test for which it does not receive a
+            response; instead, it properly inspects an agent's MIB to
+            determine if the invocation was successful.  Only if the
+            invocation was unsuccessful, is the invocation request
+            retransmitted.
+
+            Some tests may require the interface to be taken off-line in
+            order to execute them, or may even require the agent to
+            reboot after completion of the test.  In these
+            circumstances, communication with the management station
+            invoking the test may be lost until after completion of the
+            test.  An agent is not required to support such tests.
+            However, if such tests are supported, then the agent should
+            make every effort to transmit a response to the request
+            which invoked the test prior to losing communication.  When
+            the agent is restored to normal service, the results of the
+            test are properly made available in the appropriate objects.
+            Note that this requires that the ifIndex value assigned to
+            an interface must be unchanged even if the test causes a
+            reboot.  An agent must reject any test for which it cannot,
+            perhaps due to resource constraints, make available at least
+            the minimum amount of information after that test
+            completes."
+    ::= { ifMIBObjects 3 }
+
+ifTestEntry OBJECT-TYPE
+    SYNTAX       IfTestEntry
+    MAX-ACCESS   not-accessible
+    STATUS       deprecated
+    DESCRIPTION
+            "An entry containing objects for invoking tests on an
+            interface."
+    AUGMENTS  { ifEntry }
+    ::= { ifTestTable 1 }
+
+IfTestEntry ::=
+
+    SEQUENCE {
+        ifTestId           TestAndIncr,
+        ifTestStatus       INTEGER,
+        ifTestType         AutonomousType,
+        ifTestResult       INTEGER,
+        ifTestCode         OBJECT IDENTIFIER,
+        ifTestOwner        OwnerString
+    }
+
+ifTestId         OBJECT-TYPE
+    SYNTAX       TestAndIncr
+    MAX-ACCESS   read-write
+    STATUS       deprecated
+    DESCRIPTION
+            "This object identifies the current invocation of the
+            interface's test."
+    ::= { ifTestEntry 1 }
+
+ifTestStatus     OBJECT-TYPE
+    SYNTAX       INTEGER { notInUse(1), inUse(2) }
+    MAX-ACCESS   read-write
+    STATUS       deprecated
+    DESCRIPTION
+            "This object indicates whether or not some manager currently
+            has the necessary 'ownership' required to invoke a test on
+            this interface.  A write to this object is only successful
+            when it changes its value from 'notInUse(1)' to 'inUse(2)'.
+            After completion of a test, the agent resets the value back
+            to 'notInUse(1)'."
+    ::= { ifTestEntry 2 }
+
+ifTestType       OBJECT-TYPE
+    SYNTAX       AutonomousType
+    MAX-ACCESS   read-write
+    STATUS       deprecated
+    DESCRIPTION
+            "A control variable used to start and stop operator-
+            initiated interface tests.  Most OBJECT IDENTIFIER values
+            assigned to tests are defined elsewhere, in association with
+            specific types of interface.  However, this document assigns
+            a value for a full-duplex loopback test, and defines the
+            special meanings of the subject identifier:
+
+                noTest  OBJECT IDENTIFIER ::= { 0 0 }
+
+            When the value noTest is written to this object, no action
+            is taken unless a test is in progress, in which case the
+            test is aborted.  Writing any other value to this object is
+
+            only valid when no test is currently in progress, in which
+            case the indicated test is initiated.
+
+            When read, this object always returns the most recent value
+            that ifTestType was set to.  If it has not been set since
+            the last initialization of the network management subsystem
+            on the agent, a value of noTest is returned."
+    ::= { ifTestEntry 3 }
+
+ifTestResult  OBJECT-TYPE
+    SYNTAX       INTEGER {
+                     none(1),          -- no test yet requested
+                     success(2),
+                     inProgress(3),
+                     notSupported(4),
+                     unAbleToRun(5),   -- due to state of system
+                     aborted(6),
+                     failed(7)
+                 }
+    MAX-ACCESS   read-only
+    STATUS       deprecated
+    DESCRIPTION
+            "This object contains the result of the most recently
+            requested test, or the value none(1) if no tests have been
+            requested since the last reset.  Note that this facility
+            provides no provision for saving the results of one test
+            when starting another, as could be required if used by
+            multiple managers concurrently."
+    ::= { ifTestEntry 4 }
+
+ifTestCode  OBJECT-TYPE
+    SYNTAX       OBJECT IDENTIFIER
+    MAX-ACCESS   read-only
+    STATUS       deprecated
+    DESCRIPTION
+            "This object contains a code which contains more specific
+            information on the test result, for example an error-code
+            after a failed test.  Error codes and other values this
+            object may take are specific to the type of interface and/or
+            test.  The value may have the semantics of either the
+            AutonomousType or InstancePointer textual conventions as
+            defined in RFC 2579.  The identifier:
+
+                testCodeUnknown  OBJECT IDENTIFIER ::= { 0 0 }
+
+            is defined for use if no additional result code is
+            available."
+    ::= { ifTestEntry 5 }
+
+ifTestOwner      OBJECT-TYPE
+    SYNTAX       OwnerString
+    MAX-ACCESS   read-write
+    STATUS       deprecated
+    DESCRIPTION
+            "The entity which currently has the 'ownership' required to
+            invoke a test on this interface."
+    ::= { ifTestEntry 6 }
+
+-- Deprecated Definitions - Groups
+
+ifGeneralGroup    OBJECT-GROUP
+    OBJECTS { ifDescr, ifType, ifSpeed, ifPhysAddress,
+              ifAdminStatus, ifOperStatus, ifLastChange,
+              ifLinkUpDownTrapEnable, ifConnectorPresent,
+              ifHighSpeed, ifName }
+    STATUS  deprecated
+    DESCRIPTION
+            "A collection of objects deprecated in favour of
+            ifGeneralInformationGroup."
+    ::= { ifGroups 1 }
+
+ifTestGroup    OBJECT-GROUP
+    OBJECTS { ifTestId, ifTestStatus, ifTestType,
+              ifTestResult, ifTestCode, ifTestOwner }
+    STATUS  deprecated
+    DESCRIPTION
+            "A collection of objects providing the ability to invoke
+            tests on an interface."
+    ::= { ifGroups 8 }
+
+ifStackGroup    OBJECT-GROUP
+    OBJECTS { ifStackStatus }
+    STATUS  deprecated
+    DESCRIPTION
+            "The previous collection of objects providing information on
+            the layering of MIB-II interfaces."
+    ::= { ifGroups 9 }
+
+ifOldObjectsGroup    OBJECT-GROUP
+    OBJECTS { ifInNUcastPkts, ifOutNUcastPkts,
+              ifOutQLen, ifSpecific }
+    STATUS  deprecated
+    DESCRIPTION
+            "The collection of objects deprecated from the original MIB-
+            II interfaces group."
+    ::= { ifGroups 12 }
+
+-- Deprecated Definitions - Compliance
+
+ifCompliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+            "A compliance statement defined in a previous version of
+            this MIB module, for SNMP entities which have network
+            interfaces."
+
+    MODULE  -- this module
+        MANDATORY-GROUPS { ifGeneralGroup, ifStackGroup }
+
+        GROUP       ifFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory for all network interfaces which
+            are character-oriented or transmit data in fixed-length
+            transmission units."
+
+        GROUP       ifHCFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are character-oriented or transmit data in fixed-
+            length transmission units, and for which the value of the
+            corresponding instance of ifSpeed is greater than 20,000,000
+            bits/second."
+
+        GROUP       ifPacketGroup
+        DESCRIPTION
+            "This group is mandatory for all network interfaces which
+            are packet-oriented."
+
+        GROUP       ifHCPacketGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are packet-oriented and for which the value of the
+            corresponding instance of ifSpeed is greater than
+            650,000,000 bits/second."
+
+        GROUP       ifTestGroup
+        DESCRIPTION
+            "This group is optional.  Media-specific MIBs which require
+            interface tests are strongly encouraged to use this group
+            for invoking tests and reporting results.  A medium specific
+            MIB which has mandatory tests may make implementation of
+
+            this group mandatory."
+
+        GROUP       ifRcvAddressGroup
+        DESCRIPTION
+            "The applicability of this group MUST be defined by the
+            media-specific MIBs.  Media-specific MIBs must define the
+            exact meaning, use, and semantics of the addresses in this
+            group."
+
+        OBJECT      ifLinkUpDownTrapEnable
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifPromiscuousMode
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifStackStatus
+        SYNTAX      INTEGER { active(1) } -- subset of RowStatus
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required, and only one of the six
+            enumerated values for the RowStatus textual convention need
+            be supported, specifically: active(1)."
+
+        OBJECT       ifAdminStatus
+        SYNTAX       INTEGER { up(1), down(2) }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support for the value
+            testing(3)."
+    ::= { ifCompliances 1 }
+
+ifCompliance2 MODULE-COMPLIANCE
+    STATUS      deprecated
+    DESCRIPTION
+            "A compliance statement defined in a previous version of
+            this MIB module, for SNMP entities which have network
+            interfaces."
+
+    MODULE  -- this module
+        MANDATORY-GROUPS { ifGeneralInformationGroup, ifStackGroup2,
+                           ifCounterDiscontinuityGroup }
+
+        GROUP       ifFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory for all network interfaces which
+            are character-oriented or transmit data in fixed-length
+            transmission units."
+
+        GROUP       ifHCFixedLengthGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are character-oriented or transmit data in fixed-
+            length transmission units, and for which the value of the
+            corresponding instance of ifSpeed is greater than 20,000,000
+            bits/second."
+
+        GROUP       ifPacketGroup
+        DESCRIPTION
+            "This group is mandatory for all network interfaces which
+            are packet-oriented."
+
+        GROUP       ifHCPacketGroup
+        DESCRIPTION
+            "This group is mandatory only for those network interfaces
+            which are packet-oriented and for which the value of the
+            corresponding instance of ifSpeed is greater than
+            650,000,000 bits/second."
+
+        GROUP       ifRcvAddressGroup
+        DESCRIPTION
+            "The applicability of this group MUST be defined by the
+            media-specific MIBs.  Media-specific MIBs must define the
+            exact meaning, use, and semantics of the addresses in this
+            group."
+
+        OBJECT      ifLinkUpDownTrapEnable
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifPromiscuousMode
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required."
+
+        OBJECT      ifStackStatus
+        SYNTAX      INTEGER { active(1) } -- subset of RowStatus
+        MIN-ACCESS  read-only
+        DESCRIPTION
+            "Write access is not required, and only one of the six
+            enumerated values for the RowStatus textual convention need
+            be supported, specifically: active(1)."
+
+        OBJECT       ifAdminStatus
+        SYNTAX       INTEGER { up(1), down(2) }
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required, nor is support for the value
+            testing(3)."
+
+        OBJECT       ifAlias
+        MIN-ACCESS   read-only
+        DESCRIPTION
+            "Write access is not required."
+    ::= { ifCompliances 2 }
+
+END

--- a/services/monitoring/assets/snmp/mibs/PerfHist-TC-MIB
+++ b/services/monitoring/assets/snmp/mibs/PerfHist-TC-MIB
@@ -1,0 +1,178 @@
+PerfHist-TC-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+   MODULE-IDENTITY,
+   Gauge32, mib-2
+       FROM SNMPv2-SMI
+   TEXTUAL-CONVENTION
+       FROM SNMPv2-TC;
+
+perfHistTCMIB MODULE-IDENTITY
+     LAST-UPDATED "200308130000Z"
+     ORGANIZATION "IETF AToM MIB WG"
+     CONTACT-INFO
+        "WG charter:
+           http://www.ietf.org/html.charters/atommib-charter.html
+
+         Mailing Lists:
+           General Discussion: atommib@research.telcordia.com
+           To Subscribe: atommib-request@research.telcordia.com
+
+         Editor:  Kaj Tesink
+         Postal:  Telcordia Technologies
+                  331 Newman Springs Road
+                  Red Bank, NJ 07701
+                  USA
+         Tel:     +1 732 758 5254
+         E-mail:  kaj@research.telcordia.com"
+     DESCRIPTION
+      "This MIB Module provides Textual Conventions
+       to be used by systems supporting 15 minute
+       based performance history counts.
+
+       Copyright (C) The Internet Society (2003).
+       This version of this MIB module is part of
+       RFC 3593;  see the RFC itself for full
+       legal notices."
+     REVISION      "200308130000Z"
+     DESCRIPTION
+      "Contact information and references updated.
+       No technical changes have been applied.
+       Published as RFC 3593."
+     REVISION      "199811071100Z"
+     DESCRIPTION
+      "The RFC 2493 version of this MIB module."
+     ::= { mib-2 58 }
+
+-- The Textual Conventions defined below are organized
+-- alphabetically
+
+-- Use of these TCs assumes the following:
+-- 0  The agent supports 15 minute based history
+--    counters.
+-- 0  The agent is capable of keeping a history of n
+--    intervals of 15 minute performance data.  The
+--    value of n is defined by the specific MIB
+--    module but shall be 0 < n =< 96.
+-- 0  The agent may optionally support performance
+--    data aggregating the history intervals.
+-- 0  The agent will keep separate tables for the
+--    current interval, the history intervals, and
+--    the total aggregates.
+-- 0  The agent will keep the following objects.
+--    If performance data is kept for multiple instances
+--    of a measured entity, then
+--    these objects are applied to each instance of
+--    the measured entity (e.g., interfaces).
+--
+-- xyzTimeElapsed OBJECT-TYPE
+--       SYNTAX  INTEGER (0..899)
+--       MAX-ACCESS  read-only
+--       STATUS  current
+--       DESCRIPTION
+--       "The number of seconds that have elapsed since
+--       the beginning of the current measurement period.
+--       If, for some reason, such as an adjustment in the
+--       system's time-of-day clock, the current interval
+--       exceeds the maximum value, the agent will return
+--       the maximum value."
+--       ::= { xxx }
+
+-- xyzValidIntervals OBJECT-TYPE
+--       SYNTAX  INTEGER (0..<n>)
+--       MAX-ACCESS  read-only
+--       STATUS  current
+--       DESCRIPTION
+--       "The number of previous near end intervals
+--       for which data was collected.
+--          [ The overall constraint on <n> is 1 =< n =< 96; ]
+--          [ Define any additional constraints on <n> here. ]
+--       The value will be <n> unless the measurement was
+--       (re-)started within the last (<n>*15) minutes, in which
+--       case the value will be the number of complete 15
+--       minute intervals for which the agent has at least
+--       some data.  In certain cases (e.g., in the case
+
+--       where the agent is a proxy) it is possible that some
+--       intervals are unavailable.  In this case, this
+--       interval is the maximum interval number for
+--       which data is available."
+--       ::= { xxx }
+
+-- xyzInvalidIntervals OBJECT-TYPE
+--     SYNTAX  INTEGER (0..<n>)
+--     MAX-ACCESS  read-only
+--     STATUS  current
+--     DESCRIPTION
+--       "The number of intervals in the range from
+--        0 to xyzValidIntervals for which no
+--        data is available.  This object will typically
+--        be zero except in cases where the data for some
+--        intervals are not available (e.g., in proxy
+--        situations)."
+--       ::= { xxx }
+
+PerfCurrentCount ::= TEXTUAL-CONVENTION
+      STATUS  current
+      DESCRIPTION
+         "A counter associated with a
+          performance measurement in a current 15
+          minute measurement interval.  The value
+          of this counter starts from zero and is
+          increased when associated events occur,
+          until the end of the 15 minute interval.
+          At that time the value of the counter is
+          stored in the first 15 minute history
+          interval, and the CurrentCount is
+          restarted at zero.  In the
+          case where the agent has no valid data
+          available for the current interval the
+          corresponding object instance is not
+          available and upon a retrieval request
+          a corresponding error message shall be
+          returned to indicate that this instance
+          does not exist (for example, a noSuchName
+          error for SNMPv1 and a noSuchInstance for
+          SNMPv2 GET operation)."
+       SYNTAX  Gauge32
+
+PerfIntervalCount ::= TEXTUAL-CONVENTION
+      STATUS  current
+      DESCRIPTION
+         "A counter associated with a
+          performance measurement in a previous
+          15 minute measurement interval.  In the
+          case where the agent has no valid data
+          available for a particular interval the
+          corresponding object instance is not
+          available and upon a retrieval request
+          a corresponding error message shall be
+          returned to indicate that this instance
+          does not exist (for example, a noSuchName
+          error for SNMPv1 and a noSuchInstance for
+          SNMPv2 GET operation).
+          In a system supporting
+          a history of n intervals with
+          IntervalCount(1) and IntervalCount(n) the
+          most and least recent intervals
+          respectively, the following applies at
+          the end of a 15 minute interval:
+          - discard the value of IntervalCount(n)
+          - the value of IntervalCount(i) becomes that
+            of IntervalCount(i-1) for n >= i > 1
+          - the value of IntervalCount(1) becomes that
+            of CurrentCount
+          - the TotalCount, if supported, is adjusted."
+       SYNTAX  Gauge32
+
+PerfTotalCount ::= TEXTUAL-CONVENTION
+      STATUS  current
+      DESCRIPTION
+         "A counter associated with a
+          performance measurements aggregating the
+          previous valid 15 minute measurement
+          intervals.  (Intervals for which no valid
+          data was available are not counted)"
+       SYNTAX  Gauge32
+
+END

--- a/services/monitoring/assets/snmp/mibs/SNMP-FRAMEWORK-MIB
+++ b/services/monitoring/assets/snmp/mibs/SNMP-FRAMEWORK-MIB
@@ -1,0 +1,526 @@
+SNMP-FRAMEWORK-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    OBJECT-IDENTITY,
+    snmpModules                           FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION                    FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP       FROM SNMPv2-CONF;
+
+snmpFrameworkMIB MODULE-IDENTITY
+    LAST-UPDATED "200210140000Z"
+    ORGANIZATION "SNMPv3 Working Group"
+    CONTACT-INFO "WG-EMail:   snmpv3@lists.tislabs.com
+                  Subscribe:  snmpv3-request@lists.tislabs.com
+
+                  Co-Chair:   Russ Mundy
+                              Network Associates Laboratories
+                  postal:     15204 Omega Drive, Suite 300
+                              Rockville, MD 20850-4601
+                              USA
+                  EMail:      mundy@tislabs.com
+                  phone:      +1 301-947-7107
+
+                  Co-Chair &
+                  Co-editor:  David Harrington
+                              Enterasys Networks
+                  postal:     35 Industrial Way
+                              P. O. Box 5005
+                              Rochester, New Hampshire 03866-5005
+                              USA
+                  EMail:      dbh@enterasys.com
+                  phone:      +1 603-337-2614
+
+                  Co-editor:  Randy Presuhn
+                              BMC Software, Inc.
+                  postal:     2141 North First Street
+                              San Jose, California 95131
+                              USA
+                  EMail:      randy_presuhn@bmc.com
+                  phone:      +1 408-546-1006
+
+                  Co-editor:  Bert Wijnen
+                              Lucent Technologies
+                  postal:     Schagen 33
+                              3461 GL Linschoten
+                              Netherlands
+
+                  EMail:      bwijnen@lucent.com
+                  phone:      +31 348-680-485
+                    "
+       DESCRIPTION  "The SNMP Management Architecture MIB
+
+                     Copyright (C) The Internet Society (2002). This
+                     version of this MIB module is part of RFC 3411;
+                     see the RFC itself for full legal notices.
+                    "
+
+       REVISION     "200210140000Z"         -- 14 October 2002
+       DESCRIPTION  "Changes in this revision:
+                     - Updated various administrative information.
+                     - Corrected some typos.
+                     - Corrected typo in description of SnmpEngineID
+                       that led to range overlap for 127.
+                     - Changed '255a' to '255t' in definition of
+                       SnmpAdminString to align with current SMI.
+                     - Reworded 'reserved' for value zero in
+                       DESCRIPTION of SnmpSecurityModel.
+                     - The algorithm for allocating security models
+                       should give 256 per enterprise block, rather
+                       than 255.
+                     - The example engine ID of 'abcd' is not
+                       legal. Replaced with '800002b804616263'H based
+                       on example enterprise 696, string 'abc'.
+                     - Added clarification that engineID should
+                       persist across re-initializations.
+                     This revision published as RFC 3411.
+                    "
+       REVISION     "199901190000Z"         -- 19 January 1999
+       DESCRIPTION  "Updated editors' addresses, fixed typos.
+                     Published as RFC 2571.
+                    "
+       REVISION     "199711200000Z"         -- 20 November 1997
+       DESCRIPTION  "The initial version, published in RFC 2271.
+                    "
+       ::= { snmpModules 10 }
+
+   -- Textual Conventions used in the SNMP Management Architecture ***
+
+SnmpEngineID ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION "An SNMP engine's administratively-unique identifier.
+                 Objects of this type are for identification, not for
+                 addressing, even though it is possible that an
+                 address may have been used in the generation of
+                 a specific value.
+
+                 The value for this object may not be all zeros or
+                 all 'ff'H or the empty (zero length) string.
+
+                 The initial value for this object may be configured
+                 via an operator console entry or via an algorithmic
+                 function.  In the latter case, the following
+                 example algorithm is recommended.
+
+                 In cases where there are multiple engines on the
+                 same system, the use of this algorithm is NOT
+                 appropriate, as it would result in all of those
+                 engines ending up with the same ID value.
+
+                 1) The very first bit is used to indicate how the
+                    rest of the data is composed.
+
+                    0 - as defined by enterprise using former methods
+                        that existed before SNMPv3. See item 2 below.
+
+                    1 - as defined by this architecture, see item 3
+                        below.
+
+                    Note that this allows existing uses of the
+                    engineID (also known as AgentID [RFC1910]) to
+                    co-exist with any new uses.
+
+                 2) The snmpEngineID has a length of 12 octets.
+
+                    The first four octets are set to the binary
+                    equivalent of the agent's SNMP management
+                    private enterprise number as assigned by the
+                    Internet Assigned Numbers Authority (IANA).
+                    For example, if Acme Networks has been assigned
+                    { enterprises 696 }, the first four octets would
+                    be assigned '000002b8'H.
+
+                    The remaining eight octets are determined via
+                    one or more enterprise-specific methods. Such
+                    methods must be designed so as to maximize the
+                    possibility that the value of this object will
+                    be unique in the agent's administrative domain.
+                    For example, it may be the IP address of the SNMP
+                    entity, or the MAC address of one of the
+                    interfaces, with each address suitably padded
+                    with random octets.  If multiple methods are
+                    defined, then it is recommended that the first
+                    octet indicate the method being used and the
+                    remaining octets be a function of the method.
+
+                 3) The length of the octet string varies.
+
+                    The first four octets are set to the binary
+                    equivalent of the agent's SNMP management
+                    private enterprise number as assigned by the
+                    Internet Assigned Numbers Authority (IANA).
+                    For example, if Acme Networks has been assigned
+                    { enterprises 696 }, the first four octets would
+                    be assigned '000002b8'H.
+
+                    The very first bit is set to 1. For example, the
+                    above value for Acme Networks now changes to be
+                    '800002b8'H.
+
+                    The fifth octet indicates how the rest (6th and
+                    following octets) are formatted. The values for
+                    the fifth octet are:
+
+                      0     - reserved, unused.
+
+                      1     - IPv4 address (4 octets)
+                              lowest non-special IP address
+
+                      2     - IPv6 address (16 octets)
+                              lowest non-special IP address
+
+                      3     - MAC address (6 octets)
+                              lowest IEEE MAC address, canonical
+                              order
+
+                      4     - Text, administratively assigned
+                              Maximum remaining length 27
+
+                      5     - Octets, administratively assigned
+                              Maximum remaining length 27
+
+                      6-127 - reserved, unused
+
+                    128-255 - as defined by the enterprise
+                              Maximum remaining length 27
+                "
+    SYNTAX       OCTET STRING (SIZE(5..32))
+
+SnmpSecurityModel ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION "An identifier that uniquely identifies a
+                 Security Model of the Security Subsystem within
+                 this SNMP Management Architecture.
+
+                 The values for securityModel are allocated as
+                 follows:
+
+                 - The zero value does not identify any particular
+                   security model.
+
+                 - Values between 1 and 255, inclusive, are reserved
+                   for standards-track Security Models and are
+                   managed by the Internet Assigned Numbers Authority
+                   (IANA).
+                 - Values greater than 255 are allocated to
+                   enterprise-specific Security Models.  An
+                   enterprise-specific securityModel value is defined
+                   to be:
+
+                   enterpriseID * 256 + security model within
+                   enterprise
+
+                   For example, the fourth Security Model defined by
+                   the enterprise whose enterpriseID is 1 would be
+                   259.
+
+                 This scheme for allocation of securityModel
+                 values allows for a maximum of 255 standards-
+                 based Security Models, and for a maximum of
+                 256 Security Models per enterprise.
+
+                 It is believed that the assignment of new
+                 securityModel values will be rare in practice
+                 because the larger the number of simultaneously
+                 utilized Security Models, the larger the
+                 chance that interoperability will suffer.
+                 Consequently, it is believed that such a range
+                 will be sufficient.  In the unlikely event that
+                 the standards committee finds this number to be
+                 insufficient over time, an enterprise number
+                 can be allocated to obtain an additional 256
+                 possible values.
+
+                 Note that the most significant bit must be zero;
+                 hence, there are 23 bits allocated for various
+                 organizations to design and define non-standard
+
+                 securityModels.  This limits the ability to
+                 define new proprietary implementations of Security
+                 Models to the first 8,388,608 enterprises.
+
+                 It is worthwhile to note that, in its encoded
+                 form, the securityModel value will normally
+                 require only a single byte since, in practice,
+                 the leftmost bits will be zero for most messages
+                 and sign extension is suppressed by the encoding
+                 rules.
+
+                 As of this writing, there are several values
+                 of securityModel defined for use with SNMP or
+                 reserved for use with supporting MIB objects.
+                 They are as follows:
+
+                     0  reserved for 'any'
+                     1  reserved for SNMPv1
+                     2  reserved for SNMPv2c
+                     3  User-Based Security Model (USM)
+                "
+    SYNTAX       INTEGER(0 .. 2147483647)
+
+SnmpMessageProcessingModel ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION "An identifier that uniquely identifies a Message
+                 Processing Model of the Message Processing
+                 Subsystem within this SNMP Management Architecture.
+
+                 The values for messageProcessingModel are
+                 allocated as follows:
+
+                 - Values between 0 and 255, inclusive, are
+                   reserved for standards-track Message Processing
+                   Models and are managed by the Internet Assigned
+                   Numbers Authority (IANA).
+
+                 - Values greater than 255 are allocated to
+                   enterprise-specific Message Processing Models.
+                   An enterprise messageProcessingModel value is
+                   defined to be:
+
+                   enterpriseID * 256 +
+                        messageProcessingModel within enterprise
+
+                   For example, the fourth Message Processing Model
+                   defined by the enterprise whose enterpriseID
+
+                   is 1 would be 259.
+
+                 This scheme for allocating messageProcessingModel
+                 values allows for a maximum of 255 standards-
+                 based Message Processing Models, and for a
+                 maximum of 256 Message Processing Models per
+                 enterprise.
+
+                 It is believed that the assignment of new
+                 messageProcessingModel values will be rare
+                 in practice because the larger the number of
+                 simultaneously utilized Message Processing Models,
+                 the larger the chance that interoperability
+                 will suffer. It is believed that such a range
+                 will be sufficient.  In the unlikely event that
+                 the standards committee finds this number to be
+                 insufficient over time, an enterprise number
+                 can be allocated to obtain an additional 256
+                 possible values.
+
+                 Note that the most significant bit must be zero;
+                 hence, there are 23 bits allocated for various
+                 organizations to design and define non-standard
+                 messageProcessingModels.  This limits the ability
+                 to define new proprietary implementations of
+                 Message Processing Models to the first 8,388,608
+                 enterprises.
+
+                 It is worthwhile to note that, in its encoded
+                 form, the messageProcessingModel value will
+                 normally require only a single byte since, in
+                 practice, the leftmost bits will be zero for
+                 most messages and sign extension is suppressed
+                 by the encoding rules.
+
+                 As of this writing, there are several values of
+                 messageProcessingModel defined for use with SNMP.
+                 They are as follows:
+
+                     0  reserved for SNMPv1
+                     1  reserved for SNMPv2c
+                     2  reserved for SNMPv2u and SNMPv2*
+                     3  reserved for SNMPv3
+                "
+    SYNTAX       INTEGER(0 .. 2147483647)
+
+SnmpSecurityLevel ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION "A Level of Security at which SNMP messages can be
+                 sent or with which operations are being processed;
+                 in particular, one of:
+
+                   noAuthNoPriv - without authentication and
+                                  without privacy,
+                   authNoPriv   - with authentication but
+                                  without privacy,
+                   authPriv     - with authentication and
+                                  with privacy.
+
+                 These three values are ordered such that
+                 noAuthNoPriv is less than authNoPriv and
+                 authNoPriv is less than authPriv.
+                "
+    SYNTAX       INTEGER { noAuthNoPriv(1),
+                           authNoPriv(2),
+                           authPriv(3)
+                         }
+
+SnmpAdminString ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "255t"
+    STATUS       current
+    DESCRIPTION "An octet string containing administrative
+                 information, preferably in human-readable form.
+
+                 To facilitate internationalization, this
+                 information is represented using the ISO/IEC
+                 IS 10646-1 character set, encoded as an octet
+                 string using the UTF-8 transformation format
+                 described in [RFC2279].
+
+                 Since additional code points are added by
+                 amendments to the 10646 standard from time
+                 to time, implementations must be prepared to
+                 encounter any code point from 0x00000000 to
+                 0x7fffffff.  Byte sequences that do not
+                 correspond to the valid UTF-8 encoding of a
+                 code point or are outside this range are
+                 prohibited.
+
+                 The use of control codes should be avoided.
+
+                 When it is necessary to represent a newline,
+                 the control code sequence CR LF should be used.
+
+                 The use of leading or trailing white space should
+                 be avoided.
+
+                 For code points not directly supported by user
+                 interface hardware or software, an alternative
+                 means of entry and display, such as hexadecimal,
+                 may be provided.
+
+                 For information encoded in 7-bit US-ASCII,
+                 the UTF-8 encoding is identical to the
+                 US-ASCII encoding.
+
+                 UTF-8 may require multiple bytes to represent a
+                 single character / code point; thus the length
+                 of this object in octets may be different from
+                 the number of characters encoded.  Similarly,
+                 size constraints refer to the number of encoded
+                 octets, not the number of characters represented
+                 by an encoding.
+
+                 Note that when this TC is used for an object that
+                 is used or envisioned to be used as an index, then
+                 a SIZE restriction MUST be specified so that the
+                 number of sub-identifiers for any object instance
+                 does not exceed the limit of 128, as defined by
+                 [RFC3416].
+
+                 Note that the size of an SnmpAdminString object is
+                 measured in octets, not characters.
+                "
+    SYNTAX       OCTET STRING (SIZE (0..255))
+
+-- Administrative assignments ***************************************
+
+snmpFrameworkAdmin
+    OBJECT IDENTIFIER ::= { snmpFrameworkMIB 1 }
+snmpFrameworkMIBObjects
+    OBJECT IDENTIFIER ::= { snmpFrameworkMIB 2 }
+snmpFrameworkMIBConformance
+    OBJECT IDENTIFIER ::= { snmpFrameworkMIB 3 }
+
+-- the snmpEngine Group ********************************************
+
+snmpEngine OBJECT IDENTIFIER ::= { snmpFrameworkMIBObjects 1 }
+
+snmpEngineID     OBJECT-TYPE
+    SYNTAX       SnmpEngineID
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION "An SNMP engine's administratively-unique identifier.
+
+                 This information SHOULD be stored in non-volatile
+                 storage so that it remains constant across
+                 re-initializations of the SNMP engine.
+                "
+    ::= { snmpEngine 1 }
+
+snmpEngineBoots  OBJECT-TYPE
+    SYNTAX       INTEGER (1..2147483647)
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION "The number of times that the SNMP engine has
+                 (re-)initialized itself since snmpEngineID
+                 was last configured.
+                "
+    ::= { snmpEngine 2 }
+
+snmpEngineTime   OBJECT-TYPE
+    SYNTAX       INTEGER (0..2147483647)
+    UNITS        "seconds"
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION "The number of seconds since the value of
+                 the snmpEngineBoots object last changed.
+                 When incrementing this object's value would
+                 cause it to exceed its maximum,
+                 snmpEngineBoots is incremented as if a
+                 re-initialization had occurred, and this
+                 object's value consequently reverts to zero.
+                "
+    ::= { snmpEngine 3 }
+
+snmpEngineMaxMessageSize OBJECT-TYPE
+    SYNTAX       INTEGER (484..2147483647)
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION "The maximum length in octets of an SNMP message
+                 which this SNMP engine can send or receive and
+                 process, determined as the minimum of the maximum
+                 message size values supported among all of the
+                 transports available to and supported by the engine.
+                "
+    ::= { snmpEngine 4 }
+
+-- Registration Points for Authentication and Privacy Protocols **
+
+snmpAuthProtocols OBJECT-IDENTITY
+    STATUS        current
+    DESCRIPTION  "Registration point for standards-track
+                  authentication protocols used in SNMP Management
+                  Frameworks.
+                 "
+    ::= { snmpFrameworkAdmin 1 }
+
+snmpPrivProtocols OBJECT-IDENTITY
+    STATUS        current
+    DESCRIPTION  "Registration point for standards-track privacy
+                  protocols used in SNMP Management Frameworks.
+                 "
+    ::= { snmpFrameworkAdmin 2 }
+
+-- Conformance information ******************************************
+
+snmpFrameworkMIBCompliances
+               OBJECT IDENTIFIER ::= {snmpFrameworkMIBConformance 1}
+snmpFrameworkMIBGroups
+               OBJECT IDENTIFIER ::= {snmpFrameworkMIBConformance 2}
+
+-- compliance statements
+
+snmpFrameworkMIBCompliance MODULE-COMPLIANCE
+    STATUS       current
+    DESCRIPTION "The compliance statement for SNMP engines which
+                 implement the SNMP Management Framework MIB.
+                "
+    MODULE    -- this module
+        MANDATORY-GROUPS { snmpEngineGroup }
+    ::= { snmpFrameworkMIBCompliances 1 }
+
+-- units of conformance
+
+snmpEngineGroup OBJECT-GROUP
+    OBJECTS {
+              snmpEngineID,
+              snmpEngineBoots,
+              snmpEngineTime,
+              snmpEngineMaxMessageSize
+            }
+    STATUS       current
+    DESCRIPTION "A collection of objects for identifying and
+                 determining the configuration and current timeliness
+
+                 values of an SNMP engine.
+                "
+    ::= { snmpFrameworkMIBGroups 1 }
+
+END

--- a/services/monitoring/assets/snmp/mibs/SNMPv2-MIB
+++ b/services/monitoring/assets/snmp/mibs/SNMPv2-MIB
@@ -1,0 +1,854 @@
+SNMPv2-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+    TimeTicks, Counter32, snmpModules, mib-2
+        FROM SNMPv2-SMI
+    DisplayString, TestAndIncr, TimeStamp
+
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF;
+
+snmpMIB MODULE-IDENTITY
+    LAST-UPDATED "200210160000Z"
+    ORGANIZATION "IETF SNMPv3 Working Group"
+    CONTACT-INFO
+            "WG-EMail:   snmpv3@lists.tislabs.com
+             Subscribe:  snmpv3-request@lists.tislabs.com
+
+             Co-Chair:   Russ Mundy
+                         Network Associates Laboratories
+             postal:     15204 Omega Drive, Suite 300
+                         Rockville, MD 20850-4601
+                         USA
+             EMail:      mundy@tislabs.com
+             phone:      +1 301 947-7107
+
+             Co-Chair:   David Harrington
+                         Enterasys Networks
+             postal:     35 Industrial Way
+                         P. O. Box 5005
+                         Rochester, NH 03866-5005
+                         USA
+             EMail:      dbh@enterasys.com
+             phone:      +1 603 337-2614
+
+             Editor:     Randy Presuhn
+                         BMC Software, Inc.
+             postal:     2141 North First Street
+                         San Jose, CA 95131
+                         USA
+             EMail:      randy_presuhn@bmc.com
+             phone:      +1 408 546-1006"
+    DESCRIPTION
+            "The MIB module for SNMP entities.
+
+             Copyright (C) The Internet Society (2002). This
+             version of this MIB module is part of RFC 3418;
+             see the RFC itself for full legal notices.
+            "
+    REVISION      "200210160000Z"
+    DESCRIPTION
+            "This revision of this MIB module was published as
+             RFC 3418."
+    REVISION      "199511090000Z"
+    DESCRIPTION
+            "This revision of this MIB module was published as
+             RFC 1907."
+    REVISION      "199304010000Z"
+    DESCRIPTION
+            "The initial revision of this MIB module was published
+            as RFC 1450."
+    ::= { snmpModules 1 }
+
+snmpMIBObjects OBJECT IDENTIFIER ::= { snmpMIB 1 }
+
+--  ::= { snmpMIBObjects 1 }        this OID is obsolete
+--  ::= { snmpMIBObjects 2 }        this OID is obsolete
+--  ::= { snmpMIBObjects 3 }        this OID is obsolete
+
+-- the System group
+--
+-- a collection of objects common to all managed systems.
+
+system   OBJECT IDENTIFIER ::= { mib-2 1 }
+
+sysDescr OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A textual description of the entity.  This value should
+            include the full name and version identification of
+            the system's hardware type, software operating-system,
+            and networking software."
+    ::= { system 1 }
+
+sysObjectID OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The vendor's authoritative identification of the
+            network management subsystem contained in the entity.
+            This value is allocated within the SMI enterprises
+            subtree (1.3.6.1.4.1) and provides an easy and
+            unambiguous means for determining `what kind of box' is
+            being managed.  For example, if vendor `Flintstones,
+            Inc.' was assigned the subtree 1.3.6.1.4.1.424242,
+            it could assign the identifier 1.3.6.1.4.1.424242.1.1
+            to its `Fred Router'."
+    ::= { system 2 }
+
+sysUpTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "The time (in hundredths of a second) since the
+            network management portion of the system was last
+            re-initialized."
+    ::= { system 3 }
+
+sysContact OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "The textual identification of the contact person for
+            this managed node, together with information on how
+            to contact this person.  If no contact information is
+            known, the value is the zero-length string."
+    ::= { system 4 }
+
+sysName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "An administratively-assigned name for this managed
+            node.  By convention, this is the node's fully-qualified
+            domain name.  If the name is unknown, the value is
+            the zero-length string."
+    ::= { system 5 }
+
+sysLocation OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "The physical location of this node (e.g., 'telephone
+            closet, 3rd floor').  If the location is unknown, the
+            value is the zero-length string."
+    ::= { system 6 }
+
+sysServices OBJECT-TYPE
+    SYNTAX      INTEGER (0..127)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "A value which indicates the set of services that this
+            entity may potentially offer.  The value is a sum.
+
+            This sum initially takes the value zero. Then, for
+            each layer, L, in the range 1 through 7, that this node
+            performs transactions for, 2 raised to (L - 1) is added
+            to the sum.  For example, a node which performs only
+            routing functions would have a value of 4 (2^(3-1)).
+            In contrast, a node which is a host offering application
+            services would have a value of 72 (2^(4-1) + 2^(7-1)).
+            Note that in the context of the Internet suite of
+            protocols, values should be calculated accordingly:
+
+                 layer      functionality
+                   1        physical (e.g., repeaters)
+                   2        datalink/subnetwork (e.g., bridges)
+                   3        internet (e.g., supports the IP)
+                   4        end-to-end  (e.g., supports the TCP)
+                   7        applications (e.g., supports the SMTP)
+
+            For systems including OSI protocols, layers 5 and 6
+            may also be counted."
+    ::= { system 7 }
+
+-- object resource information
+--
+-- a collection of objects which describe the SNMP entity's
+-- (statically and dynamically configurable) support of
+-- various MIB modules.
+
+sysORLastChange OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The value of sysUpTime at the time of the most recent
+            change in state or value of any instance of sysORID."
+    ::= { system 8 }
+
+sysORTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF SysOREntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The (conceptual) table listing the capabilities of
+            the local SNMP application acting as a command
+            responder with respect to various MIB modules.
+            SNMP entities having dynamically-configurable support
+            of MIB modules will have a dynamically-varying number
+            of conceptual rows."
+    ::= { system 9 }
+
+sysOREntry OBJECT-TYPE
+    SYNTAX     SysOREntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "An entry (conceptual row) in the sysORTable."
+    INDEX      { sysORIndex }
+    ::= { sysORTable 1 }
+
+SysOREntry ::= SEQUENCE {
+    sysORIndex     INTEGER,
+    sysORID        OBJECT IDENTIFIER,
+    sysORDescr     DisplayString,
+    sysORUpTime    TimeStamp
+}
+
+sysORIndex OBJECT-TYPE
+    SYNTAX     INTEGER (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION
+            "The auxiliary variable used for identifying instances
+            of the columnar objects in the sysORTable."
+    ::= { sysOREntry 1 }
+
+sysORID OBJECT-TYPE
+    SYNTAX     OBJECT IDENTIFIER
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "An authoritative identification of a capabilities
+            statement with respect to various MIB modules supported
+            by the local SNMP application acting as a command
+            responder."
+    ::= { sysOREntry 2 }
+
+sysORDescr OBJECT-TYPE
+    SYNTAX     DisplayString
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "A textual description of the capabilities identified
+            by the corresponding instance of sysORID."
+    ::= { sysOREntry 3 }
+
+sysORUpTime OBJECT-TYPE
+    SYNTAX     TimeStamp
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The value of sysUpTime at the time this conceptual
+            row was last instantiated."
+    ::= { sysOREntry 4 }
+
+-- the SNMP group
+--
+-- a collection of objects providing basic instrumentation and
+-- control of an SNMP entity.
+
+snmp     OBJECT IDENTIFIER ::= { mib-2 11 }
+
+snmpInPkts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The total number of messages delivered to the SNMP
+            entity from the transport service."
+    ::= { snmp 1 }
+
+snmpInBadVersions OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The total number of SNMP messages which were delivered
+            to the SNMP entity and were for an unsupported SNMP
+            version."
+    ::= { snmp 3 }
+
+snmpInBadCommunityNames OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of community-based SNMP messages (for
+           example,  SNMPv1) delivered to the SNMP entity which
+           used an SNMP community name not known to said entity.
+           Also, implementations which authenticate community-based
+           SNMP messages using check(s) in addition to matching
+           the community name (for example, by also checking
+           whether the message originated from a transport address
+           allowed to use a specified community name) MAY include
+           in this value the number of messages which failed the
+           additional check(s).  It is strongly RECOMMENDED that
+
+           the documentation for any security model which is used
+           to authenticate community-based SNMP messages specify
+           the precise conditions that contribute to this value."
+    ::= { snmp 4 }
+
+snmpInBadCommunityUses OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of community-based SNMP messages (for
+           example, SNMPv1) delivered to the SNMP entity which
+           represented an SNMP operation that was not allowed for
+           the SNMP community named in the message.  The precise
+           conditions under which this counter is incremented
+           (if at all) depend on how the SNMP entity implements
+           its access control mechanism and how its applications
+           interact with that access control mechanism.  It is
+           strongly RECOMMENDED that the documentation for any
+           access control mechanism which is used to control access
+           to and visibility of MIB instrumentation specify the
+           precise conditions that contribute to this value."
+    ::= { snmp 5 }
+
+snmpInASNParseErrs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The total number of ASN.1 or BER errors encountered by
+            the SNMP entity when decoding received SNMP messages."
+    ::= { snmp 6 }
+
+snmpEnableAuthenTraps OBJECT-TYPE
+    SYNTAX      INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION
+            "Indicates whether the SNMP entity is permitted to
+            generate authenticationFailure traps.  The value of this
+            object overrides any configuration information; as such,
+            it provides a means whereby all authenticationFailure
+            traps may be disabled.
+
+            Note that it is strongly recommended that this object
+            be stored in non-volatile memory so that it remains
+            constant across re-initializations of the network
+            management system."
+    ::= { snmp 30 }
+
+snmpSilentDrops OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+           "The total number of Confirmed Class PDUs (such as
+           GetRequest-PDUs, GetNextRequest-PDUs,
+           GetBulkRequest-PDUs, SetRequest-PDUs, and
+           InformRequest-PDUs) delivered to the SNMP entity which
+           were silently dropped because the size of a reply
+           containing an alternate Response Class PDU (such as a
+           Response-PDU) with an empty variable-bindings field
+           was greater than either a local constraint or the
+           maximum message size associated with the originator of
+           the request."
+    ::= { snmp 31 }
+
+snmpProxyDrops OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION
+            "The total number of Confirmed Class PDUs
+            (such as GetRequest-PDUs, GetNextRequest-PDUs,
+            GetBulkRequest-PDUs, SetRequest-PDUs, and
+            InformRequest-PDUs) delivered to the SNMP entity which
+            were silently dropped because the transmission of
+            the (possibly translated) message to a proxy target
+            failed in a manner (other than a time-out) such that
+            no Response Class PDU (such as a Response-PDU) could
+            be returned."
+    ::= { snmp 32 }
+
+-- information for notifications
+--
+-- a collection of objects which allow the SNMP entity, when
+-- supporting a notification originator application,
+-- to be configured to generate SNMPv2-Trap-PDUs.
+
+snmpTrap       OBJECT IDENTIFIER ::= { snmpMIBObjects 4 }
+
+snmpTrapOID OBJECT-TYPE
+    SYNTAX     OBJECT IDENTIFIER
+    MAX-ACCESS accessible-for-notify
+    STATUS     current
+    DESCRIPTION
+            "The authoritative identification of the notification
+            currently being sent.  This variable occurs as
+            the second varbind in every SNMPv2-Trap-PDU and
+            InformRequest-PDU."
+    ::= { snmpTrap 1 }
+
+--  ::= { snmpTrap 2 }   this OID is obsolete
+
+snmpTrapEnterprise OBJECT-TYPE
+    SYNTAX     OBJECT IDENTIFIER
+    MAX-ACCESS accessible-for-notify
+    STATUS     current
+    DESCRIPTION
+            "The authoritative identification of the enterprise
+            associated with the trap currently being sent.  When an
+            SNMP proxy agent is mapping an RFC1157 Trap-PDU
+            into a SNMPv2-Trap-PDU, this variable occurs as the
+            last varbind."
+    ::= { snmpTrap 3 }
+
+--  ::= { snmpTrap 4 }   this OID is obsolete
+
+-- well-known traps
+
+snmpTraps      OBJECT IDENTIFIER ::= { snmpMIBObjects 5 }
+
+coldStart NOTIFICATION-TYPE
+    STATUS  current
+    DESCRIPTION
+            "A coldStart trap signifies that the SNMP entity,
+            supporting a notification originator application, is
+            reinitializing itself and that its configuration may
+            have been altered."
+    ::= { snmpTraps 1 }
+
+warmStart NOTIFICATION-TYPE
+    STATUS  current
+    DESCRIPTION
+            "A warmStart trap signifies that the SNMP entity,
+            supporting a notification originator application,
+            is reinitializing itself such that its configuration
+            is unaltered."
+    ::= { snmpTraps 2 }
+
+-- Note the linkDown NOTIFICATION-TYPE ::= { snmpTraps 3 }
+-- and the linkUp NOTIFICATION-TYPE ::= { snmpTraps 4 }
+-- are defined in RFC 2863 [RFC2863]
+
+authenticationFailure NOTIFICATION-TYPE
+    STATUS  current
+    DESCRIPTION
+            "An authenticationFailure trap signifies that the SNMP
+             entity has received a protocol message that is not
+             properly authenticated.  While all implementations
+             of SNMP entities MAY be capable of generating this
+             trap, the snmpEnableAuthenTraps object indicates
+             whether this trap will be generated."
+    ::= { snmpTraps 5 }
+
+-- Note the egpNeighborLoss notification is defined
+-- as { snmpTraps 6 } in RFC 1213
+
+-- the set group
+--
+-- a collection of objects which allow several cooperating
+-- command generator applications to coordinate their use of the
+-- set operation.
+
+snmpSet        OBJECT IDENTIFIER ::= { snmpMIBObjects 6 }
+
+snmpSetSerialNo OBJECT-TYPE
+    SYNTAX     TestAndIncr
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION
+            "An advisory lock used to allow several cooperating
+            command generator applications to coordinate their
+            use of the SNMP set operation.
+
+            This object is used for coarse-grain coordination.
+            To achieve fine-grain coordination, one or more similar
+            objects might be defined within each MIB group, as
+            appropriate."
+    ::= { snmpSet 1 }
+
+-- conformance information
+
+snmpMIBConformance
+               OBJECT IDENTIFIER ::= { snmpMIB 2 }
+
+snmpMIBCompliances
+               OBJECT IDENTIFIER ::= { snmpMIBConformance 1 }
+snmpMIBGroups  OBJECT IDENTIFIER ::= { snmpMIBConformance 2 }
+
+-- compliance statements
+
+--    ::= { snmpMIBCompliances 1 }      this OID is obsolete
+snmpBasicCompliance MODULE-COMPLIANCE
+    STATUS  deprecated
+    DESCRIPTION
+            "The compliance statement for SNMPv2 entities which
+            implement the SNMPv2 MIB.
+
+            This compliance statement is replaced by
+            snmpBasicComplianceRev2."
+    MODULE  -- this module
+        MANDATORY-GROUPS { snmpGroup, snmpSetGroup, systemGroup,
+                           snmpBasicNotificationsGroup }
+
+        GROUP   snmpCommunityGroup
+        DESCRIPTION
+            "This group is mandatory for SNMPv2 entities which
+            support community-based authentication."
+    ::= { snmpMIBCompliances 2 }
+
+snmpBasicComplianceRev2 MODULE-COMPLIANCE
+    STATUS  current
+    DESCRIPTION
+            "The compliance statement for SNMP entities which
+            implement this MIB module."
+    MODULE  -- this module
+        MANDATORY-GROUPS { snmpGroup, snmpSetGroup, systemGroup,
+                           snmpBasicNotificationsGroup }
+
+        GROUP   snmpCommunityGroup
+        DESCRIPTION
+            "This group is mandatory for SNMP entities which
+            support community-based authentication."
+
+        GROUP   snmpWarmStartNotificationGroup
+        DESCRIPTION
+            "This group is mandatory for an SNMP entity which
+            supports command responder applications, and is
+            able to reinitialize itself such that its
+            configuration is unaltered."
+    ::= { snmpMIBCompliances 3 }
+
+-- units of conformance
+
+--  ::= { snmpMIBGroups 1 }           this OID is obsolete
+--  ::= { snmpMIBGroups 2 }           this OID is obsolete
+--  ::= { snmpMIBGroups 3 }           this OID is obsolete
+
+--  ::= { snmpMIBGroups 4 }           this OID is obsolete
+
+snmpGroup OBJECT-GROUP
+    OBJECTS { snmpInPkts,
+              snmpInBadVersions,
+              snmpInASNParseErrs,
+              snmpSilentDrops,
+              snmpProxyDrops,
+              snmpEnableAuthenTraps }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing basic instrumentation
+            and control of an SNMP entity."
+    ::= { snmpMIBGroups 8 }
+
+snmpCommunityGroup OBJECT-GROUP
+    OBJECTS { snmpInBadCommunityNames,
+              snmpInBadCommunityUses }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects providing basic instrumentation
+            of a SNMP entity which supports community-based
+            authentication."
+    ::= { snmpMIBGroups 9 }
+
+snmpSetGroup OBJECT-GROUP
+    OBJECTS { snmpSetSerialNo }
+    STATUS  current
+    DESCRIPTION
+            "A collection of objects which allow several cooperating
+            command generator applications to coordinate their
+            use of the set operation."
+    ::= { snmpMIBGroups 5 }
+
+systemGroup OBJECT-GROUP
+    OBJECTS { sysDescr, sysObjectID, sysUpTime,
+              sysContact, sysName, sysLocation,
+              sysServices,
+              sysORLastChange, sysORID,
+              sysORUpTime, sysORDescr }
+    STATUS  current
+    DESCRIPTION
+            "The system group defines objects which are common to all
+            managed systems."
+    ::= { snmpMIBGroups 6 }
+
+snmpBasicNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS { coldStart, authenticationFailure }
+    STATUS        current
+    DESCRIPTION
+       "The basic notifications implemented by an SNMP entity
+        supporting command responder applications."
+    ::= { snmpMIBGroups 7 }
+
+snmpWarmStartNotificationGroup NOTIFICATION-GROUP
+   NOTIFICATIONS { warmStart }
+   STATUS        current
+   DESCRIPTION
+     "An additional notification for an SNMP entity supporting
+     command responder applications, if it is able to reinitialize
+     itself such that its configuration is unaltered."
+  ::= { snmpMIBGroups 11 }
+
+snmpNotificationGroup OBJECT-GROUP
+    OBJECTS { snmpTrapOID, snmpTrapEnterprise }
+    STATUS  current
+    DESCRIPTION
+            "These objects are required for entities
+            which support notification originator applications."
+    ::= { snmpMIBGroups 12 }
+
+-- definitions in RFC 1213 made obsolete by the inclusion of a
+-- subset of the snmp group in this MIB
+
+snmpOutPkts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Messages which were
+            passed from the SNMP protocol entity to the
+            transport service."
+    ::= { snmp 2 }
+
+-- { snmp 7 } is not used
+
+snmpInTooBigs OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP PDUs which were
+            delivered to the SNMP protocol entity and for
+            which the value of the error-status field was
+            `tooBig'."
+    ::= { snmp 8 }
+
+snmpInNoSuchNames OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP PDUs which were
+            delivered to the SNMP protocol entity and for
+            which the value of the error-status field was
+            `noSuchName'."
+    ::= { snmp 9 }
+
+snmpInBadValues OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP PDUs which were
+            delivered to the SNMP protocol entity and for
+            which the value of the error-status field was
+            `badValue'."
+    ::= { snmp 10 }
+
+snmpInReadOnlys OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number valid SNMP PDUs which were delivered
+            to the SNMP protocol entity and for which the value
+            of the error-status field was `readOnly'.  It should
+            be noted that it is a protocol error to generate an
+            SNMP PDU which contains the value `readOnly' in the
+            error-status field, as such this object is provided
+            as a means of detecting incorrect implementations of
+            the SNMP."
+    ::= { snmp 11 }
+
+snmpInGenErrs OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP PDUs which were delivered
+            to the SNMP protocol entity and for which the value
+            of the error-status field was `genErr'."
+    ::= { snmp 12 }
+
+snmpInTotalReqVars OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of MIB objects which have been
+            retrieved successfully by the SNMP protocol entity
+            as the result of receiving valid SNMP Get-Request
+            and Get-Next PDUs."
+    ::= { snmp 13 }
+
+snmpInTotalSetVars OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of MIB objects which have been
+            altered successfully by the SNMP protocol entity as
+            the result of receiving valid SNMP Set-Request PDUs."
+    ::= { snmp 14 }
+
+snmpInGetRequests OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Get-Request PDUs which
+            have been accepted and processed by the SNMP
+            protocol entity."
+    ::= { snmp 15 }
+
+snmpInGetNexts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Get-Next PDUs which have been
+            accepted and processed by the SNMP protocol entity."
+    ::= { snmp 16 }
+
+snmpInSetRequests OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Set-Request PDUs which
+            have been accepted and processed by the SNMP protocol
+            entity."
+    ::= { snmp 17 }
+
+snmpInGetResponses OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Get-Response PDUs which
+            have been accepted and processed by the SNMP protocol
+            entity."
+    ::= { snmp 18 }
+
+snmpInTraps OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Trap PDUs which have been
+            accepted and processed by the SNMP protocol entity."
+    ::= { snmp 19 }
+
+snmpOutTooBigs OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP PDUs which were generated
+            by the SNMP protocol entity and for which the value
+            of the error-status field was `tooBig.'"
+    ::= { snmp 20 }
+
+snmpOutNoSuchNames OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP PDUs which were generated
+            by the SNMP protocol entity and for which the value
+            of the error-status was `noSuchName'."
+    ::= { snmp 21 }
+
+snmpOutBadValues OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP PDUs which were generated
+            by the SNMP protocol entity and for which the value
+            of the error-status field was `badValue'."
+    ::= { snmp 22 }
+
+-- { snmp 23 } is not used
+
+snmpOutGenErrs OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP PDUs which were generated
+            by the SNMP protocol entity and for which the value
+            of the error-status field was `genErr'."
+    ::= { snmp 24 }
+
+snmpOutGetRequests OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Get-Request PDUs which
+            have been generated by the SNMP protocol entity."
+    ::= { snmp 25 }
+
+snmpOutGetNexts OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Get-Next PDUs which have
+            been generated by the SNMP protocol entity."
+    ::= { snmp 26 }
+
+snmpOutSetRequests OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Set-Request PDUs which
+            have been generated by the SNMP protocol entity."
+    ::= { snmp 27 }
+
+snmpOutGetResponses OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Get-Response PDUs which
+            have been generated by the SNMP protocol entity."
+    ::= { snmp 28 }
+
+snmpOutTraps OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      obsolete
+    DESCRIPTION
+            "The total number of SNMP Trap PDUs which have
+            been generated by the SNMP protocol entity."
+    ::= { snmp 29 }
+
+snmpObsoleteGroup OBJECT-GROUP
+    OBJECTS { snmpOutPkts, snmpInTooBigs, snmpInNoSuchNames,
+              snmpInBadValues, snmpInReadOnlys, snmpInGenErrs,
+              snmpInTotalReqVars, snmpInTotalSetVars,
+              snmpInGetRequests, snmpInGetNexts, snmpInSetRequests,
+              snmpInGetResponses, snmpInTraps, snmpOutTooBigs,
+              snmpOutNoSuchNames, snmpOutBadValues,
+              snmpOutGenErrs, snmpOutGetRequests, snmpOutGetNexts,
+              snmpOutSetRequests, snmpOutGetResponses, snmpOutTraps
+              }
+    STATUS  obsolete
+    DESCRIPTION
+            "A collection of objects from RFC 1213 made obsolete
+            by this MIB module."
+    ::= { snmpMIBGroups 10 }
+
+END

--- a/services/monitoring/assets/snmp/mibs/SNMPv2-SMI
+++ b/services/monitoring/assets/snmp/mibs/SNMPv2-SMI
@@ -1,0 +1,344 @@
+SNMPv2-SMI DEFINITIONS ::= BEGIN
+
+-- the path to the root
+
+org            OBJECT IDENTIFIER ::= { iso 3 }  --  "iso" = 1
+dod            OBJECT IDENTIFIER ::= { org 6 }
+internet       OBJECT IDENTIFIER ::= { dod 1 }
+
+directory      OBJECT IDENTIFIER ::= { internet 1 }
+
+mgmt           OBJECT IDENTIFIER ::= { internet 2 }
+mib-2          OBJECT IDENTIFIER ::= { mgmt 1 }
+transmission   OBJECT IDENTIFIER ::= { mib-2 10 }
+
+experimental   OBJECT IDENTIFIER ::= { internet 3 }
+
+private        OBJECT IDENTIFIER ::= { internet 4 }
+enterprises    OBJECT IDENTIFIER ::= { private 1 }
+
+security       OBJECT IDENTIFIER ::= { internet 5 }
+
+snmpV2         OBJECT IDENTIFIER ::= { internet 6 }
+
+-- transport domains
+snmpDomains    OBJECT IDENTIFIER ::= { snmpV2 1 }
+
+-- transport proxies
+snmpProxys     OBJECT IDENTIFIER ::= { snmpV2 2 }
+
+-- module identities
+snmpModules    OBJECT IDENTIFIER ::= { snmpV2 3 }
+
+-- Extended UTCTime, to allow dates with four-digit years
+-- (Note that this definition of ExtUTCTime is not to be IMPORTed
+--  by MIB modules.)
+ExtUTCTime ::= OCTET STRING(SIZE(11 | 13))
+    -- format is YYMMDDHHMMZ or YYYYMMDDHHMMZ
+
+    --   where: YY   - last two digits of year (only years
+    --                 between 1900-1999)
+    --          YYYY - last four digits of the year (any year)
+    --          MM   - month (01 through 12)
+    --          DD   - day of month (01 through 31)
+    --          HH   - hours (00 through 23)
+    --          MM   - minutes (00 through 59)
+    --          Z    - denotes GMT (the ASCII character Z)
+    --
+    -- For example, "9502192015Z" and "199502192015Z" represent
+    -- 8:15pm GMT on 19 February 1995. Years after 1999 must use
+    -- the four digit year format. Years 1900-1999 may use the
+    -- two or four digit format.
+
+-- definitions for information modules
+
+MODULE-IDENTITY MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  "LAST-UPDATED" value(Update ExtUTCTime)
+                  "ORGANIZATION" Text
+                  "CONTACT-INFO" Text
+                  "DESCRIPTION" Text
+                  RevisionPart
+
+    VALUE NOTATION ::=
+                  value(VALUE OBJECT IDENTIFIER)
+
+    RevisionPart ::=
+                  Revisions
+                | empty
+    Revisions ::=
+                  Revision
+                | Revisions Revision
+    Revision ::=
+                  "REVISION" value(Update ExtUTCTime)
+                  "DESCRIPTION" Text
+
+    -- a character string as defined in section 3.1.1
+    Text ::= value(IA5String)
+END
+
+OBJECT-IDENTITY MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+
+                  ReferPart
+
+    VALUE NOTATION ::=
+                  value(VALUE OBJECT IDENTIFIER)
+
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+
+    -- a character string as defined in section 3.1.1
+    Text ::= value(IA5String)
+END
+
+-- names of objects
+-- (Note that these definitions of ObjectName and NotificationName
+--  are not to be IMPORTed by MIB modules.)
+
+ObjectName ::=
+    OBJECT IDENTIFIER
+
+NotificationName ::=
+    OBJECT IDENTIFIER
+
+-- syntax of objects
+
+-- the "base types" defined here are:
+--   3 built-in ASN.1 types: INTEGER, OCTET STRING, OBJECT IDENTIFIER
+--   8 application-defined types: Integer32, IpAddress, Counter32,
+--              Gauge32, Unsigned32, TimeTicks, Opaque, and Counter64
+
+ObjectSyntax ::=
+    CHOICE {
+        simple
+            SimpleSyntax,
+          -- note that SEQUENCEs for conceptual tables and
+          -- rows are not mentioned here...
+
+        application-wide
+            ApplicationSyntax
+    }
+
+-- built-in ASN.1 types
+
+SimpleSyntax ::=
+    CHOICE {
+        -- INTEGERs with a more restrictive range
+        -- may also be used
+        integer-value               -- includes Integer32
+            INTEGER (-2147483648..2147483647),
+        -- OCTET STRINGs with a more restrictive size
+        -- may also be used
+        string-value
+            OCTET STRING (SIZE (0..65535)),
+        objectID-value
+            OBJECT IDENTIFIER
+    }
+
+-- indistinguishable from INTEGER, but never needs more than
+-- 32-bits for a two's complement representation
+Integer32 ::=
+        INTEGER (-2147483648..2147483647)
+
+-- application-wide types
+
+ApplicationSyntax ::=
+    CHOICE {
+        ipAddress-value
+            IpAddress,
+        counter-value
+            Counter32,
+        timeticks-value
+            TimeTicks,
+        arbitrary-value
+            Opaque,
+        big-counter-value
+            Counter64,
+        unsigned-integer-value  -- includes Gauge32
+            Unsigned32
+    }
+
+-- in network-byte order
+
+-- (this is a tagged type for historical reasons)
+IpAddress ::=
+    [APPLICATION 0]
+        IMPLICIT OCTET STRING (SIZE (4))
+
+-- this wraps
+Counter32 ::=
+    [APPLICATION 1]
+        IMPLICIT INTEGER (0..4294967295)
+
+-- this doesn't wrap
+Gauge32 ::=
+    [APPLICATION 2]
+        IMPLICIT INTEGER (0..4294967295)
+
+-- an unsigned 32-bit quantity
+-- indistinguishable from Gauge32
+Unsigned32 ::=
+    [APPLICATION 2]
+        IMPLICIT INTEGER (0..4294967295)
+
+-- hundredths of seconds since an epoch
+TimeTicks ::=
+    [APPLICATION 3]
+        IMPLICIT INTEGER (0..4294967295)
+
+-- for backward-compatibility only
+Opaque ::=
+    [APPLICATION 4]
+        IMPLICIT OCTET STRING
+
+-- for counters that wrap in less than one hour with only 32 bits
+Counter64 ::=
+    [APPLICATION 6]
+        IMPLICIT INTEGER (0..18446744073709551615)
+
+-- definition for objects
+
+OBJECT-TYPE MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  "SYNTAX" Syntax
+                  UnitsPart
+                  "MAX-ACCESS" Access
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+
+                  IndexPart
+                  DefValPart
+
+    VALUE NOTATION ::=
+                  value(VALUE ObjectName)
+
+    Syntax ::=   -- Must be one of the following:
+                       -- a base type (or its refinement),
+                       -- a textual convention (or its refinement), or
+                       -- a BITS pseudo-type
+                   type
+                | "BITS" "{" NamedBits "}"
+
+    NamedBits ::= NamedBit
+                | NamedBits "," NamedBit
+
+    NamedBit ::=  identifier "(" number ")" -- number is nonnegative
+
+    UnitsPart ::=
+                  "UNITS" Text
+                | empty
+
+    Access ::=
+                  "not-accessible"
+                | "accessible-for-notify"
+                | "read-only"
+                | "read-write"
+                | "read-create"
+
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+
+    IndexPart ::=
+                  "INDEX"    "{" IndexTypes "}"
+                | "AUGMENTS" "{" Entry      "}"
+                | empty
+    IndexTypes ::=
+                  IndexType
+                | IndexTypes "," IndexType
+    IndexType ::=
+                  "IMPLIED" Index
+                | Index
+
+    Index ::=
+                    -- use the SYNTAX value of the
+                    -- correspondent OBJECT-TYPE invocation
+                  value(ObjectName)
+    Entry ::=
+                    -- use the INDEX value of the
+                    -- correspondent OBJECT-TYPE invocation
+                  value(ObjectName)
+
+    DefValPart ::= "DEFVAL" "{" Defvalue "}"
+                | empty
+
+    Defvalue ::=  -- must be valid for the type specified in
+                  -- SYNTAX clause of same OBJECT-TYPE macro
+                  value(ObjectSyntax)
+                | "{" BitsValue "}"
+
+    BitsValue ::= BitNames
+                | empty
+
+    BitNames ::=  BitName
+                | BitNames "," BitName
+
+    BitName ::= identifier
+
+    -- a character string as defined in section 3.1.1
+    Text ::= value(IA5String)
+END
+
+-- definitions for notifications
+
+NOTIFICATION-TYPE MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  ObjectsPart
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+
+    VALUE NOTATION ::=
+                  value(VALUE NotificationName)
+
+    ObjectsPart ::=
+                  "OBJECTS" "{" Objects "}"
+                | empty
+    Objects ::=
+                  Object
+
+                | Objects "," Object
+    Object ::=
+                  value(ObjectName)
+
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+
+    -- a character string as defined in section 3.1.1
+    Text ::= value(IA5String)
+END
+
+-- definitions of administrative identifiers
+
+zeroDotZero    OBJECT-IDENTITY
+    STATUS     current
+    DESCRIPTION
+            "A value used for null identifiers."
+    ::= { 0 0 }
+
+END

--- a/services/monitoring/assets/snmp/mibs/SNMPv2-TC
+++ b/services/monitoring/assets/snmp/mibs/SNMPv2-TC
@@ -1,0 +1,772 @@
+SNMPv2-TC DEFINITIONS ::= BEGIN
+
+IMPORTS
+    TimeTicks         FROM SNMPv2-SMI;
+
+-- definition of textual conventions
+
+TEXTUAL-CONVENTION MACRO ::=
+
+BEGIN
+    TYPE NOTATION ::=
+                  DisplayPart
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+                  "SYNTAX" Syntax
+
+    VALUE NOTATION ::=
+                   value(VALUE Syntax)      -- adapted ASN.1
+
+    DisplayPart ::=
+                  "DISPLAY-HINT" Text
+                | empty
+
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+
+    -- a character string as defined in [2]
+    Text ::= value(IA5String)
+
+    Syntax ::=   -- Must be one of the following:
+                       -- a base type (or its refinement), or
+                       -- a BITS pseudo-type
+                  type
+                | "BITS" "{" NamedBits "}"
+
+    NamedBits ::= NamedBit
+                | NamedBits "," NamedBit
+
+    NamedBit ::=  identifier "(" number ")" -- number is nonnegative
+
+END
+
+DisplayString ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "255a"
+    STATUS       current
+    DESCRIPTION
+            "Represents textual information taken from the NVT ASCII
+
+            character set, as defined in pages 4, 10-11 of RFC 854.
+
+            To summarize RFC 854, the NVT ASCII repertoire specifies:
+
+              - the use of character codes 0-127 (decimal)
+
+              - the graphics characters (32-126) are interpreted as
+                US ASCII
+
+              - NUL, LF, CR, BEL, BS, HT, VT and FF have the special
+                meanings specified in RFC 854
+
+              - the other 25 codes have no standard interpretation
+
+              - the sequence 'CR LF' means newline
+
+              - the sequence 'CR NUL' means carriage-return
+
+              - an 'LF' not preceded by a 'CR' means moving to the
+                same column on the next line.
+
+              - the sequence 'CR x' for any x other than LF or NUL is
+                illegal.  (Note that this also means that a string may
+                end with either 'CR LF' or 'CR NUL', but not with CR.)
+
+            Any object defined using this syntax may not exceed 255
+            characters in length."
+    SYNTAX       OCTET STRING (SIZE (0..255))
+
+PhysAddress ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "1x:"
+    STATUS       current
+    DESCRIPTION
+            "Represents media- or physical-level addresses."
+    SYNTAX       OCTET STRING
+
+MacAddress ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "1x:"
+    STATUS       current
+    DESCRIPTION
+            "Represents an 802 MAC address represented in the
+            `canonical' order defined by IEEE 802.1a, i.e., as if it
+            were transmitted least significant bit first, even though
+            802.5 (in contrast to other 802.x protocols) requires MAC
+            addresses to be transmitted most significant bit first."
+    SYNTAX       OCTET STRING (SIZE (6))
+
+TruthValue ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "Represents a boolean value."
+    SYNTAX       INTEGER { true(1), false(2) }
+
+TestAndIncr ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "Represents integer-valued information used for atomic
+            operations.  When the management protocol is used to specify
+            that an object instance having this syntax is to be
+            modified, the new value supplied via the management protocol
+            must precisely match the value presently held by the
+            instance.  If not, the management protocol set operation
+            fails with an error of `inconsistentValue'.  Otherwise, if
+            the current value is the maximum value of 2^31-1 (2147483647
+            decimal), then the value held by the instance is wrapped to
+            zero; otherwise, the value held by the instance is
+            incremented by one.  (Note that regardless of whether the
+            management protocol set operation succeeds, the variable-
+            binding in the request and response PDUs are identical.)
+
+            The value of the ACCESS clause for objects having this
+            syntax is either `read-write' or `read-create'.  When an
+            instance of a columnar object having this syntax is created,
+            any value may be supplied via the management protocol.
+
+            When the network management portion of the system is re-
+            initialized, the value of every object instance having this
+            syntax must either be incremented from its value prior to
+            the re-initialization, or (if the value prior to the re-
+            initialization is unknown) be set to a pseudo-randomly
+            generated value."
+    SYNTAX       INTEGER (0..2147483647)
+
+AutonomousType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "Represents an independently extensible type identification
+            value.  It may, for example, indicate a particular sub-tree
+            with further MIB definitions, or define a particular type of
+            protocol or hardware."
+    SYNTAX       OBJECT IDENTIFIER
+
+InstancePointer ::= TEXTUAL-CONVENTION
+    STATUS       obsolete
+    DESCRIPTION
+            "A pointer to either a specific instance of a MIB object or
+            a conceptual row of a MIB table in the managed device.  In
+            the latter case, by convention, it is the name of the
+            particular instance of the first accessible columnar object
+            in the conceptual row.
+
+            The two uses of this textual convention are replaced by
+            VariablePointer and RowPointer, respectively."
+    SYNTAX       OBJECT IDENTIFIER
+
+VariablePointer ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "A pointer to a specific object instance.  For example,
+            sysContact.0 or ifInOctets.3."
+    SYNTAX       OBJECT IDENTIFIER
+
+RowPointer ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "Represents a pointer to a conceptual row.  The value is the
+            name of the instance of the first accessible columnar object
+            in the conceptual row.
+
+            For example, ifIndex.3 would point to the 3rd row in the
+            ifTable (note that if ifIndex were not-accessible, then
+            ifDescr.3 would be used instead)."
+    SYNTAX       OBJECT IDENTIFIER
+
+RowStatus ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "The RowStatus textual convention is used to manage the
+            creation and deletion of conceptual rows, and is used as the
+            value of the SYNTAX clause for the status column of a
+            conceptual row (as described in Section 7.7.1 of [2].)
+
+            The status column has six defined values:
+
+                 - `active', which indicates that the conceptual row is
+                 available for use by the managed device;
+
+                 - `notInService', which indicates that the conceptual
+                 row exists in the agent, but is unavailable for use by
+                 the managed device (see NOTE below); 'notInService' has
+                 no implication regarding the internal consistency of
+                 the row, availability of resources, or consistency with
+                 the current state of the managed device;
+
+                 - `notReady', which indicates that the conceptual row
+                 exists in the agent, but is missing information
+                 necessary in order to be available for use by the
+                 managed device (i.e., one or more required columns in
+                 the conceptual row have not been instanciated);
+
+                 - `createAndGo', which is supplied by a management
+                 station wishing to create a new instance of a
+                 conceptual row and to have its status automatically set
+                 to active, making it available for use by the managed
+                 device;
+
+                 - `createAndWait', which is supplied by a management
+                 station wishing to create a new instance of a
+                 conceptual row (but not make it available for use by
+                 the managed device); and,
+                 - `destroy', which is supplied by a management station
+                 wishing to delete all of the instances associated with
+                 an existing conceptual row.
+
+            Whereas five of the six values (all except `notReady') may
+            be specified in a management protocol set operation, only
+            three values will be returned in response to a management
+            protocol retrieval operation:  `notReady', `notInService' or
+            `active'.  That is, when queried, an existing conceptual row
+            has only three states:  it is either available for use by
+            the managed device (the status column has value `active');
+            it is not available for use by the managed device, though
+            the agent has sufficient information to attempt to make it
+            so (the status column has value `notInService'); or, it is
+            not available for use by the managed device, and an attempt
+            to make it so would fail because the agent has insufficient
+            information (the state column has value `notReady').
+
+                                     NOTE WELL
+
+                 This textual convention may be used for a MIB table,
+                 irrespective of whether the values of that table's
+                 conceptual rows are able to be modified while it is
+                 active, or whether its conceptual rows must be taken
+                 out of service in order to be modified.  That is, it is
+                 the responsibility of the DESCRIPTION clause of the
+                 status column to specify whether the status column must
+                 not be `active' in order for the value of some other
+                 column of the same conceptual row to be modified.  If
+                 such a specification is made, affected columns may be
+                 changed by an SNMP set PDU if the RowStatus would not
+                 be equal to `active' either immediately before or after
+                 processing the PDU.  In other words, if the PDU also
+                 contained a varbind that would change the RowStatus
+                 value, the column in question may be changed if the
+                 RowStatus was not equal to `active' as the PDU was
+                 received, or if the varbind sets the status to a value
+                 other than 'active'.
+
+            Also note that whenever any elements of a row exist, the
+            RowStatus column must also exist.
+
+            To summarize the effect of having a conceptual row with a
+            status column having a SYNTAX clause value of RowStatus,
+            consider the following state diagram:
+
+                                         STATE
+              +--------------+-----------+-------------+-------------
+              |      A       |     B     |      C      |      D
+              |              |status col.|status column|
+              |status column |    is     |      is     |status column
+    ACTION    |does not exist|  notReady | notInService|  is active
+--------------+--------------+-----------+-------------+-------------
+set status    |noError    ->D|inconsist- |inconsistent-|inconsistent-
+column to     |       or     |   entValue|        Value|        Value
+createAndGo   |inconsistent- |           |             |
+              |         Value|           |             |
+--------------+--------------+-----------+-------------+-------------
+set status    |noError  see 1|inconsist- |inconsistent-|inconsistent-
+column to     |       or     |   entValue|        Value|        Value
+createAndWait |wrongValue    |           |             |
+--------------+--------------+-----------+-------------+-------------
+set status    |inconsistent- |inconsist- |noError      |noError
+column to     |         Value|   entValue|             |
+active        |              |           |             |
+              |              |     or    |             |
+              |              |           |             |
+              |              |see 2   ->D|see 8     ->D|          ->D
+--------------+--------------+-----------+-------------+-------------
+set status    |inconsistent- |inconsist- |noError      |noError   ->C
+column to     |         Value|   entValue|             |
+notInService  |              |           |             |
+              |              |     or    |             |      or
+              |              |           |             |
+              |              |see 3   ->C|          ->C|see 6
+--------------+--------------+-----------+-------------+-------------
+set status    |noError       |noError    |noError      |noError   ->A
+column to     |              |           |             |      or
+destroy       |           ->A|        ->A|          ->A|see 7
+--------------+--------------+-----------+-------------+-------------
+set any other |see 4         |noError    |noError      |see 5
+column to some|              |           |             |
+value         |              |      see 1|          ->C|          ->D
+--------------+--------------+-----------+-------------+-------------
+
+            (1) goto B or C, depending on information available to the
+            agent.
+
+            (2) if other variable bindings included in the same PDU,
+            provide values for all columns which are missing but
+            required, and all columns have acceptable values, then
+            return noError and goto D.
+
+            (3) if other variable bindings included in the same PDU,
+            provide legal values for all columns which are missing but
+            required, then return noError and goto C.
+
+            (4) at the discretion of the agent, the return value may be
+            either:
+
+                 inconsistentName:  because the agent does not choose to
+                 create such an instance when the corresponding
+                 RowStatus instance does not exist, or
+
+                 inconsistentValue:  if the supplied value is
+                 inconsistent with the state of some other MIB object's
+                 value, or
+
+                 noError: because the agent chooses to create the
+                 instance.
+
+            If noError is returned, then the instance of the status
+            column must also be created, and the new state is B or C,
+            depending on the information available to the agent.  If
+            inconsistentName or inconsistentValue is returned, the row
+            remains in state A.
+
+            (5) depending on the MIB definition for the column/table,
+            either noError or inconsistentValue may be returned.
+
+            (6) the return value can indicate one of the following
+            errors:
+
+                 wrongValue: because the agent does not support
+                 notInService (e.g., an agent which does not support
+                 createAndWait), or
+
+                 inconsistentValue: because the agent is unable to take
+                 the row out of service at this time, perhaps because it
+                 is in use and cannot be de-activated.
+
+            (7) the return value can indicate the following error:
+
+                 inconsistentValue: because the agent is unable to
+                 remove the row at this time, perhaps because it is in
+                 use and cannot be de-activated.
+
+            (8) the transition to D can fail, e.g., if the values of the
+            conceptual row are inconsistent, then the error code would
+            be inconsistentValue.
+
+            NOTE: Other processing of (this and other varbinds of) the
+            set request may result in a response other than noError
+            being returned, e.g., wrongValue, noCreation, etc.
+
+                              Conceptual Row Creation
+
+            There are four potential interactions when creating a
+            conceptual row:  selecting an instance-identifier which is
+            not in use; creating the conceptual row; initializing any
+            objects for which the agent does not supply a default; and,
+            making the conceptual row available for use by the managed
+            device.
+
+            Interaction 1: Selecting an Instance-Identifier
+
+            The algorithm used to select an instance-identifier varies
+            for each conceptual row.  In some cases, the instance-
+            identifier is semantically significant, e.g., the
+            destination address of a route, and a management station
+            selects the instance-identifier according to the semantics.
+
+            In other cases, the instance-identifier is used solely to
+            distinguish conceptual rows, and a management station
+            without specific knowledge of the conceptual row might
+            examine the instances present in order to determine an
+            unused instance-identifier.  (This approach may be used, but
+            it is often highly sub-optimal; however, it is also a
+            questionable practice for a naive management station to
+            attempt conceptual row creation.)
+
+            Alternately, the MIB module which defines the conceptual row
+            might provide one or more objects which provide assistance
+            in determining an unused instance-identifier.  For example,
+            if the conceptual row is indexed by an integer-value, then
+            an object having an integer-valued SYNTAX clause might be
+            defined for such a purpose, allowing a management station to
+            issue a management protocol retrieval operation.  In order
+            to avoid unnecessary collisions between competing management
+            stations, `adjacent' retrievals of this object should be
+            different.
+
+            Finally, the management station could select a pseudo-random
+            number to use as the index.  In the event that this index
+
+            was already in use and an inconsistentValue was returned in
+            response to the management protocol set operation, the
+            management station should simply select a new pseudo-random
+            number and retry the operation.
+
+            A MIB designer should choose between the two latter
+            algorithms based on the size of the table (and therefore the
+            efficiency of each algorithm).  For tables in which a large
+            number of entries are expected, it is recommended that a MIB
+            object be defined that returns an acceptable index for
+            creation.  For tables with small numbers of entries, it is
+            recommended that the latter pseudo-random index mechanism be
+            used.
+
+            Interaction 2: Creating the Conceptual Row
+
+            Once an unused instance-identifier has been selected, the
+            management station determines if it wishes to create and
+            activate the conceptual row in one transaction or in a
+            negotiated set of interactions.
+
+            Interaction 2a: Creating and Activating the Conceptual Row
+
+            The management station must first determine the column
+            requirements, i.e., it must determine those columns for
+            which it must or must not provide values.  Depending on the
+            complexity of the table and the management station's
+            knowledge of the agent's capabilities, this determination
+            can be made locally by the management station.  Alternately,
+            the management station issues a management protocol get
+            operation to examine all columns in the conceptual row that
+            it wishes to create.  In response, for each column, there
+            are three possible outcomes:
+
+                 - a value is returned, indicating that some other
+                 management station has already created this conceptual
+                 row.  We return to interaction 1.
+
+                 - the exception `noSuchInstance' is returned,
+                 indicating that the agent implements the object-type
+                 associated with this column, and that this column in at
+                 least one conceptual row would be accessible in the MIB
+                 view used by the retrieval were it to exist. For those
+                 columns to which the agent provides read-create access,
+                 the `noSuchInstance' exception tells the management
+                 station that it should supply a value for this column
+                 when the conceptual row is to be created.
+
+                 - the exception `noSuchObject' is returned, indicating
+                 that the agent does not implement the object-type
+                 associated with this column or that there is no
+                 conceptual row for which this column would be
+                 accessible in the MIB view used by the retrieval.  As
+                 such, the management station can not issue any
+                 management protocol set operations to create an
+                 instance of this column.
+
+            Once the column requirements have been determined, a
+            management protocol set operation is accordingly issued.
+            This operation also sets the new instance of the status
+            column to `createAndGo'.
+
+            When the agent processes the set operation, it verifies that
+            it has sufficient information to make the conceptual row
+            available for use by the managed device.  The information
+            available to the agent is provided by two sources:  the
+            management protocol set operation which creates the
+            conceptual row, and, implementation-specific defaults
+            supplied by the agent (note that an agent must provide
+            implementation-specific defaults for at least those objects
+            which it implements as read-only).  If there is sufficient
+            information available, then the conceptual row is created, a
+            `noError' response is returned, the status column is set to
+            `active', and no further interactions are necessary (i.e.,
+            interactions 3 and 4 are skipped).  If there is insufficient
+            information, then the conceptual row is not created, and the
+            set operation fails with an error of `inconsistentValue'.
+            On this error, the management station can issue a management
+            protocol retrieval operation to determine if this was
+            because it failed to specify a value for a required column,
+            or, because the selected instance of the status column
+            already existed.  In the latter case, we return to
+            interaction 1.  In the former case, the management station
+            can re-issue the set operation with the additional
+            information, or begin interaction 2 again using
+            `createAndWait' in order to negotiate creation of the
+            conceptual row.
+
+                                     NOTE WELL
+
+                 Regardless of the method used to determine the column
+                 requirements, it is possible that the management
+                 station might deem a column necessary when, in fact,
+                 the agent will not allow that particular columnar
+                 instance to be created or written.  In this case, the
+                 management protocol set operation will fail with an
+                 error such as `noCreation' or `notWritable'.  In this
+                 case, the management station decides whether it needs
+                 to be able to set a value for that particular columnar
+                 instance.  If not, the management station re-issues the
+                 management protocol set operation, but without setting
+                 a value for that particular columnar instance;
+                 otherwise, the management station aborts the row
+                 creation algorithm.
+
+            Interaction 2b: Negotiating the Creation of the Conceptual
+            Row
+
+            The management station issues a management protocol set
+            operation which sets the desired instance of the status
+            column to `createAndWait'.  If the agent is unwilling to
+            process a request of this sort, the set operation fails with
+            an error of `wrongValue'.  (As a consequence, such an agent
+            must be prepared to accept a single management protocol set
+            operation, i.e., interaction 2a above, containing all of the
+            columns indicated by its column requirements.)  Otherwise,
+            the conceptual row is created, a `noError' response is
+            returned, and the status column is immediately set to either
+            `notInService' or `notReady', depending on whether it has
+            sufficient information to (attempt to) make the conceptual
+            row available for use by the managed device.  If there is
+            sufficient information available, then the status column is
+            set to `notInService'; otherwise, if there is insufficient
+            information, then the status column is set to `notReady'.
+            Regardless, we proceed to interaction 3.
+
+            Interaction 3: Initializing non-defaulted Objects
+
+            The management station must now determine the column
+            requirements.  It issues a management protocol get operation
+            to examine all columns in the created conceptual row.  In
+            the response, for each column, there are three possible
+            outcomes:
+
+                 - a value is returned, indicating that the agent
+                 implements the object-type associated with this column
+                 and had sufficient information to provide a value.  For
+                 those columns to which the agent provides read-create
+                 access (and for which the agent allows their values to
+                 be changed after their creation), a value return tells
+                 the management station that it may issue additional
+                 management protocol set operations, if it desires, in
+                 order to change the value associated with this column.
+
+                 - the exception `noSuchInstance' is returned,
+                 indicating that the agent implements the object-type
+                 associated with this column, and that this column in at
+                 least one conceptual row would be accessible in the MIB
+                 view used by the retrieval were it to exist. However,
+                 the agent does not have sufficient information to
+                 provide a value, and until a value is provided, the
+                 conceptual row may not be made available for use by the
+                 managed device.  For those columns to which the agent
+                 provides read-create access, the `noSuchInstance'
+                 exception tells the management station that it must
+                 issue additional management protocol set operations, in
+                 order to provide a value associated with this column.
+
+                 - the exception `noSuchObject' is returned, indicating
+                 that the agent does not implement the object-type
+                 associated with this column or that there is no
+                 conceptual row for which this column would be
+                 accessible in the MIB view used by the retrieval.  As
+                 such, the management station can not issue any
+                 management protocol set operations to create an
+                 instance of this column.
+
+            If the value associated with the status column is
+            `notReady', then the management station must first deal with
+            all `noSuchInstance' columns, if any.  Having done so, the
+            value of the status column becomes `notInService', and we
+            proceed to interaction 4.
+
+            Interaction 4: Making the Conceptual Row Available
+
+            Once the management station is satisfied with the values
+            associated with the columns of the conceptual row, it issues
+            a management protocol set operation to set the status column
+            to `active'.  If the agent has sufficient information to
+            make the conceptual row available for use by the managed
+            device, the management protocol set operation succeeds (a
+            `noError' response is returned).  Otherwise, the management
+            protocol set operation fails with an error of
+            `inconsistentValue'.
+
+                                     NOTE WELL
+
+                 A conceptual row having a status column with value
+                 `notInService' or `notReady' is unavailable to the
+                 managed device.  As such, it is possible for the
+                 managed device to create its own instances during the
+                 time between the management protocol set operation
+                 which sets the status column to `createAndWait' and the
+                 management protocol set operation which sets the status
+                 column to `active'.  In this case, when the management
+                 protocol set operation is issued to set the status
+                 column to `active', the values held in the agent
+                 supersede those used by the managed device.
+
+            If the management station is prevented from setting the
+            status column to `active' (e.g., due to management station
+            or network failure) the conceptual row will be left in the
+            `notInService' or `notReady' state, consuming resources
+            indefinitely.  The agent must detect conceptual rows that
+            have been in either state for an abnormally long period of
+            time and remove them.  It is the responsibility of the
+            DESCRIPTION clause of the status column to indicate what an
+            abnormally long period of time would be.  This period of
+            time should be long enough to allow for human response time
+            (including `think time') between the creation of the
+            conceptual row and the setting of the status to `active'.
+            In the absence of such information in the DESCRIPTION
+            clause, it is suggested that this period be approximately 5
+            minutes in length.  This removal action applies not only to
+            newly-created rows, but also to previously active rows which
+            are set to, and left in, the notInService state for a
+            prolonged period exceeding that which is considered normal
+            for such a conceptual row.
+
+                             Conceptual Row Suspension
+
+            When a conceptual row is `active', the management station
+            may issue a management protocol set operation which sets the
+            instance of the status column to `notInService'.  If the
+            agent is unwilling to do so, the set operation fails with an
+            error of `wrongValue' or `inconsistentValue'.  Otherwise,
+            the conceptual row is taken out of service, and a `noError'
+            response is returned.  It is the responsibility of the
+            DESCRIPTION clause of the status column to indicate under
+            what circumstances the status column should be taken out of
+            service (e.g., in order for the value of some other column
+            of the same conceptual row to be modified).
+
+                              Conceptual Row Deletion
+
+            For deletion of conceptual rows, a management protocol set
+            operation is issued which sets the instance of the status
+            column to `destroy'.  This request may be made regardless of
+            the current value of the status column (e.g., it is possible
+            to delete conceptual rows which are either `notReady',
+            `notInService' or `active'.)  If the operation succeeds,
+            then all instances associated with the conceptual row are
+            immediately removed."
+    SYNTAX       INTEGER {
+                     -- the following two values are states:
+                     -- these values may be read or written
+                     active(1),
+                     notInService(2),
+                     -- the following value is a state:
+                     -- this value may be read, but not written
+                     notReady(3),
+                     -- the following three values are
+                     -- actions: these values may be written,
+                     --   but are never read
+                     createAndGo(4),
+                     createAndWait(5),
+                     destroy(6)
+                 }
+
+TimeStamp ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "The value of the sysUpTime object at which a specific
+            occurrence happened.  The specific occurrence must be
+
+            defined in the description of any object defined using this
+            type.
+
+            If sysUpTime is reset to zero as a result of a re-
+            initialization of the network management (sub)system, then
+            the values of all TimeStamp objects are also reset.
+            However, after approximately 497 days without a re-
+            initialization, the sysUpTime object will reach 2^^32-1 and
+            then increment around to zero; in this case, existing values
+            of TimeStamp objects do not change.  This can lead to
+            ambiguities in the value of TimeStamp objects."
+    SYNTAX       TimeTicks
+
+TimeInterval ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "A period of time, measured in units of 0.01 seconds."
+    SYNTAX       INTEGER (0..2147483647)
+
+DateAndTime ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "2d-1d-1d,1d:1d:1d.1d,1a1d:1d"
+    STATUS       current
+    DESCRIPTION
+            "A date-time specification.
+
+            field  octets  contents                  range
+            -----  ------  --------                  -----
+              1      1-2   year*                     0..65536
+              2       3    month                     1..12
+              3       4    day                       1..31
+              4       5    hour                      0..23
+              5       6    minutes                   0..59
+              6       7    seconds                   0..60
+                           (use 60 for leap-second)
+              7       8    deci-seconds              0..9
+              8       9    direction from UTC        '+' / '-'
+              9      10    hours from UTC*           0..13
+             10      11    minutes from UTC          0..59
+
+            * Notes:
+            - the value of year is in network-byte order
+            - daylight saving time in New Zealand is +13
+
+            For example, Tuesday May 26, 1992 at 1:30:15 PM EDT would be
+            displayed as:
+
+                             1992-5-26,13:30:15.0,-4:0
+
+            Note that if only local time is known, then timezone
+            information (fields 8-10) is not present."
+    SYNTAX       OCTET STRING (SIZE (8 | 11))
+
+StorageType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+            "Describes the memory realization of a conceptual row.  A
+            row which is volatile(2) is lost upon reboot.  A row which
+            is either nonVolatile(3), permanent(4) or readOnly(5), is
+            backed up by stable storage.  A row which is permanent(4)
+            can be changed but not deleted.  A row which is readOnly(5)
+            cannot be changed nor deleted.
+
+            If the value of an object with this syntax is either
+            permanent(4) or readOnly(5), it cannot be written.
+            Conversely, if the value is either other(1), volatile(2) or
+            nonVolatile(3), it cannot be modified to be permanent(4) or
+            readOnly(5).  (All illegal modifications result in a
+            'wrongValue' error.)
+
+            Every usage of this textual convention is required to
+            specify the columnar objects which a permanent(4) row must
+            at a minimum allow to be writable."
+    SYNTAX       INTEGER {
+                     other(1),       -- eh?
+                     volatile(2),    -- e.g., in RAM
+                     nonVolatile(3), -- e.g., in NVRAM
+                     permanent(4),   -- e.g., partially in ROM
+                     readOnly(5)     -- e.g., completely in ROM
+                 }
+
+TDomain ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+          "Denotes a kind of transport service.
+
+          Some possible values, such as snmpUDPDomain, are defined in
+          the SNMPv2-TM MIB module.  Other possible values are defined
+          in other MIB modules."
+    REFERENCE    "The SNMPv2-TM MIB module is defined in RFC 1906."
+    SYNTAX       OBJECT IDENTIFIER
+
+TAddress ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION
+          "Denotes a transport service address.
+
+          A TAddress value is always interpreted within the context of a
+          TDomain value.  Thus, each definition of a TDomain value must
+          be accompanied by a definition of a textual convention for use
+          with that TDomain.  Some possible textual conventions, such as
+          SnmpUDPAddress for snmpUDPDomain, are defined in the SNMPv2-TM
+          MIB module.  Other possible textual conventions are defined in
+          other MIB modules."
+    REFERENCE    "The SNMPv2-TM MIB module is defined in RFC 1906."
+    SYNTAX       OCTET STRING (SIZE (1..255))
+
+END

--- a/services/monitoring/assets/snmp/mibs/VDSL2-LINE-MIB
+++ b/services/monitoring/assets/snmp/mibs/VDSL2-LINE-MIB
@@ -1,0 +1,7189 @@
+VDSL2-LINE-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+   MODULE-IDENTITY,
+   OBJECT-TYPE,
+   transmission,
+   Unsigned32,
+   NOTIFICATION-TYPE,
+   Integer32,
+   Counter32
+      FROM SNMPv2-SMI
+
+   ifIndex
+      FROM IF-MIB
+
+   TruthValue,
+   RowStatus
+       FROM SNMPv2-TC
+   SnmpAdminString
+      FROM SNMP-FRAMEWORK-MIB
+
+   HCPerfIntervalThreshold,
+   HCPerfTimeElapsed
+      FROM  HC-PerfHist-TC-MIB   -- [RFC3705]
+
+   Xdsl2Unit,
+   Xdsl2Direction,
+   Xdsl2Band,
+   Xdsl2TransmissionModeType,
+   Xdsl2RaMode,
+   Xdsl2InitResult,
+   Xdsl2OperationModes,
+   Xdsl2PowerMngState,
+   Xdsl2ConfPmsForce,
+   Xdsl2LinePmMode,
+   Xdsl2LineLdsf,
+   Xdsl2LdsfResult,
+   Xdsl2LineBpsc,
+   Xdsl2BpscResult,
+   Xdsl2LineReset,
+   Xdsl2SymbolProtection,
+   Xdsl2SymbolProtection8,
+   Xdsl2MaxBer,
+   Xdsl2ChInitPolicy,
+   Xdsl2ScMaskDs,
+   Xdsl2ScMaskUs,
+   Xdsl2CarMask,
+   Xdsl2RfiBands,
+   Xdsl2PsdMaskDs,
+   Xdsl2PsdMaskUs,
+   Xdsl2Tssi,
+   Xdsl2LastTransmittedState,
+   Xdsl2LineStatus,
+   Xdsl2ChInpReport,
+   Xdsl2ChAtmStatus,
+   Xdsl2ChPtmStatus,
+   Xdsl2UpboKLF,
+   Xdsl2BandUs,
+   Xdsl2LineProfiles,
+   Xdsl2LineUs0Mask,
+   Xdsl2LineClassMask,
+   Xdsl2LineLimitMask,
+   Xdsl2LineUs0Disable,
+   Xdsl2LinePsdMaskSelectUs,
+   Xdsl2LineCeFlag,
+   Xdsl2LineSnrMode,
+   Xdsl2LineTxRefVnDs,
+   Xdsl2LineTxRefVnUs,
+   Xdsl2BitsAlloc,
+   Xdsl2MrefPsdDs,
+   Xdsl2MrefPsdUs
+
+          FROM   VDSL2-LINE-TC-MIB       -- [This document]
+
+   MODULE-COMPLIANCE,
+   OBJECT-GROUP,
+   NOTIFICATION-GROUP
+      FROM SNMPv2-CONF;
+
+vdsl2MIB MODULE-IDENTITY
+   LAST-UPDATED "200909300000Z" -- September 30, 2009
+   ORGANIZATION "ADSLMIB Working Group"
+   CONTACT-INFO "WG-email:  adslmib@ietf.org
+   Info:      https://www1.ietf.org/mailman/listinfo/adslmib
+
+             Chair:     Mike Sneed
+                        Sand Channel Systems
+             Postal:    P.O. Box 37324
+                        Raleigh NC 27627-732
+             Email:     sneedmike@hotmail.com
+             Phone:     +1 206 600 7022
+
+             Co-Chair:  Menachem Dodge
+                        ECI Telecom Ltd.
+             Postal:    30 Hasivim St.
+                        Petach Tikva 49517,
+                        Israel.
+             Email:     mbdodge@ieee.org
+             Phone:     +972 3 926 8421
+
+             Co-editor: Moti Morgenstern
+                        ECI Telecom Ltd.
+             Postal:    30 Hasivim St.
+                        Petach Tikva 49517,
+                        Israel.
+             Email:     moti.morgenstern@ecitele.com
+             Phone:     +972 3 926 6258
+
+             Co-editor: Scott Baillie
+                        NEC Australia
+             Postal:    649-655 Springvale Road,
+                        Mulgrave, Victoria 3170,
+                        Australia.
+             Email:     scott.baillie@nec.com.au
+             Phone:     +61 3 9264 3986
+
+             Co-editor: Umberto Bonollo
+                        NEC Australia
+             Postal:    649-655 Springvale Road,
+                        Mulgrave, Victoria 3170,
+                        Australia.
+             Email:     umberto.bonollo@nec.com.au
+             Phone:     +61 3 9264 3385
+            "
+   DESCRIPTION
+        "
+         This document defines a Management Information Base (MIB)
+         module for use with network management protocols in the
+         Internet community for the purpose of managing VDSL2, ADSL,
+         ADSL2, and ADSL2+ lines.
+
+         The MIB module described in RFC 2662 [RFC2662] defines
+         objects used for managing Asymmetric Bit-Rate DSL (ADSL)
+
+         interfaces per [T1E1.413], [G.992.1], and [G.992.2].
+         These object descriptions are based upon the specifications
+         for the ADSL Embedded Operations Channel (EOC) as defined
+         in American National Standards Institute (ANSI) T1E1.413
+         [T1E1.413] and International Telecommunication Union (ITU-T)
+         G.992.1 [G.992.1] and G.992.2 [G.992.2].
+
+         The MIB module described in RFC 4706 [RFC4706] defines
+         objects used for managing ADSL2 interfaces per [G.992.3]
+         and [G.992.4], and ADSL2+ interfaces per [G.992.5].  That MIB
+         is also capable of managing ADSL interfaces per [T1E1.413],
+         [G.992.1], and [G.992.2].
+
+         This document does not obsolete RFC 2662 [RFC2662] or
+         RFC 4706 [RFC4706], but rather provides a more comprehensive
+         management model that manages VDSL2 interfaces per G.993.2
+         [G.993.2] as well as ADSL, ADSL2, and ADSL2+ technologies
+         per T1E1.413, G.992.1, G.992.2, G.992.3, G.992.4, and
+         G.992.5
+         ([T1E1.413], [G.992.1], [G.992.2], [G.992.3], [G.992.4], and
+         [G.992.5], respectively).
+
+         Additionally, the management framework for VDSL2 lines
+         specified by the Digital Subscriber Line Forum
+         (DSLF) has been taken into consideration [TR-129].  That
+         framework is based on the ITU-T G.997.1 standard [G.997.1] and
+         its amendment 1 [G.997.1-Am1].
+
+         The MIB module is located in the MIB tree under MIB 2
+         transmission, as discussed in the MIB-2 Integration (RFC 2863
+         [RFC2863]) section of this document.
+
+         Copyright (c) 2009 IETF Trust and the persons identified
+         as authors of the code.  All rights reserved.
+
+         Redistribution and use in source and binary forms, with
+         or without modification, are permitted provided that the
+         following conditions are met:
+
+         - Redistributions of source code must retain the above
+           copyright notice, this list of conditions and the
+           following disclaimer.
+
+         - Redistributions in binary form must reproduce the above
+           copyright notice, this list of conditions and the
+           following disclaimer in the documentation and/or other
+           materials provided with the distribution.
+
+         - Neither the name of Internet Society, IETF or IETF Trust,
+           nor the names of specific contributors, may be used to
+           endorse or promote products derived from this software
+           without specific prior written permission.
+
+         THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+         CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+         INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+         MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+         DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+         CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+         SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+         NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+         LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+         HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+         CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+         OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+         SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+         This version of this MIB module is part of RFC 5650;
+         see the RFC itself for full legal notices."
+
+   REVISION "200909300000Z" -- September 30, 2009
+   DESCRIPTION "Initial version, published as RFC 5650."
+      ::= { transmission 251 }
+
+  xdsl2Notifications OBJECT IDENTIFIER ::= { vdsl2MIB 0 }
+  xdsl2Objects       OBJECT IDENTIFIER ::= { vdsl2MIB 1 }
+  xdsl2Conformance   OBJECT IDENTIFIER ::= { vdsl2MIB 2 }
+  ------------------------------------------------
+  xdsl2Line          OBJECT IDENTIFIER ::= { xdsl2Objects 1 }
+  xdsl2Status        OBJECT IDENTIFIER ::= { xdsl2Objects 2 }
+  xdsl2Inventory     OBJECT IDENTIFIER ::= { xdsl2Objects 3 }
+  xdsl2PM            OBJECT IDENTIFIER ::= { xdsl2Objects 4 }
+  xdsl2Profile       OBJECT IDENTIFIER ::= { xdsl2Objects 5 }
+  xdsl2Scalar        OBJECT IDENTIFIER ::= { xdsl2Objects 6 }
+  ------------------------------------------------
+  xdsl2PMLine      OBJECT IDENTIFIER ::= { xdsl2PM 1 }
+  xdsl2PMChannel   OBJECT IDENTIFIER ::= { xdsl2PM 2 }
+  ------------------------------------------------
+  xdsl2ProfileLine      OBJECT IDENTIFIER ::= { xdsl2Profile 1 }
+  xdsl2ProfileChannel   OBJECT IDENTIFIER ::= { xdsl2Profile 2 }
+  xdsl2ProfileAlarmConf OBJECT IDENTIFIER ::= { xdsl2Profile 3 }
+  ------------------------------------------------
+  xdsl2ScalarSC         OBJECT IDENTIFIER ::= { xdsl2Scalar 1 }
+  ------------------------------------------------
+
+------------------------------------------------
+
+--          xdsl2LineTable                    --
+------------------------------------------------
+
+xdsl2LineTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineTable contains configuration, command and
+       status parameters of the VDSL2/ADSL/ADSL2 or ADSL2+ line.
+
+       Several objects in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2Line 1 }
+
+xdsl2LineEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The index of this table is an interface index where the
+       interface has an ifType of vdsl2(251)."
+   INDEX  { ifIndex }
+   ::= { xdsl2LineTable 1 }
+
+Xdsl2LineEntry  ::=
+   SEQUENCE {
+      xdsl2LineConfTemplate            SnmpAdminString,
+      xdsl2LineConfFallbackTemplate    SnmpAdminString,
+      xdsl2LineAlarmConfTemplate       SnmpAdminString,
+      xdsl2LineCmndConfPmsf            Xdsl2ConfPmsForce,
+      xdsl2LineCmndConfLdsf            Xdsl2LineLdsf,
+      xdsl2LineCmndConfLdsfFailReason  Xdsl2LdsfResult,
+      xdsl2LineCmndConfBpsc            Xdsl2LineBpsc,
+      xdsl2LineCmndConfBpscFailReason  Xdsl2BpscResult,
+      xdsl2LineCmndConfBpscRequests    Counter32,
+      xdsl2LineCmndAutomodeColdStart   TruthValue,
+      xdsl2LineCmndConfReset           Xdsl2LineReset,
+      xdsl2LineStatusActTemplate       SnmpAdminString,
+      xdsl2LineStatusXtuTransSys       Xdsl2TransmissionModeType,
+      xdsl2LineStatusPwrMngState       Xdsl2PowerMngState,
+      xdsl2LineStatusInitResult        Xdsl2InitResult,
+      xdsl2LineStatusLastStateDs       Xdsl2LastTransmittedState,
+      xdsl2LineStatusLastStateUs       Xdsl2LastTransmittedState,
+      xdsl2LineStatusXtur              Xdsl2LineStatus,
+      xdsl2LineStatusXtuc              Xdsl2LineStatus,
+      xdsl2LineStatusAttainableRateDs  Unsigned32,
+      xdsl2LineStatusAttainableRateUs  Unsigned32,
+      xdsl2LineStatusActPsdDs          Integer32,
+      xdsl2LineStatusActPsdUs          Integer32,
+      xdsl2LineStatusActAtpDs          Integer32,
+      xdsl2LineStatusActAtpUs          Integer32,
+      xdsl2LineStatusActProfile        Xdsl2LineProfiles,
+      xdsl2LineStatusActLimitMask      Xdsl2LineLimitMask,
+      xdsl2LineStatusActUs0Mask        Xdsl2LineUs0Mask,
+      xdsl2LineStatusActSnrModeDs      Xdsl2LineSnrMode,
+      xdsl2LineStatusActSnrModeUs      Xdsl2LineSnrMode,
+      xdsl2LineStatusElectricalLength  Unsigned32,
+      xdsl2LineStatusTssiDs            Xdsl2Tssi,
+      xdsl2LineStatusTssiUs            Xdsl2Tssi,
+      xdsl2LineStatusMrefPsdDs         Xdsl2MrefPsdDs,
+      xdsl2LineStatusMrefPsdUs         Xdsl2MrefPsdUs,
+      xdsl2LineStatusTrellisDs         TruthValue,
+      xdsl2LineStatusTrellisUs         TruthValue,
+      xdsl2LineStatusActualCe          Unsigned32
+   }
+
+xdsl2LineConfTemplate  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the xDSL2
+       Line Configuration Template Table, xdsl2LineConfTemplateTable,
+       that applies for this line.
+
+       This object MUST be maintained in a persistent manner."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.1"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineEntry 1 }
+
+xdsl2LineConfFallbackTemplate  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "This object is used to identify the template that will be
+       used if the xDSL2 line fails to operate using the primary
+       template.  The primary template is identified using the
+       xdsl2LineConfTemplate object.
+
+       For example, a xDSL2 line may fall back to a template with a
+       lower rate if the rate specified in the primary template
+       cannot be achieved.
+
+       The value of this object identifies a row in the xDSL2 Line
+
+       Configuration Template Table, xdsl2LineConfTemplateTable.
+       Any row in the xdsl2LineConfTemplateTable table may be used as a
+       fall-back template.
+
+       If the xDSL2 line fails to operate using the fall-back template,
+       then the primary template should be retried.
+       The xTU-C should continue to alternate between the primary and
+       fall-back templates until one of them succeeds.
+
+       If the value of this object is a zero-length string, then no
+       fall-back template is defined and only the primary template will
+       be used.
+
+       Note that implementation of this object is not mandatory.
+       If this object is not supported, any attempt to modify this
+       object should result in the SET request being rejected.
+
+       This object MUST be maintained in a persistent manner."
+   ::= { xdsl2LineEntry 2 }
+
+xdsl2LineAlarmConfTemplate  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the xDSL2
+       Line Alarm Configuration Template Table,
+       xdsl2LineAlarmConfTemplateTable, which applies to this line.
+
+       This object MUST be maintained in a persistent manner."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.1"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineEntry 3 }
+
+xdsl2LineCmndConfPmsf  OBJECT-TYPE
+   SYNTAX      Xdsl2ConfPmsForce
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "Power management state forced (PMSF).  Defines the line
+       states to be forced by the near-end xTU on this line.
+       This object MUST be maintained in a persistent manner."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.3 (PMSF)"
+   DEFVAL       { l3toL0 }
+   ::= { xdsl2LineEntry 4 }
+
+xdsl2LineCmndConfLdsf  OBJECT-TYPE
+   SYNTAX      Xdsl2LineLdsf
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "Loop diagnostic state forced (LDSF).
+       Defines whether the line should be forced into the loop
+       diagnostics mode by the near-end xTU of this line.  Note that
+       a loop diagnostic may be initiated by the far-end xTU at any
+       time.
+
+       Only when the xdsl2LineStatusPwrMngState object is in the
+       'l3' state and the xdsl2LineCmndConfPmsf object is in the
+       'l0orL2toL3' state, can the line be forced into loop diagnostic
+       mode procedures.  Upon successful completion of the loop
+       diagnostic mode procedures, the Access Node shall set this
+       object to 'inhibit', and xdsl2LineStatusPwrMngState will
+       remain in the 'l3' state.  The loop diagnostic data shall be
+       available at least until xdsl2LineCmndConfPmsf is set to the
+       'l3toL0' state.
+
+       The results of the loop diagnostic procedure are stored in the
+       tables xdsl2SCStatusTable, xdsl2SCStatusBandTable, and
+       xdsl2SCStatusSegmentTable.  The status of the loop diagnostic
+       procedure is indicated by xdsl2LineCmndConfLdsfFailReason.
+
+       As long as loop diagnostic procedures are not completed
+       successfully, attempts shall be made to do so, until the loop
+       diagnostic mode is no longer forced on the line through this
+       configuration parameter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.8 (LDSF)"
+   DEFVAL       { inhibit }
+   ::= { xdsl2LineEntry 5 }
+
+xdsl2LineCmndConfLdsfFailReason  OBJECT-TYPE
+   SYNTAX      Xdsl2LdsfResult
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The status of the most recent occasion when the loop
+       diagnostics state forced (LDSF) command was issued for the
+       associated line."
+   DEFVAL       { none }
+   ::= { xdsl2LineEntry 6 }
+
+xdsl2LineCmndConfBpsc  OBJECT-TYPE
+   SYNTAX      Xdsl2LineBpsc
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "Request a bits-per-subcarrier measurement to be made.
+
+       A request for a bits-per-subcarrier measurement is made by
+       setting this object to the value of 'measure'.  Upon
+       completion of the measurement request, the Access Node shall set
+       this object to 'idle'.
+
+       The SNMP agent should allow initiating a bits-per-subcarrier
+       measurement process only if there is no other bits-per-subcarrier
+       measurement already running, and respond with an SNMP error
+       (e.g., wrongValue) otherwise.
+
+       Note that a bits-per-subcarrier measurement is also performed
+       during a line diagnostic procedure.  This object provides an
+       additional mechanism to fetch the bits-per-subcarrier data.  This
+       additional mechanism is provided so that bits-per-subcarrier
+       data may be fetched without forcing the line into no power state.
+       This is useful because the bits-per-subcarrier allocation may be
+       adjusted at show time due to rate adaption and bit swapping.
+
+       The implementation of this additional mechanism for measuring
+       bits per subcarrier is not mandatory.
+
+       The results of the bits-per-subcarrier measurement are stored in
+       xdsl2LineSegmentTable.  The status of the bits-per-subcarrier
+       measurement is indicated by
+       xdsl2LineCmndConfBpscFailReason."
+   DEFVAL       { idle }
+   ::= { xdsl2LineEntry 7 }
+
+xdsl2LineCmndConfBpscFailReason  OBJECT-TYPE
+   SYNTAX      Xdsl2BpscResult
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The status of the most recent bits-per-subcarrier
+       measurement request issued for the associated line."
+   DEFVAL       { none }
+   ::= { xdsl2LineEntry 8 }
+
+xdsl2LineCmndConfBpscRequests  OBJECT-TYPE
+   SYNTAX      Counter32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Measurement request counter.
+       This counter is incremented by one every time a request for a
+       bits-per-subcarrier measurement is made.  A measurement request
+
+       is made by modifying the xdsl2LineCmndConfBpsc object from
+       idle(1) to the value measure(2).
+
+       The measurement results may be very large and will not fit
+       into a single PDU; hence, multiple SNMP GET requests may be
+       required to fetch the measurement results.
+       Because the measurement results cannot be fetched atomically,
+       it is possible for a second manager to start a new measurement
+       before a first manager has fetched all of its results.
+       An SNMP manager can use this object to ensure that the
+       measurement results retrieved using one or more GET requests
+       all belong to the measurement initiated by that manager.
+
+       The following steps are suggested in order for the SNMP
+       manager to initiate the bits-per-subcarrier measurement:
+
+       1. Wait for xdsl2LineCmndConfBpsc value to be idle(1).
+       2. Perform an SNMP GET for xdsl2LineCmndConfBpscRequests.
+       3. Wait a short delay (4 -> 8 seconds).
+       4. Perform an SNMP SET on xdsl2LineCmndConfBpsc with
+          the value measure(2).
+       5. If step 4 returns an error, then go to step 1.
+       6. Wait for xdsl2LineCmndConfBpsc value to be idle(1).
+       7. Fetch measurement results using one or more GET PDUs.
+       8. Perform an SNMP GET for xdsl2LineCmndConfBpscRequests.
+       9. Compute the difference between the two values of
+          xdsl2LineCmndConfBpscRequests.  If the value is one,
+          then the results are valid, else go to step 1."
+   ::= { xdsl2LineEntry 9 }
+
+xdsl2LineCmndAutomodeColdStart   OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-write
+   STATUS      current
+   DESCRIPTION
+      "Automode cold start forced.  This parameter is defined in
+       order to improve testing of the performance of xTUs supporting
+       automode when it is enabled in the MIB.
+       Change the value of this parameter to 'true' to indicate a change
+       in loop conditions applied to the devices under the test.  The
+       xTUs shall reset any historical information used for automode
+       and for shortening G.994.1 handshake and initialization.
+
+       Automode is the case where multiple operation-modes are enabled
+       through the xdsl2LConfProfXtuTransSysEna object in the line
+       configuration profile being used for the line, and where the
+       selection of the actual operation-mode depends not only on the
+       common capabilities of both xTUs (as exchanged in G.994.1), but
+
+       also on achievable data rates under given loop conditions."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.10
+                (Automode Cold Start Forced)"
+   DEFVAL       { false }
+   ::= { xdsl2LineEntry 10 }
+
+xdsl2LineCmndConfReset   OBJECT-TYPE
+      SYNTAX      Xdsl2LineReset
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "Request a line reset to occur.
+          If this object is set to the value of 'reset', then force
+          the line to reset (i.e., the modems will retrain).
+          When the line has successfully reset, the SNMP agent will
+          set the value of this object to 'idle'.
+
+          Note that the xdsl2LineCmndConfPmsf object will always take
+          precedence over this object.
+          If the xdsl2LineCmndConfPmsf object is set to the value
+          'l0orL2toL3', then the line MUST NOT return to the Showtime
+          state due to a reset request action performed using this
+          object."
+   DEFVAL       { idle }
+      ::= { xdsl2LineEntry 11 }
+
+xdsl2LineStatusActTemplate  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This object is used to identify the template that is
+       currently in use for this line.
+       This object is updated when a successful line initialization
+       occurs.
+       This object indicates if the primary template
+       (xdsl2LineConfTemplate) is in use or the fall-back template
+       (xdsl2LineConfFallbackTemplate) is in use.
+       If the line is not successfully initialized, then the value of
+       this object will be a zero-length string."
+   ::= { xdsl2LineEntry 12 }
+
+xdsl2LineStatusXtuTransSys  OBJECT-TYPE
+   SYNTAX      Xdsl2TransmissionModeType
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU Transmission System (xTS) in use.
+
+       It is coded in a bitmap representation with one bit set to
+       '1' (the selected coding for the DSL line).  This
+       parameter may be derived from the handshaking procedures defined
+       in Recommendation G.994.1.  A set of xDSL line transmission
+       modes, with one bit per mode."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.1
+                (xDSL transmission system)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineEntry 13 }
+
+xdsl2LineStatusPwrMngState  OBJECT-TYPE
+   SYNTAX      Xdsl2PowerMngState
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The current power management state."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.5
+                (Line power management state)"
+   DEFVAL       { l3 }
+      ::= { xdsl2LineEntry 14 }
+
+xdsl2LineStatusInitResult  OBJECT-TYPE
+   SYNTAX      Xdsl2InitResult
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates the result of the last full initialization
+       performed on the line."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.6
+                (Initialization success/failure cause)"
+   DEFVAL       { noFail }
+   ::= { xdsl2LineEntry 15 }
+
+xdsl2LineStatusLastStateDs  OBJECT-TYPE
+   SYNTAX      Xdsl2LastTransmittedState
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The last successful transmitted initialization state in
+       the downstream direction in the last full initialization
+       performed on the line."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.7
+                (Downstream last transmitted state)"
+   DEFVAL       { atucG9941 }
+   ::= { xdsl2LineEntry 16 }
+
+xdsl2LineStatusLastStateUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LastTransmittedState
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The last successful transmitted initialization state in the
+       upstream direction in the last full initialization performed on
+       the line."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.8
+                (Upstream last transmitted state)"
+   DEFVAL       { aturG9941 }
+   ::= { xdsl2LineEntry 17 }
+
+xdsl2LineStatusXtur  OBJECT-TYPE
+   SYNTAX      Xdsl2LineStatus
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates the current state (existing failures) of the xTU-R.
+       This is a bitmap of possible conditions."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.1.1.2
+                (Line far-end failures)"
+   DEFVAL       { { noDefect } }
+   ::= { xdsl2LineEntry 18 }
+
+xdsl2LineStatusXtuc  OBJECT-TYPE
+   SYNTAX      Xdsl2LineStatus
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates the current state (existing failures) of the xTU-C.
+       This is a bitmap of possible conditions."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.1.1.1
+                (Line near-end failures)"
+   DEFVAL       { { noDefect } }
+   ::= { xdsl2LineEntry 19 }
+
+xdsl2LineStatusAttainableRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Maximum Attainable Data Rate Downstream.
+       The maximum downstream net data rate currently attainable by
+       the xTU-C transmitter and the xTU-R receiver, coded in
+       bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.19 (ATTNDRds)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineEntry 20 }
+
+xdsl2LineStatusAttainableRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Maximum Attainable Data Rate Upstream.
+       The maximum upstream net data rate currently attainable by the
+       xTU-R transmitter and the xTU-C receiver, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.20 (ATTNDRus)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineEntry 21 }
+
+xdsl2LineStatusActPsdDs OBJECT-TYPE
+   SYNTAX      Integer32 (-900..0 | 2147483647)
+   UNITS       "0.1 dBm/Hz"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual Power Spectral Density (PSD) Downstream.  The average
+       downstream transmit PSD over the subcarriers used for downstream.
+       It ranges from -900 to 0 units of 0.1 dBm/Hz (physical values are
+       -90 to 0 dBm/Hz).
+       A value of 0x7FFFFFFF (2147483647) indicates the measurement is
+       out of range to be represented."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.21 (ACTPSDds)"
+   DEFVAL       { 2147483647 }
+   ::= { xdsl2LineEntry 22 }
+
+xdsl2LineStatusActPsdUs OBJECT-TYPE
+   SYNTAX      Integer32 (-900..0 | 2147483647)
+   UNITS       "0.1 dBm/Hz"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual Power Spectral Density (PSD) Upstream.  The average
+       upstream transmit PSD over the subcarriers used for upstream.
+       It ranges from -900 to 0 units of 0.1 dBm/Hz (physical values are
+       -90 to 0 dBm/Hz).
+       A value of 0x7FFFFFFF (2147483647) indicates the measurement is
+       out of range to be represented."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.22 (ACTPSDus)"
+   DEFVAL       { 2147483647 }
+   ::= { xdsl2LineEntry 23 }
+
+xdsl2LineStatusActAtpDs  OBJECT-TYPE
+   SYNTAX      Integer32 (-310..310 | 2147483647)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual Aggregate Transmit Power Downstream.
+       The total amount of transmit power delivered by the xTU-C at
+       the U-C reference point, at the instant of measurement.  It
+       ranges from -310 to 310 units of 0.1 dBm (physical values are -31
+       to 31 dBm).
+       A value of 0x7FFFFFFF (2147483647) indicates the measurement is
+       out of range to be represented."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.24 (ACTATPds)"
+   DEFVAL       { 2147483647 }
+   ::= { xdsl2LineEntry 24 }
+
+xdsl2LineStatusActAtpUs  OBJECT-TYPE
+   SYNTAX      Integer32 (-310..310 | 2147483647)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual Aggregate Transmit Power Upstream.
+       The total amount of transmit power delivered by the xTU-R at the
+       U-R reference point, at the instant of measurement.  It ranges
+       from -310 to 310 units of 0.1 dBm (physical values are -31
+       to 31 dBm).
+       A value of 0x7FFFFFFF (2147483647) indicates the measurement is
+       out of range to be represented."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.25 (ACTATPus)"
+   DEFVAL       { 2147483647 }
+   ::= { xdsl2LineEntry 25 }
+
+xdsl2LineStatusActProfile  OBJECT-TYPE
+   SYNTAX      Xdsl2LineProfiles
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The G.993.2 profile in use.
+       The configuration parameter xdsl2LConfProfProfiles defines
+       the set of allowed G.993.2 profiles.  This parameter indicates
+       the profile in use on this line.
+       This parameter may be derived from the handshaking procedures
+       defined in ITU-T Recommendation G.994.1."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.2 (VDSL2 Profile)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineEntry 26 }
+
+xdsl2LineStatusActLimitMask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineLimitMask
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The Limit PSD mask and band plan in use.
+       The configuration parameter xdsl2LConfProfLimitMask defines
+       the set of allowed G.993.2 limit PSD masks.
+       This parameter indicates the limit PSD mask in use on this
+       line."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.3
+                (VDSL2 Limit PSD Mask and Band plan)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineEntry 27 }
+
+xdsl2LineStatusActUs0Mask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineUs0Mask
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The US0 PSD mask in use.
+       The configuration parameter xdsl2LConfProfUs0Mask defines
+       the set of allowed US0 PSD masks.
+       This parameter indicates the US0 PSD mask in use on this line.
+       This parameter may be derived from the handshaking procedures
+       defined in ITU-T Recommendation G.994.1."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.4
+                (VDSL2 US0 PSD Mask)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineEntry 28 }
+
+xdsl2LineStatusActSnrModeDs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSnrMode
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter indicates if the transmitter-referred
+       virtual noise is active on the line in the downstream
+       direction.
+       The configuration parameter xdsl2LConfProfSnrModeDs is used to
+       configure referred virtual noise."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.15 (ACTSNRMODEds)"
+   DEFVAL       { virtualNoiseDisabled }
+   ::= { xdsl2LineEntry 29 }
+
+xdsl2LineStatusActSnrModeUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSnrMode
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter indicates if the transmitter-referred virtual
+       noise is active on the line in the upstream direction.
+       The configuration parameter xdsl2LConfProfSnrModeUs is used to
+       configure referred virtual noise."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.18 (ACTSNRMODEus)"
+   DEFVAL       { virtualNoiseDisabled }
+   ::= { xdsl2LineEntry 30 }
+
+xdsl2LineStatusElectricalLength  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1280)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter contains the estimated electrical length
+       expressed in dB at 1 MHz, kl0.  This is the final electrical
+       length that would have been sent from the VTU-O to VTU-R if the
+       electrical length was not forced by the CO-MIB.
+       The value ranges from 0 to 128 dB in steps of 0.1 dB."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.23 (UPBOKLE)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineEntry 31 }
+
+xdsl2LineStatusTssiDs  OBJECT-TYPE
+     SYNTAX      Xdsl2Tssi
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The transmit spectrum shaping (TSSi) breakpoints expressed
+      as the set of breakpoints exchanged
+      during G.994.1 (Downstream)."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.29.5 (TSSpsds)"
+     ::= { xdsl2LineEntry 32 }
+
+xdsl2LineStatusTssiUs  OBJECT-TYPE
+     SYNTAX      Xdsl2Tssi
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The transmit spectrum shaping (TSSi) breakpoints expressed
+      as the set of breakpoints exchanged
+      during G.994.1 (Upstream)."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.29.6 (TSSpsus)"
+     ::= { xdsl2LineEntry 33 }
+
+xdsl2LineStatusMrefPsdDs  OBJECT-TYPE
+     SYNTAX      Xdsl2MrefPsdDs
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The MEDLEY Reference PSD status parameters
+      in the downstream
+      direction expressed as the set of breakpoints exchanged at
+      initialization."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.29.7 (MREFPSDds)"
+     ::= { xdsl2LineEntry 34 }
+
+xdsl2LineStatusMrefPsdUs  OBJECT-TYPE
+     SYNTAX      Xdsl2MrefPsdUs
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The MEDLEY Reference PSD status parameters in the
+      upstream direction expressed as the set of breakpoints
+      exchanged at initialization."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.29.8 (MREFPSDus)"
+     ::= { xdsl2LineEntry 35 }
+
+xdsl2LineStatusTrellisDs  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter reports whether trellis coding is in use in
+      the downstream direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.30 (TRELLISds)"
+   DEFVAL       { false }
+   ::= { xdsl2LineEntry 36 }
+
+xdsl2LineStatusTrellisUs  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This parameter reports whether trellis coding is in use in
+      the upstream direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.31 (TRELLISus)"
+   DEFVAL       { false }
+   ::= { xdsl2LineEntry 37 }
+
+xdsl2LineStatusActualCe  OBJECT-TYPE
+   SYNTAX      Unsigned32 (2..16)
+   UNITS       "N/32 samples"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "(ACTUALCE)
+       This parameter reports the cyclic extension used on the line.  It
+       is coded as an unsigned integer from 2 to 16 in units of N/32
+       samples, where 2N is the Inverse Discrete Fourier Transform
+       (IDFT) size."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.32 (ACTUALCE)"
+   DEFVAL       { 2 }
+   ::= { xdsl2LineEntry 38 }
+
+------------------------------------------------
+--          xdsl2LineSegmentTable             --
+------------------------------------------------
+
+xdsl2LineSegmentTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineSegmentEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineSegmentTable contains status parameters
+       of VDSL2/ADSL/ADSL2 and ADSL2+ subcarriers.
+       The parameters in this table are updated when a measurement
+       request is made using the xdsl2LineCmndConfBpsc object.
+
+       Note that a bits-per-subcarrier measurement is also performed
+       during a line diagnostic procedure.  This table provides an
+       additional mechanism to fetch the bits-per-subcarrier data.  This
+       additional mechanism is provided so that bits-per-subcarrier
+       data may be fetched without forcing the line into no power state.
+       This is useful because the bits-per-subcarrier allocation may be
+       adjusted at Showtime due to rate adaption and bit swapping.
+
+       The implementation of this additional mechanism for measuring
+       bits per subcarrier is not mandatory."
+   ::= { xdsl2Status 1 }
+
+xdsl2LineSegmentEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSegmentEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineSegmentEntry contains status parameters
+       of VDSL2/ADSL/ADSL2 and ADSL2+ subcarriers.
+
+       Objects in the table refer to NSus and NSds.  For G.993.2, the
+       value of NSus and NSds are, respectively, the indices of the
+       highest supported upstream and downstream subcarriers according
+       to the selected implementation profile.  For ADSL, NSus is equal
+       to NSCus-1 and NSds is equal to NSCds-1.
+
+       One index of this table is an interface index where the interface
+       has an ifType of vdsl2(251).  A second index of this table is the
+       transmission direction.  A third index identifies the specific
+       segment of the subcarriers status addressed."
+   INDEX  { ifIndex,
+            xdsl2LineSegmentDirection,
+            xdsl2LineSegment   }
+   ::= { xdsl2LineSegmentTable 1 }
+
+Xdsl2LineSegmentEntry  ::=
+   SEQUENCE {
+      xdsl2LineSegmentDirection         Xdsl2Direction,
+      xdsl2LineSegment                  Unsigned32,
+      xdsl2LineSegmentBitsAlloc         Xdsl2BitsAlloc,
+      xdsl2LineSegmentRowStatus         RowStatus
+   }
+
+xdsl2LineSegmentDirection  OBJECT-TYPE
+     SYNTAX      Xdsl2Direction
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The direction of the subcarrier either
+      upstream or downstream."
+     ::= { xdsl2LineSegmentEntry 1 }
+
+xdsl2LineSegment  OBJECT-TYPE
+     SYNTAX      Unsigned32(1..8)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The segment of the subcarriers status information
+      provided by this row.
+      Status parameters in this table are retrieved in segments.
+      The first segment of the status information is retrieved with
+      xdsl2LineSegment=1, the second segment is retrieved with
+      xdsl2LineSegment=2, and so on.  When a status parameter is
+      retrieved in n segments where n<8) then, for that parameter,
+      GET operations for the remaining segment numbers (n+1 to 8) will
+      respond with a zero-length OCTET STRING."
+     ::= { xdsl2LineSegmentEntry 2 }
+
+xdsl2LineSegmentBitsAlloc  OBJECT-TYPE
+     SYNTAX      Xdsl2BitsAlloc
+     UNITS       "bits"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The bits allocation per subcarrier.  An array of 256 octets
+      (512 nibbles), designed for supporting up to 512 (downstream)
+      subcarriers.  When more than 512 subcarriers are supported, the
+      status information is reported through multiple (up to 8)
+      segments.  The first segment is then used for the first 512
+      subcarriers.  The second segment is used for the subcarriers
+      512 to 1023 and so on.
+      The aggregate number of utilized nibbles in the downstream
+      direction (in all segments) depends on NSds; in the
+      upstream direction, it depends on NSus.
+      This value is referred to here as NS.  The segment number is in
+      xdsl2SCStatusSegment.
+      Nibble i (0 <= i < MIN((NS+1)-(segment-1)*512,512)) in each
+      segment is set to a value in the range 0 to 15 to indicate that
+      the respective downstream or upstream subcarrier j
+      (j=(segement-1)*512+i) has the same amount of bits
+      allocation."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.29.1 (BITSpsds)
+                 and paragraph #7.5.1.29.2 (BITSpsus)"
+     ::= { xdsl2LineSegmentEntry 3 }
+
+xdsl2LineSegmentRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+     "Row Status.  The SNMP agent will create a row in this table
+      for storing the results of a measurement performed on the
+      associated line, if the row does not already exist.
+
+      The SNMP manager is not permitted to create rows in this table or
+      set the row status to 'notInService'.  In the first case,
+      if the SNMP manager tries to create a new row, the SNMP agent
+      responds with the value 'noCreation' in the error status
+      field of the response-PDU.  In the latter case, the SNMP agent
+      responds with the value 'wrongValue' in the error status
+      field of the response-PDU.
+
+      The SNMP agent may have limited resources; therefore, if multiple
+      rows coexist in this table, it may fail to add new rows to this
+      table or allocate memory resources.
+      If that occurs, the SNMP agent responds with the value
+      'noResources' (for the xdsl2LineCmndConfBpscFailReason
+      object in xdsl2LineTable).
+
+      The management system (the operator) may delete rows from this
+      table according to any scheme.  For example, after retrieving
+      the results.
+
+      When the SNMP manager deletes any row in this table, the SNMP
+      agent MUST delete all rows in this table that have the same
+      ifIndex value."
+     ::= { xdsl2LineSegmentEntry 4 }
+
+------------------------------------------------
+--          xdsl2LineBandTable                --
+------------------------------------------------
+
+xdsl2LineBandTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineBandEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineBandTable contains the, per-band line
+       status parameters of the VDSL2/ADSL/ADSL2 or ADSL2+ line.
+       The parameters in this table are updated at line initialization
+       time and at Showtime."
+   ::= { xdsl2Line 2 }
+
+xdsl2LineBandEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineBandEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+       interface
+       has an ifType of vdsl2(251).  A second index of this table is a
+       per-band index covering both VDSL2 and ADSL/ADSL2/ADSL2+."
+   INDEX  { ifIndex, xdsl2LineBand }
+   ::= { xdsl2LineBandTable 1 }
+
+Xdsl2LineBandEntry  ::=
+   SEQUENCE {
+      xdsl2LineBand                        Xdsl2Band,
+      xdsl2LineBandStatusLnAtten           Unsigned32,
+      xdsl2LineBandStatusSigAtten          Unsigned32,
+      xdsl2LineBandStatusSnrMargin         Integer32
+   }
+
+xdsl2LineBand OBJECT-TYPE
+     SYNTAX      Xdsl2Band
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "Identifies the band(s) associated with this line.
+      For ADSL/ADSL2/ADSL2+, the values 'upstream' and 'downstream'
+      will always be present.
+
+      For VDSL2, a subset of {'us0', 'ds1', 'us1' ... 'ds4', 'us4' }
+      will always be present, together with rows for
+      'upstream' and 'downstream', in which only the
+      xdsl2LineBandStatusSnrMargin object is expected to hold a valid
+      (average) measurement."
+     ::= { xdsl2LineBandEntry 1 }
+
+xdsl2LineBandStatusLnAtten  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1270 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Line Attenuation.
+       When referring to a band in the downstream direction, it is
+       the measured difference in the total power transmitted by the
+       xTU-C and the total power received by the xTU-R over all
+       subcarriers of that band during initialization.
+
+       When referring to a band in the upstream direction, it is the
+       measured difference in the total power transmitted by the xTU-R
+       and the total power received by the xTU-C over all subcarriers of
+       that band during initialization.
+
+       Values range from 0 to 1270 in units of 0.1 dB (physical values
+       are 0 to 127 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the line
+       attenuation is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the line
+       attenuation measurement is unavailable."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.9 (LATNds)
+               and paragraph #7.5.1.10 (LATNus)6"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2LineBandEntry 2 }
+
+xdsl2LineBandStatusSigAtten  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1270 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Signal Attenuation.
+       When referring to a band in the downstream direction, it is
+       the measured difference in the total power transmitted by the
+       xTU-C and the total power received by the xTU-R over all
+       subcarriers of that band during Showtime.
+
+       When referring to a band in the upstream direction, it is the
+
+       measured difference in the total power transmitted by the xTU-R
+       and the total power received by the xTU-C over all subcarriers of
+       that band during Showtime.
+
+       Values range from 0 to 1270 in units of 0.1 dB (physical values
+       are 0 to 127 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the line
+       attenuation is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the line
+       attenuation measurement is unavailable."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.11 (SATNds)
+                 and paragraph #7.5.1.12 (SATNus)"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2LineBandEntry 3 }
+
+xdsl2LineBandStatusSnrMargin  OBJECT-TYPE
+   SYNTAX      Integer32 (-640..630 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "SNR Margin is the maximum increase in dB of the noise power
+       received at the xTU (xTU-R for a band in the downstream direction
+       and xTU-C for a band in the upstream direction), such that the
+       BER requirements are met for all bearer channels received at the
+       xTU.  Values range from -640 to 630 in units of 0.1 dB (physical
+       values are -64 to 63 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the SNR
+       Margin is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the SNR
+       Margin measurement is currently unavailable."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.13 (SNRMds)
+                 and paragraph #7.5.1.14 (SNRMpbds)
+                 and paragraph #7.5.1.16 (SNRMus)
+                 and paragraph #7.5.1.17 (SNRMpbus)"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2LineBandEntry 4 }
+
+------------------------------------------------
+--        xdsl2ChannelStatusTable             --
+------------------------------------------------
+
+xdsl2ChannelStatusTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2ChannelStatusEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2ChannelStatusTable contains status
+
+       parameters of VDSL2/ADSL/ADSL2 or ADSL2+ channel.
+       This table contains live data from equipment."
+   ::= { xdsl2Status 2 }
+
+xdsl2ChannelStatusEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2ChannelStatusEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of a DSL channel.  A second index of
+        this table is the termination unit."
+   INDEX  { ifIndex, xdsl2ChStatusUnit }
+   ::= { xdsl2ChannelStatusTable 1 }
+
+Xdsl2ChannelStatusEntry  ::=
+   SEQUENCE {
+      xdsl2ChStatusUnit                Xdsl2Unit,
+      xdsl2ChStatusActDataRate         Unsigned32,
+      xdsl2ChStatusPrevDataRate        Unsigned32,
+      xdsl2ChStatusActDelay            Unsigned32,
+      xdsl2ChStatusActInp              Unsigned32,
+      xdsl2ChStatusInpReport           Xdsl2ChInpReport,
+      xdsl2ChStatusNFec                Unsigned32,
+      xdsl2ChStatusRFec                Unsigned32,
+      xdsl2ChStatusLSymb               Unsigned32,
+      xdsl2ChStatusIntlvDepth          Unsigned32,
+      xdsl2ChStatusIntlvBlock          Unsigned32,
+      xdsl2ChStatusLPath               Unsigned32,
+      xdsl2ChStatusAtmStatus           Xdsl2ChAtmStatus,
+      xdsl2ChStatusPtmStatus           Xdsl2ChPtmStatus
+   }
+
+xdsl2ChStatusUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2ChannelStatusEntry 1 }
+
+xdsl2ChStatusActDataRate  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The actual net data rate at which the bearer channel is
+
+       operating, if in L0 power management state.  In L1 or L2
+       states, it relates to the previous L0 state.  The data rate is
+       coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.1
+                (Actual data rate)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 2 }
+
+xdsl2ChStatusPrevDataRate  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The previous net data rate that the bearer channel was
+       operating at just before the latest rate change event.  This
+       could be a full or short initialization, fast retrain, DRA or
+       power management transitions, excluding transitions between L0
+       state and L1 or L2 states.  The data rate is coded in
+       bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.2
+                (Previous data rate)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 3 }
+
+xdsl2ChStatusActDelay  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..8176)
+   UNITS       "milliseconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The actual one-way interleaving delay introduced by the
+       PMS-TC in the direction of the bearer channel, if in L0 power
+       management state.  In L1 or L2 states, it relates to the previous
+       L0 state.  It is coded in ms (rounded to the nearest ms)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.3
+                (Actual interleaving delay)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 4 }
+
+xdsl2ChStatusActInp  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..255)
+   UNITS       "0.1 symbols"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual impulse noise protection.
+       This parameter reports the actual impulse noise protection (INP)
+
+       on the bearer channel in the L0 state.  In the L1 or L2 state,
+       the parameter contains the INP in the previous L0 state.  For
+       ADSL, this value is computed according to the formula specified
+       in the relevant Recommendation based on the actual framing
+       parameters.  For ITU-T Recommendation G.993.2, the method to
+       report this value is according to the INPREPORT parameter.
+       The value is coded in fractions of DMT symbols with a
+       granularity of 0.1 symbols.  The range is from 0 to 25.4.
+       The special value of 255 indicates an ACTINP higher
+       than 25.4."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.4 (ACTINP)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 5 }
+
+xdsl2ChStatusInpReport  OBJECT-TYPE
+   SYNTAX      Xdsl2ChInpReport
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Impulse noise protection reporting mode."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.5.2.5
+                (INPREPORT)"
+   DEFVAL       { inpComputedUsingFormula }
+   ::= { xdsl2ChannelStatusEntry 6 }
+
+xdsl2ChStatusNFec  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..255)
+   UNITS       "bytes"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual size of Reed-Solomon codeword.
+       This parameter reports the actual number of Reed-Solomon
+       redundancy bytes per codeword used in the latency path in which
+       the bearer channel is transported.  The value is coded in bytes.
+       It ranges from 0 to 16.
+       The value 0 indicates no Reed-Solomon coding."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.1 (NFEC)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 7 }
+
+xdsl2ChStatusRFec  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16)
+   UNITS       "bits"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual number of Reed-Solomon redundancy bytes.
+
+       This parameter reports the actual number of Reed-Solomon
+       redundancy bytes per codeword used in the latency path in which
+       the bearer channel is transported.  The value is coded in bytes.
+       It ranges from 0 to 16.
+       The value 0 indicates no Reed-Solomon coding."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.2 (RFEC)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 8 }
+
+xdsl2ChStatusLSymb  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..65535)
+   UNITS       "bits"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual number of bits per symbol.
+       This parameter reports the actual number of bits per symbol
+       assigned to the latency path in which the bearer channel is
+       transported.  This value does not include trellis overhead.  The
+       value is coded in bits.
+       It ranges from 0 to 65535."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.3 (LSYMB)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 9 }
+
+xdsl2ChStatusIntlvDepth  OBJECT-TYPE
+   SYNTAX      Unsigned32(1..4096)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual interleaving depth.
+       This parameter reports the actual depth of the interleaver used
+       in the latency path in which the bearer channel is transported.
+       The value ranges from 1 to 4096 in steps of 1.
+       The value 1 indicates no interleaving."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.4 (INTLVDEPTH)"
+   DEFVAL       { 1 }
+   ::= { xdsl2ChannelStatusEntry 10 }
+
+xdsl2ChStatusIntlvBlock  OBJECT-TYPE
+   SYNTAX      Unsigned32(4..255)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual interleaving block length.
+       This parameter reports the actual block length of the interleaver
+       used in the latency path in which the bearer channel is
+       transported.
+
+       The value ranges from 4 to 255 in steps of 1."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.2.6.5 (INTLVBLOCK)"
+   DEFVAL       { 4 }
+   ::= { xdsl2ChannelStatusEntry 11 }
+
+xdsl2ChStatusLPath  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..3)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Actual latency path.
+       This parameter reports the index of the actual latency path in
+       which the bearer is transported.
+       The valid values are 0, 1, 2 and 3.
+       For G.992.1, the FAST path shall be mapped to the latency
+       index 0, and the INTERLEAVED path shall be mapped to the latency
+       index 1."
+   REFERENCE    "ITU-T G.997.1 amendment 1, paragraph #7.5.2.7
+                 (LPATH)"
+   DEFVAL       { 0 }
+   ::= { xdsl2ChannelStatusEntry 12 }
+
+xdsl2ChStatusAtmStatus  OBJECT-TYPE
+   SYNTAX      Xdsl2ChAtmStatus
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates current state (existing failures) of the DSL
+       channel in case its Data Path is ATM.  This is a bitmap of
+       possible conditions.
+       In case the channel is not of ATM Data Path, the object is set
+       to '0'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.1.4
+                 (ATM data path failures)"
+   DEFVAL       { { noDefect } }
+   ::= { xdsl2ChannelStatusEntry 13 }
+
+xdsl2ChStatusPtmStatus  OBJECT-TYPE
+   SYNTAX      Xdsl2ChPtmStatus
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Indicates current state (existing failures) of the DSL
+       channel in case its Data Path is PTM (Packet Transfer Mode).
+       This is a bitmap of possible conditions.
+      In case the channel is not of PTM Data Path, the object is set
+      to '0'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.1.5
+
+                 (PTM Data Path failures)"
+   DEFVAL       { { noDefect } }
+   ::= { xdsl2ChannelStatusEntry 14 }
+
+------------------------------------------------
+--    Scalars that relate to the SC Status Tables
+------------------------------------------------
+
+xdsl2ScalarSCMaxInterfaces  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This value determines the maximum number of
+       interfaces supported by xdsl2SCStatusTable,
+       xdsl2SCStatusBandTable, and xdsl2SCStatusSegmentTable."
+   ::= { xdsl2ScalarSC 1 }
+
+xdsl2ScalarSCAvailInterfaces  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This value determines the currently available number of
+       interfaces listed in xdsl2SCStatusTable,
+       xdsl2SCStatusBandTable, and xdsl2SCStatusSegmentTable."
+   ::= { xdsl2ScalarSC 2 }
+
+------------------------------------------------
+--        xdsl2SCStatusTable                  --
+------------------------------------------------
+
+xdsl2SCStatusTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2SCStatusEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2SCStatusTable contains
+       status parameters for VDSL2/ADSL/ADSL2 and ADSL2+ that
+       provide information about the size of parameters in
+       xdsl2SCStatusSegmentTable.
+       The parameters in this table MUST be updated after a loop
+       diagnostic procedure, MAY be updated after a line
+       initialization, and MAY be updated at Showtime."
+   ::= { xdsl2Status 3 }
+
+xdsl2SCStatusEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2SCStatusEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of vdsl2(251).  A second index of this
+        table is the transmission direction."
+   INDEX  { ifIndex, xdsl2SCStatusDirection }
+   ::= { xdsl2SCStatusTable 1 }
+
+Xdsl2SCStatusEntry  ::=
+   SEQUENCE {
+      xdsl2SCStatusDirection         Xdsl2Direction,
+      xdsl2SCStatusLinScale          Unsigned32,
+      xdsl2SCStatusLinScGroupSize    Unsigned32,
+      xdsl2SCStatusLogMt             Unsigned32,
+      xdsl2SCStatusLogScGroupSize    Unsigned32,
+      xdsl2SCStatusQlnMt             Unsigned32,
+      xdsl2SCStatusQlnScGroupSize    Unsigned32,
+      xdsl2SCStatusSnrMtime          Unsigned32,
+      xdsl2SCStatusSnrScGroupSize    Unsigned32,
+      xdsl2SCStatusAttainableRate    Unsigned32,
+      xdsl2SCStatusRowStatus         RowStatus
+   }
+
+xdsl2SCStatusDirection  OBJECT-TYPE
+     SYNTAX      Xdsl2Direction
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The direction of the subcarrier either
+      upstream or downstream."
+     ::= { xdsl2SCStatusEntry 1 }
+
+xdsl2SCStatusLinScale  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..65535)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The scale factor to be applied to the H(f) linear
+      representation values for the respective transmission direction.
+      This parameter is only available after a loop diagnostic
+      procedure.  It is represented as an unsigned integer in the range
+      from 1 to 2^16-1."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.1 (HLINSCds)
+               and paragraph #7.5.1.26.7 (HLINSCus)"
+     ::= { xdsl2SCStatusEntry 2 }
+
+xdsl2SCStatusLinScGroupSize OBJECT-TYPE
+     SYNTAX      Unsigned32(1 | 2 | 4 | 8)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of subcarriers per group used to report the H(f)
+      linear representation values for the respective transmission
+      direction.  The valid values are 1, 2, 4, and 8.  For ADSL, this
+      parameter is equal to one and, for VDSL2, it is equal to the size
+      of a subcarrier group used to compute these parameters.
+      This parameter is only available after a loop diagnostic
+      procedure."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.2 (HLINGds)
+               and paragraph #7.5.1.26.8 (HLINGus)"
+     ::= { xdsl2SCStatusEntry 3 }
+
+xdsl2SCStatusLogMt  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..65535)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "This parameter contains the number of symbols used to
+      measure the Hlog(f) values.  It is represented as an unsigned
+      integer in the range from 1 to 2^16-1.
+      After a loop diagnostic procedure, this parameter shall contain
+      the number of symbols used to measure the Hlog(f).  It should
+      correspond to the value specified in the Recommendation (e.g., the
+      number of symbols in 1 s time interval for ITU-T Recommendation.
+      G.992.3)."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.4 (HLOGMTds)
+               and paragraph #7.5.1.26.10 (HLOGMTus)"
+     ::= { xdsl2SCStatusEntry 4 }
+
+xdsl2SCStatusLogScGroupSize OBJECT-TYPE
+     SYNTAX      Unsigned32(1 | 2 | 4 | 8)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of subcarriers per group used to report the H(f)
+      logarithmic representation values for the respective
+      transmission direction.  The valid values are 1, 2, 4, and 8.
+      For ADSL, this parameter is equal to 1, and for VDSL2, it is
+      equal to the size of a subcarrier group used to compute these
+      parameters."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.5 (HLOGGds)
+               and paragraph #7.5.1.26.11 (HLOGGus)"
+     ::= { xdsl2SCStatusEntry 5 }
+
+xdsl2SCStatusQlnMt  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..65535)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "This parameter contains the number of symbols used to
+      measure the QLN(f) values.  It is an unsigned integer in the range
+      from 1 to 2^16-1.  After a loop diagnostic procedure, this
+      parameter shall contain the number of symbols used to measure the
+      QLN(f).  It should correspond to the value specified in the
+      Recommendation (e.g., the number of symbols in 1 s time interval
+      for ITU-T Recommendation G.992.3)."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.27.1 (QLNMTds)
+               and paragraph #7.5.1.27.4 (QLNMTus)"
+     ::= { xdsl2SCStatusEntry 6 }
+
+xdsl2SCStatusQlnScGroupSize OBJECT-TYPE
+     SYNTAX      Unsigned32(1 | 2 | 4 | 8)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of subcarriers per group used to report the Quiet
+      Line Noise values for the respective transmission direction.
+      The valid values are 1, 2, 4, and 8.
+      For ADSL, this parameter is equal to 1, and for VDSL2, it is
+      equal to the size of a subcarrier group used to compute these
+      parameters."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.27.2 (QLNGds)
+               and paragraph #7.5.1.27.5 (QLNGus)"
+     ::= { xdsl2SCStatusEntry 7 }
+
+xdsl2SCStatusSnrMtime  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..65535)
+     UNITS       "symbols"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "This parameter contains the number of symbols used to measure
+      the SNR(f) values.  It is an unsigned integer in the range from 1
+      to 2^16-1.  After a loop diagnostic procedure, this parameter
+      shall contain the number of symbols used to measure the SNR(f).
+      It should correspond to the value specified in the Recommendation
+      (e.g., the number of symbols in 1 s time interval for ITU-T
+      Recommendation G.992.3)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.28.1 (SNRMTds)
+                 and paragraph #7.5.1.28.4 (SNRMTus)"
+     ::= { xdsl2SCStatusEntry 8 }
+
+xdsl2SCStatusSnrScGroupSize OBJECT-TYPE
+     SYNTAX      Unsigned32(1 | 2 | 4 | 8)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "Number of subcarriers per group used to report the SNR values
+      on the respective transmission direction.
+      The valid values are 1, 2, 4, and 8.
+      For ADSL, this parameter is equal to 1, and for VDSL2, it is
+      equal to the size of a subcarrier group used to compute these
+      parameters."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.28.2 (SNRGds)
+               and paragraph #7.5.1.28.5 (SNRGus)"
+     ::= { xdsl2SCStatusEntry 9 }
+
+xdsl2SCStatusAttainableRate  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Maximum Attainable Data Rate.  The maximum net data rate
+       currently attainable by the xTU-C transmitter and xTU-R receiver
+       (when referring to downstream direction) or by the xTU-R
+       transmitter and xTU-C receiver (when referring to upstream
+       direction).  Value is coded in bits/s.
+       This object reflects the value of the parameter following the
+       most recent DELT performed on the associated line.  Once the DELT
+       process is over, the parameter no longer changes until the row is
+       deleted or a new DELT process is initiated."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.19 (ATTNDRds)
+               and paragraph #7.5.1.20 (ATTNDRus)"
+   ::= { xdsl2SCStatusEntry 10 }
+
+xdsl2SCStatusRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+     "Row Status.  The SNMP agent will create a row in this table
+      for storing the results of a DELT performed on the associated
+      line, if the row does not already exist.
+
+      When a row is created in this table, the SNMP agent should also
+      create corresponding rows in the tables xdsl2SCStatusBandTable and
+      xdsl2SCStatusSegmentTable.
+
+      The SNMP manager is not permitted to create rows in this table or
+      set the row status to 'notInService'.  In the first case,
+      if the SNMP manager tries to create a new row, the SNMP agent
+      responds with the value 'noCreation' in the error status
+      field of the response-PDU.  In the latter case the SNMP agent
+      responds with the value 'wrongValue' in the error status
+      field of the response-PDU.
+
+      When a row is deleted in this table, the SNMP agent should also
+      delete corresponding rows in the tables xdsl2SCStatusBandTable and
+      xdsl2SCStatusSegmentTable.
+
+      The SNMP agent may have limited resources; therefore, if multiple
+      rows coexist in this table, it may fail to add new rows to this
+      table or allocate memory resources for a new DELT process.  If
+      that occurs, the SNMP agent responds with either the value
+      'tableFull' or the value 'noResources' (for
+      the xdsl2LineCmndConfLdsfFailReason object in xdsl2LineTable).
+
+      The management system (the operator) may delete rows from this
+      table according to any scheme.  For example, after retrieving the
+      results."
+     ::= { xdsl2SCStatusEntry 11 }
+
+------------------------------------------------
+--        xdsl2SCStatusBandTable              --
+------------------------------------------------
+
+xdsl2SCStatusBandTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2SCStatusBandEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2SCStatusBandTable contains subcarrier status
+       parameters for VDSL2/ADSL/ADSL2 and ADSL2+ that are grouped per-
+       band.
+       For ADSL/ADSL2/ADSL2+, there is a single upstream band and a
+       single downstream band.  For VDSL2, there are several downstream
+       bands and several upstream bands.
+       The parameters in this table are only available after a loop
+       diagnostic procedure."
+   ::= { xdsl2Status 4 }
+
+xdsl2SCStatusBandEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2SCStatusBandEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+       interface
+
+       has an ifType of vdsl2(251).  A second index of this table is the
+       transmission band."
+   INDEX  { ifIndex, xdsl2SCStatusBand }
+   ::= { xdsl2SCStatusBandTable 1 }
+
+Xdsl2SCStatusBandEntry  ::=
+   SEQUENCE {
+      xdsl2SCStatusBand                  Xdsl2Band,
+      xdsl2SCStatusBandLnAtten           Unsigned32,
+      xdsl2SCStatusBandSigAtten          Unsigned32
+   }
+
+xdsl2SCStatusBand OBJECT-TYPE
+     SYNTAX      Xdsl2Band
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The transmission band."
+     ::= { xdsl2SCStatusBandEntry 1 }
+
+xdsl2SCStatusBandLnAtten  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1270 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "When referring to a band in the downstream direction, it is
+       the measured difference in the total power transmitted by the
+       xTU-C and the total power received by the xTU-R over all
+       subcarriers during diagnostics mode.
+       When referring to a band in the upstream direction, it is the
+       measured difference in the total power transmitted by the xTU-R
+       and the total power received by the xTU-C over all subcarriers
+       during diagnostics mode.
+       It ranges from 0 to 1270 units of 0.1 dB (physical values are 0
+       to 127 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the line
+       attenuation is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the line
+       attenuation measurement is unavailable.
+       This object reflects the value of the parameter following the
+       most recent DELT performed on the associated line.  Once the DELT
+       process is over, the parameter no longer changes until the row is
+       deleted or a new DELT process is initiated."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.9 (LATNds)
+               and paragraph #7.5.1.10 (LATNus)"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2SCStatusBandEntry 2 }
+
+xdsl2SCStatusBandSigAtten  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1270 | 2147483646 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "When referring to a band in the downstream direction, it is the
+       measured difference in the total power transmitted by the xTU-C
+       and the total power received by the xTU-R over all subcarriers
+       during Showtime after the diagnostics mode.
+       When referring to the upstream direction, it is the measured
+       difference in the total power transmitted by the xTU-R and the
+       total power received by the xTU-C over all subcarriers during
+       Showtime after the diagnostics mode.
+       It ranges from 0 to 1270 units of 0.1 dB (physical values are 0
+       to 127 dB).
+       A special value of 0x7FFFFFFF (2147483647) indicates the line
+       attenuation is out of range to be represented.
+       A special value of 0x7FFFFFFE (2147483646) indicates the line
+       attenuation measurement is unavailable.
+       This object reflects the value of the parameter following the
+       most recent DELT performed on the associated line.  Once the DELT
+       process is over, the parameter no longer changes until the row is
+       deleted or a new DELT process is initiated."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.11 (SATNds)
+               and paragraph #7.5.1.12 (SATNus)"
+   DEFVAL       { 2147483646 }
+   ::= { xdsl2SCStatusBandEntry 3 }
+
+------------------------------------------------
+--        xdsl2SCStatusSegmentTable           --
+------------------------------------------------
+
+xdsl2SCStatusSegmentTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2SCStatusSegmentEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2SCStatusSegmentTable contains status
+       parameters of VDSL2/ADSL/ADSL2 and ADSL2+ subcarriers.
+
+       Several objects in the table refer to NSus and NSds.  For
+       G.993.2, the value of NSus and NSds are, respectively, the
+       indices of the highest supported upstream and downstream
+       subcarriers according to the selected implementation profile.
+       For ADSL, NSus is equal to NSCus-1 and NSds is equal to NSCds-1.
+
+       The parameters in this table MUST be updated after a loop
+
+       diagnostic procedure and MAY be updated after a line
+       initialization and MAY be updated at Showtime."
+   ::= { xdsl2Status 5 }
+
+xdsl2SCStatusSegmentEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2SCStatusSegmentEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+       interface has an ifType of vdsl2(251).  A second index of this
+       table is the transmission direction.  A third index identifies
+       the specific segment of the subcarriers status addressed."
+   INDEX  { ifIndex,
+            xdsl2SCStatusDirection,
+            xdsl2SCStatusSegment   }
+   ::= { xdsl2SCStatusSegmentTable 1 }
+
+Xdsl2SCStatusSegmentEntry  ::=
+   SEQUENCE {
+      xdsl2SCStatusSegment                  Unsigned32,
+      xdsl2SCStatusSegmentLinReal           OCTET STRING,
+      xdsl2SCStatusSegmentLinImg            OCTET STRING,
+      xdsl2SCStatusSegmentLog               OCTET STRING,
+      xdsl2SCStatusSegmentQln               OCTET STRING,
+      xdsl2SCStatusSegmentSnr               OCTET STRING,
+      xdsl2SCStatusSegmentBitsAlloc         Xdsl2BitsAlloc,
+      xdsl2SCStatusSegmentGainAlloc         OCTET STRING
+   }
+
+xdsl2SCStatusSegment  OBJECT-TYPE
+     SYNTAX      Unsigned32(1..8)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "The segment of the subcarriers status information provided by
+      this row.
+      Several status parameters in this table are retrieved in segments.
+      The first segment of the status information is retrieved with
+      xdsl2SCStatusSegment=1, the second segment is retrieved with
+      xdsl2SCStatusSegment=2, and so on.  When any status parameter is
+      retrieved in n segments where n<8), then for that parameter,
+      GET operations for the remaining segment numbers (n+1 to 8) will
+      respond with a zero-length OCTET STRING."
+     ::= { xdsl2SCStatusSegmentEntry 1 }
+
+xdsl2SCStatusSegmentLinReal  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..1024))
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "An array of up to 512 complex H(f) linear representation
+      values in linear scale for the respective transmission direction.
+      It is designed to support up to 512 (downstream) subcarrier
+      groups and can be retrieved in a single segment.
+      The number of utilized values in the downstream direction depends
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Each array entry represents the real component (referred to here
+      as a(i)) of Hlin(f = i*Df) value for a particular subcarrier
+      group index i (0 <= i <= NS).
+      Hlin(f) is represented as ((scale/2^15)*((a(i)+j*b(i))/2^15)),
+      where scale is xdsl2SCStatusLinScale and a(i) and b(i)
+      (provided by the xdsl2SCStatusSegmentLinImg object) are in the
+      range (-2^15+1) to (+2^15-1).
+      A special value a(i)=b(i)= -2^15 indicates that no measurement
+      could be done for the subcarrier group because it is out of the
+      passband or that the attenuation is out of range to be
+      represented.  This parameter is only available after a loop
+      diagnostic procedure.
+      Each value in this array is 16 bits wide and is stored in big
+      endian format."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.3 (HLINpsds)
+               and paragraph #7.5.1.26.9 (HLINpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 2 }
+
+xdsl2SCStatusSegmentLinImg  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..1024))
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "An array of up to 512 complex H(f) linear representation
+      values in linear scale for the respective transmission direction.
+      It is designed to support up to 512 (downstream) subcarrier
+      groups and can be retrieved in a single segment.
+      The number of utilized values in the downstream direction depends
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Each array entry represents the imaginary component (referred to
+      here as b(i)) of Hlin(f = i*Df) value for a particular
+      subcarrier group index i (0 <= i <= NS).
+      Hlin(f) is represented as ((scale/2^15)*((a(i)+j*b(i))/2^15)),
+      where scale is xdsl2SCStatusLinScale and a(i) (provided by the
+      xdsl2SCStatusSegmentLinReal object) and b(i) are in the range
+      (-2^15+1) to (+2^15-1).
+      A special value a(i)=b(i)= -2^15 indicates that no measurement
+
+      could be done for the subcarrier group because it is out of the
+      passband or that the attenuation is out of range to be
+      represented.  This parameter is only available after a loop
+      diagnostic procedure.
+      Each value in this array is 16 bits wide and is stored in big
+      endian format."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.3 (HLINpsds)
+               and paragraph #7.5.1.26.9 (HLINpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 3 }
+
+xdsl2SCStatusSegmentLog  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..1024))
+     UNITS       "dB"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "An array of up to 512 real H(f) logarithmic representation
+      values in dB for the respective transmission direction.  It is
+      designed to support up to 512 (downstream) subcarrier groups
+      and can be retrieved in a single segment.
+      The number of utilized values in the downstream direction depends
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Each array entry represents the real Hlog(f = i*Df) value for a
+      particular subcarrier group index i, (0 <= i <= NS).
+      The real Hlog(f) value is represented as (6-m(i)/10), with m(i)
+      in the range 0 to 1022.  A special value m=1023 indicates that
+      no measurement could be done for the subcarrier group because
+      it is out of the passband or that the attenuation is out of
+      range to be represented.  This parameter is applicable in loop
+      diagnostic procedure and initialization.
+      Each value in this array is 16 bits wide and is stored in big
+      endian format."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.26.6 (HLOGpsds)
+               and paragraph #7.5.1.26.12 (HLOGpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 4 }
+
+xdsl2SCStatusSegmentQln  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..512))
+     UNITS       "dBm/Hz"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "An array of up to 512 real Quiet Line Noise values in dBm/Hz
+      for the respective transmission direction.  It is designed for up
+      to 512 (downstream) subcarrier groups and can be retrieved in a
+      single segment.
+      The number of utilized values in the downstream direction depends
+
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Each array entry represents the QLN(f = i*Df) value for a
+      particular subcarrier index i, (0 <= i <= NS).
+      The QLN(f) is represented as ( -23-n(i)/2), with n(i) in the range
+      0 to 254.  A special value n(i)=255 indicates that no measurement
+      could be done for the subcarrier group because it is out of the
+      passband or that the noise PSD is out of range to be represented.
+      This parameter is applicable in loop diagnostic procedure and
+      initialization.  Each value in this array is 8 bits wide."
+   REFERENCE  "ITU-T G.997.1, paragraph #7.5.1.27.3 (QLNpsds)
+               and paragraph #7.5.1.27.6 (QLNpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 5 }
+
+xdsl2SCStatusSegmentSnr  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..512))
+     UNITS       "0.5 dB"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The SNR Margin per subcarrier group, expressing the ratio
+      between the received signal power and received noise power per
+      subscriber group.  It is an array of 512 octets, designed for
+      supporting up to 512 (downstream) subcarrier groups and can be
+      retrieved in a single segment.
+      The number of utilized octets in the downstream direction depends
+      on NSds; in the upstream direction, it depends on NSus.  This
+      value is referred to here as NS.
+      Octet i (0 <= i <= NS) is set to a value in the range 0 to
+      254 to indicate that the respective downstream or upstream
+      subcarrier group i has an SNR of:
+      (-32 + xdsl2SCStatusSegmentSnr(i)/2) in dB (i.e., -32 to 95 dB).
+      The special value 255 means that no measurement could be done for
+      the subcarrier group because it is out of the PSD mask passband or
+      that the noise PSD is out of range to be represented.  Each value
+      in this array is 8 bits wide."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.28.3 (SNRpsds)
+                 and paragraph #7.5.1.28.6 (SNRpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 6 }
+
+xdsl2SCStatusSegmentBitsAlloc  OBJECT-TYPE
+     SYNTAX      Xdsl2BitsAlloc
+     UNITS       "bits"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The bits allocation per subcarrier.  An array of 256 octets
+      (512 nibbles) designed for supporting up to 512 (downstream)
+
+      subcarriers.  When more than 512 subcarriers are supported, the
+      status information is reported through multiple (up to 8)
+      segments.  The first segment is then used for the first 512
+      subcarriers.  The second segment is used for the subcarriers
+      512 to 1023 and so on.
+      The aggregate number of utilized nibbles in the downstream
+      direction (in all segments) depends on NSds; in the upstream
+      direction, it depends on NSus.
+      This value is referred to here as NS.  The segment number is in
+      xdsl2SCStatusSegment.
+      Nibble i (0 <= i < MIN((NS+1)-(segment-1)*512,512)) in each
+      segment is set to a value in the range 0 to 15 to indicate that
+      the respective downstream or upstream subcarrier j
+      (j=(segement-1)*512+i) has the same amount of bits
+      allocation."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.29.1 (BITSpsds)
+                 and paragraph #7.5.1.29.2 (BITSpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 7 }
+
+xdsl2SCStatusSegmentGainAlloc  OBJECT-TYPE
+     SYNTAX      OCTET STRING  (SIZE(0..1024))
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+     "The gain allocation per subcarrier.  An array of 512 16-bit
+      values, designed for supporting up to 512 (downstream)
+      subcarriers.  When more then 512 subcarriers are supported, the
+      status information is reported through multiple (up to 8)
+      segments.  The first segment is then used for the first 512
+      subcarriers.  The second segment is used for the subcarriers 512
+      to 1023 and so on.
+      The aggregate number of utilized octets in the downstream
+      direction depends on NSds; in the upstream direction, it depends
+      on NSus.  This value is referred to here as NS.  The segment
+      number is in xdsl2SCStatusSegment.
+      Value i (0 <= i < MIN((NS+1)-(segment-1)*512,512)) in each
+      segment is set to a value in the range 0 to 4093 to indicate that
+      the respective downstream or upstream subcarrier j
+      (j=(segement-1)*512+i) has the same amount of gain value.
+      The gain value is represented as a multiple of 1/512 on a linear
+      scale.  Each value in this array is 16 bits wide and is stored in
+      big endian format."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.5.1.29.3 (GAINSpsds)
+                 and paragraph #7.5.1.29.4 (GAINSpsus)"
+     ::= { xdsl2SCStatusSegmentEntry 8 }
+
+------------------------------------------------
+--        xdsl2LineInventoryTable             --
+
+------------------------------------------------
+
+xdsl2LineInventoryTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineInventoryEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineInventoryTable contains an inventory of the
+       DSL termination unit."
+   ::= { xdsl2Inventory 1 }
+
+xdsl2LineInventoryEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineInventoryEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+       interface
+       has an ifType of vdsl2(251).  A second index of this table is the
+       termination unit."
+   INDEX  { ifIndex, xdsl2LInvUnit }
+   ::= { xdsl2LineInventoryTable 1 }
+
+Xdsl2LineInventoryEntry  ::=
+   SEQUENCE {
+      xdsl2LInvUnit                      Xdsl2Unit,
+      xdsl2LInvG994VendorId              OCTET STRING,
+      xdsl2LInvSystemVendorId            OCTET STRING,
+      xdsl2LInvVersionNumber             OCTET STRING,
+      xdsl2LInvSerialNumber              OCTET STRING,
+      xdsl2LInvSelfTestResult            Unsigned32,
+      xdsl2LInvTransmissionCapabilities  Xdsl2TransmissionModeType
+   }
+
+xdsl2LInvUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2LineInventoryEntry 1 }
+
+xdsl2LInvG994VendorId  OBJECT-TYPE
+   SYNTAX      OCTET STRING  (SIZE(8))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The ADSL Transceiver Unit (ATU) G.994.1 Vendor ID as
+
+       inserted in the G.994.1 CL/CLR message.
+       It consists of 8 binary octets, including a country
+       code followed by a (regionally allocated) provider code, as
+       defined in Recommendation T.35."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.1-7.4.2"
+   ::= { xdsl2LineInventoryEntry 2 }
+
+xdsl2LInvSystemVendorId  OBJECT-TYPE
+   SYNTAX      OCTET STRING  (SIZE(8))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The ATU System Vendor ID (identifies the xTU system
+       integrator) as inserted in the Overhead Messages (both xTUs for
+       G.992.3, G.992.4, G.992.5, and G.993.2) or in the Embedded
+       Operations Channel (xTU-R in G.992.1 and G.992.2).
+       It consists of 8 binary octets, with same format as used for
+       Xdsl2InvG994VendorId."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.3-7.4.4"
+   ::= { xdsl2LineInventoryEntry 3 }
+
+xdsl2LInvVersionNumber  OBJECT-TYPE
+   SYNTAX      OCTET STRING  (SIZE(0..16))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU version number (vendor-specific information) as
+       inserted in the Overhead Messages (both xTUs for G.992.3,
+       G.992.4, G.992.5, and G.993.2) or in the Embedded Operations
+       Channel (xTU-R in G.992.1 and G.992.2).  It consists of up to 16
+       binary octets."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.5-7.4.6"
+   ::= { xdsl2LineInventoryEntry 4 }
+
+xdsl2LInvSerialNumber  OBJECT-TYPE
+   SYNTAX      OCTET STRING  (SIZE(0..32))
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU serial number (vendor-specific information) as
+       inserted in the Overhead Messages (both xTUs for G.992.3,
+       G.992.4, G.992.5, and G.993.2) or in the Embedded Operations
+       Channel (xTU-R in G.992.1 and G.992.2).  It is vendor-specific
+       information consisting of up to 32 ASCII characters."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.7-7.4.8"
+   ::= { xdsl2LineInventoryEntry 5 }
+
+xdsl2LInvSelfTestResult  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU self-test result, coded as a 32-bit value.  The
+       most significant octet of the result is '0' if the
+       self-test passed, and '1' if the self-test failed.  The
+       interpretation of the other octets is vendor discretionary."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.9-7.4.10"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineInventoryEntry 6 }
+
+xdsl2LInvTransmissionCapabilities  OBJECT-TYPE
+   SYNTAX      Xdsl2TransmissionModeType
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The xTU transmission system capability list of the different
+       coding types.  It is coded in a bitmap representation with 1 or
+       more bits set.  A bit set to '1' means that the xTU
+       supports the respective coding.  The value may be derived from
+       the handshaking procedures defined in G.994.1.  A set of xDSL
+       line transmission modes, with one bit per mode."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.4.11-7.4.12"
+   ::= { xdsl2LineInventoryEntry 7 }
+
+------------------------------------------------
+--        xdsl2LineConfTemplateTable          --
+------------------------------------------------
+
+xdsl2LineConfTemplateTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineConfTemplateEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfTemplateTable contains VDSL2/ADSL/
+       ADSL2 and ADSL2+ line configuration templates.
+
+       Note that this table is also used to configure the number of
+       bearer channels.
+       When the number of bearer channels is increased, the SNMP agent
+       SHOULD create rows in all tables indexed by a channel index.
+       When the number of bearer channels is decreased, the SNMP agent
+       SHOULD delete rows in all tables indexed by a channel index.
+       For example, if the value of xdsl2LConfTempChan4ConfProfile is
+       set to a non-null value, then rows SHOULD be created in
+       xdsl2ChannelStatusTable, xdsl2PMChCurrTable, and all other tables
+       indexed by a channel index.
+
+       For example, if the value of xdsl2LConfTempChan2ConfProfile is
+       set to a null value, then rows SHOULD be deleted in
+       xdsl2ChannelStatusTable, xdsl2PMChCurrTable, and all other
+       tables indexed by a channel index.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileLine 1 }
+
+xdsl2LineConfTemplateEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineConfTemplateEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "A default template with an index of 'DEFVAL' will always
+       exist, and its parameters will be set to vendor-specific values,
+       unless otherwise specified in this document."
+   INDEX  { xdsl2LConfTempTemplateName }
+   ::= { xdsl2LineConfTemplateTable 1 }
+
+Xdsl2LineConfTemplateEntry  ::=
+   SEQUENCE {
+      xdsl2LConfTempTemplateName      SnmpAdminString,
+      xdsl2LConfTempLineProfile       SnmpAdminString,
+      xdsl2LConfTempChan1ConfProfile  SnmpAdminString,
+      xdsl2LConfTempChan1RaRatioDs    Unsigned32,
+      xdsl2LConfTempChan1RaRatioUs    Unsigned32,
+      xdsl2LConfTempChan2ConfProfile  SnmpAdminString,
+      xdsl2LConfTempChan2RaRatioDs    Unsigned32,
+      xdsl2LConfTempChan2RaRatioUs    Unsigned32,
+      xdsl2LConfTempChan3ConfProfile  SnmpAdminString,
+      xdsl2LConfTempChan3RaRatioDs    Unsigned32,
+      xdsl2LConfTempChan3RaRatioUs    Unsigned32,
+      xdsl2LConfTempChan4ConfProfile  SnmpAdminString,
+      xdsl2LConfTempChan4RaRatioDs    Unsigned32,
+      xdsl2LConfTempChan4RaRatioUs    Unsigned32,
+      xdsl2LConfTempRowStatus         RowStatus
+   }
+
+xdsl2LConfTempTemplateName  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "This object identifies a row in this table."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.4"
+   ::= { xdsl2LineConfTemplateEntry 1 }
+
+xdsl2LConfTempLineProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the
+       VDSL2/ADSL/ADSL2 and ADSL2+ line configuration Profile Table
+       (xdsl2LineConfProfTable) that applies for this DSL line."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.4"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineConfTemplateEntry 2 }
+
+xdsl2LConfTempChan1ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the VDSL2/
+       ADSL/ADSL2 and ADSL2+ channel configuration Profile Table
+       (xdsl2ChConfProfileTable) that applies to DSL bearer channel #1.
+       The channel profile name specified here MUST match the name of an
+       existing row in the xdsl2ChConfProfileTable table."
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineConfTemplateEntry 3 }
+
+xdsl2LConfTempChan1RaRatioDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #1 when performing rate
+       adaptation on Downstream.  The ratio refers to the available data
+       rate in excess of the Minimum Data Rate, summed over all bearer
+       channels.
+       Also, the 100 - xdsl2LConfTempChan1RaRatioDs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Downstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                (Rate adaptation ratio)"
+   DEFVAL       { 100 }
+   ::= { xdsl2LineConfTemplateEntry 4 }
+
+xdsl2LConfTempChan1RaRatioUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #1 when performing
+       rate adaptation on Upstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan1RaRatioUs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Upstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 100 }
+   ::= { xdsl2LineConfTemplateEntry 5 }
+
+xdsl2LConfTempChan2ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the VDSL2/
+       ADSL/ADSL2 and ADSL2+ channel configuration Profile Table
+       (xdsl2ChConfProfileTable) that applies to DSL bearer channel #2.
+       If the channel is unused, then the object is set to a zero-length
+       string.
+       This object may be set to a zero-length string only if
+       xdsl2LConfTempChan3ConfProfile contains a zero-length
+       string."
+   DEFVAL       { "" }
+   ::= { xdsl2LineConfTemplateEntry 6 }
+
+xdsl2LConfTempChan2RaRatioDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #2 when performing
+       rate adaptation on Downstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan2RaRatioDs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Downstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to
+
+       100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 7 }
+
+xdsl2LConfTempChan2RaRatioUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #2 when performing
+       rate adaptation on Upstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan2RaRatioUs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Upstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 8 }
+
+xdsl2LConfTempChan3ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the VDSL2/
+       ADSL/ADSL2 and ADSL2+ channel configuration Profile Table
+       (xdsl2ChConfProfileTable) that applies to DSL bearer channel #3.
+       If the channel is unused, then the object is set to a zero-length
+       string.
+       This object may be set to a zero-length string only if
+       xdsl2LConfTempChan4ConfProfile contains a zero-length string.
+       This object may be set to a non-zero-length string only if
+       xdsl2LConfTempChan2ConfProfile contains a non-zero-length
+       string."
+   DEFVAL       { "" }
+   ::= { xdsl2LineConfTemplateEntry 9 }
+
+xdsl2LConfTempChan3RaRatioDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #3 when performing
+       rate adaptation on Downstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan3RaRatioDs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Downstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 10 }
+
+xdsl2LConfTempChan3RaRatioUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #3 when performing
+       rate adaptation on Upstream.  The ratio refers to the available
+       data rate in excess of the Minimum Data Rate, summed over all
+       bearer channels.
+       Also, the 100 - xdsl2LConfTempChan3RaRatioUs is the ratio of
+       excess data rate to be assigned to all other bearer channels on
+       Upstream direction.  The sum of rate adaptation ratios over all
+       bearers on the same direction shall be equal to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 11 }
+
+xdsl2LConfTempChan4ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the VDSL2/
+       ADSL/ADSL2 and ADSL2+ channel configuration Profile Table
+       (xdsl2ChConfProfileTable) that applies to DSL bearer channel #4.
+       If the channel is unused, then the object is set to a zero-length
+       string.
+       This object may be set to a non-zero-length string only if
+       xdsl2LConfTempChan3ConfProfile contains a non-zero-length
+
+       string."
+   DEFVAL       { "" }
+   ::= { xdsl2LineConfTemplateEntry 12 }
+
+xdsl2LConfTempChan4RaRatioDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #4 when performing rate
+       adaptation on Downstream.  The ratio refers to the available data
+       rate in excess of the Minimum Data Rate, summed over all bearer
+       channels.
+       Also, the 100 - xdsl2LConfTempChan4RaRatioDs is the ratio of
+       excess data rate to be assigned to all other bearer channels.
+       The sum of rate adaptation ratios over all bearers on the same
+       direction shall sum to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 13 }
+
+xdsl2LConfTempChan4RaRatioUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..100)
+   UNITS       "percent"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Rate Adaptation Ratio.  The ratio (in percent) that should be
+       taken into account for the bearer channel #4 when performing rate
+       adaptation on Upstream.  The ratio refers to the available data
+       rate in excess of the Minimum Data Rate, summed over all bearer
+       channels.
+       Also, the 100 - xdsl2LConfTempChan4RaRatioUs is the ratio of
+       excess data rate to be assigned to all other bearer channels.
+       The sum of rate adaptation ratios over all bearers on the same
+       direction shall sum to 100%."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.4
+                 (Rate adaptation ratio)"
+   DEFVAL       { 0 }
+   ::= { xdsl2LineConfTemplateEntry 14 }
+
+xdsl2LConfTempRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+       A template is activated by setting this object to 'active'.
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated lines.
+       A row in this table is said to be unreferenced when there is no
+       instance of xdsl2LineConfTemplate or
+       xdsl2LineConfFallbackTemplate that refers to the row."
+   ::= { xdsl2LineConfTemplateEntry 15 }
+
+------------------------------------------
+--        xdsl2LineConfProfTable        --
+------------------------------------------
+
+xdsl2LineConfProfTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineConfProfEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfTable contains VDSL2/ADSL/
+       ADSL2 and ADSL2+ line configuration profiles.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileLine 2 }
+
+xdsl2LineConfProfEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineConfProfEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "A default profile with an index of 'DEFVAL' will always
+      exist, and its parameters will be set to vendor-specific values,
+      unless otherwise specified in this document."
+   INDEX  { xdsl2LConfProfProfileName }
+   ::= { xdsl2LineConfProfTable 1 }
+
+Xdsl2LineConfProfEntry  ::=
+   SEQUENCE {
+      xdsl2LConfProfProfileName          SnmpAdminString,
+      xdsl2LConfProfScMaskDs             Xdsl2ScMaskDs,
+      xdsl2LConfProfScMaskUs             Xdsl2ScMaskUs,
+      xdsl2LConfProfVdsl2CarMask         Xdsl2CarMask,
+      xdsl2LConfProfRfiBands             Xdsl2RfiBands,
+      xdsl2LConfProfRaModeDs             Xdsl2RaMode,
+      xdsl2LConfProfRaModeUs             Xdsl2RaMode,
+      xdsl2LConfProfRaUsNrmDs            Unsigned32,
+      xdsl2LConfProfRaUsNrmUs            Unsigned32,
+      xdsl2LConfProfRaUsTimeDs           Unsigned32,
+      xdsl2LConfProfRaUsTimeUs           Unsigned32,
+      xdsl2LConfProfRaDsNrmDs            Unsigned32,
+      xdsl2LConfProfRaDsNrmUs            Unsigned32,
+      xdsl2LConfProfRaDsTimeDs           Unsigned32,
+      xdsl2LConfProfRaDsTimeUs           Unsigned32,
+      xdsl2LConfProfTargetSnrmDs         Unsigned32,
+      xdsl2LConfProfTargetSnrmUs         Unsigned32,
+      xdsl2LConfProfMaxSnrmDs            Unsigned32,
+      xdsl2LConfProfMaxSnrmUs            Unsigned32,
+      xdsl2LConfProfMinSnrmDs            Unsigned32,
+      xdsl2LConfProfMinSnrmUs            Unsigned32,
+      xdsl2LConfProfMsgMinUs             Unsigned32,
+      xdsl2LConfProfMsgMinDs             Unsigned32,
+      xdsl2LConfProfCeFlag               Xdsl2LineCeFlag,
+      xdsl2LConfProfSnrModeDs            Xdsl2LineSnrMode,
+      xdsl2LConfProfSnrModeUs            Xdsl2LineSnrMode,
+      xdsl2LConfProfTxRefVnDs            Xdsl2LineTxRefVnDs,
+      xdsl2LConfProfTxRefVnUs            Xdsl2LineTxRefVnUs,
+      xdsl2LConfProfXtuTransSysEna       Xdsl2TransmissionModeType,
+      xdsl2LConfProfPmMode               Xdsl2LinePmMode,
+      xdsl2LConfProfL0Time               Unsigned32,
+      xdsl2LConfProfL2Time               Unsigned32,
+      xdsl2LConfProfL2Atpr               Unsigned32,
+      xdsl2LConfProfL2Atprt              Unsigned32,
+      xdsl2LConfProfProfiles             Xdsl2LineProfiles,
+      xdsl2LConfProfDpboEPsd             Xdsl2PsdMaskDs,
+      xdsl2LConfProfDpboEsEL             Unsigned32,
+      xdsl2LConfProfDpboEsCableModelA    Unsigned32,
+      xdsl2LConfProfDpboEsCableModelB    Unsigned32,
+      xdsl2LConfProfDpboEsCableModelC    Unsigned32,
+      xdsl2LConfProfDpboMus              Unsigned32,
+      xdsl2LConfProfDpboFMin             Unsigned32,
+      xdsl2LConfProfDpboFMax             Unsigned32,
+      xdsl2LConfProfUpboKL               Unsigned32,
+      xdsl2LConfProfUpboKLF              Xdsl2UpboKLF,
+      xdsl2LConfProfUs0Mask              Xdsl2LineUs0Mask,
+      xdsl2LConfProfForceInp             TruthValue,
+      xdsl2LConfProfRowStatus            RowStatus
+   }
+
+xdsl2LConfProfProfileName  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "This object identifies a row in this table."
+     ::= { xdsl2LineConfProfEntry 1 }
+
+xdsl2LConfProfScMaskDs  OBJECT-TYPE
+   SYNTAX      Xdsl2ScMaskDs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Subcarrier mask.  A bitmap of 4096 bits that allows masking
+       up to 4096 downstream subcarriers.  If bit i (0 <= i <
+       NSCds) is set to '1', the respective downstream
+       subcarrier is masked, and if set to '0', the respective
+       subcarrier is unmasked.
+       Note that there should always be unmasked subcarriers (i.e.,
+       this object cannot be all 1's).
+       Also note that if NSCds < 4096, all bits i
+       (NSCds < i <= 4096) should be set to '1'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.6 (CARMASKds)"
+   ::= { xdsl2LineConfProfEntry 2 }
+
+xdsl2LConfProfScMaskUs  OBJECT-TYPE
+   SYNTAX      Xdsl2ScMaskUs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Subcarrier mask.  A bitmap of 4096 bits that allows masking
+       up to 4096 upstream subcarriers.  If bit i (0 <= i < NSCus)
+       is set to '1', the respective upstream subcarrier is
+       masked, and if set to '0', the respective subcarrier
+       is unmasked.
+       Note that there should always be unmasked subcarriers (i.e.,
+       this object cannot be all 1's).
+       Also note that if NSCus < 4096, all bits i
+       (NSCus < i <= 4096) should be set to '1'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.7 (CARMASKus)"
+   ::= { xdsl2LineConfProfEntry 3 }
+
+xdsl2LConfProfVdsl2CarMask  OBJECT-TYPE
+   SYNTAX      Xdsl2CarMask
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "VDSL2-specific subcarrier mask.  This configuration
+       parameter defines the restrictions, additional to the band plan,
+       to determine the set of subcarriers allowed for transmission in
+       both the upstream and downstream directions.
+       The parameter shall describe the not masked subcarriers as one or
+       more frequency bands.  Each band is represented by start and stop
+
+       subcarrier indices with a subcarrier spacing of 4.3125 kHz.  The
+       valid range of subcarrier indices runs from 0 to at least the
+       index of the highest allowed subcarrier in both transmission
+       directions among all profiles enabled by the parameter
+       xdsl2LConfProfProfiles.
+       Up to 32 bands may be specified.  Other subcarriers shall be
+       masked."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.8 (VDSL2-
+                 CARMASK)"
+   ::= { xdsl2LineConfProfEntry 4 }
+
+xdsl2LConfProfRfiBands  OBJECT-TYPE
+   SYNTAX      Xdsl2RfiBands
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "For ITU-T Recommendation G.992.5, this configuration
+       parameter defines
+       the subset of downstream PSD mask breakpoints, as specified in
+       xdsl2LConfProfPsdMaskDs (PSDMASKds), that shall be used to notch
+       an RFI band.  This subset consists of pairs of consecutive
+       subcarrier indices belonging to breakpoints: [ti; ti + 1],
+       corresponding to the low level of the notch.
+       The specific interpolation around these points is defined in the
+       relevant Recommendations (e.g., ITU-T Recommendation G.992.5).
+       The CO-MIB shall define the RFI notches using breakpoints in
+       xdsl2LConfProfPsdMaskDs (PSDMASKds) as specified in the relevant
+       Recommendations (e.g., ITU-T Recommendation G.992.5).
+
+       For ITU-T Recommendation G.993.2, this configuration parameter
+       defines the bands where the PSD shall be reduced as
+       specified in #7.2.1.2/G.993.2.  Each band shall be represented
+       by a start and stop subcarrier indices with a subcarrier
+       spacing of 4.3125 kHz.  Up to 16 bands may be specified.
+       This parameter defines the RFI bands for both the upstream
+       and downstream directions."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.10 (RFIBANDS)"
+   ::= { xdsl2LineConfProfEntry 5 }
+
+xdsl2LConfProfRaModeDs  OBJECT-TYPE
+   SYNTAX      Xdsl2RaMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The mode of operation of a rate-adaptive xTU-C in the
+       transmit direction."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.4.1 (RA-MODEds)"
+   DEFVAL      { manual }
+   ::= { xdsl2LineConfProfEntry 6 }
+
+xdsl2LConfProfRaModeUs  OBJECT-TYPE
+   SYNTAX      Xdsl2RaMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The mode of operation of a rate-adaptive xTU-R in the
+       transmit direction."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.4.2 (RA-MODEus)"
+   DEFVAL      { manual }
+   ::= { xdsl2LineConfProfEntry 7 }
+
+xdsl2LConfProfRaUsNrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Downstream Up-Shift Noise Margin value, to be used when
+       xdsl2LConfProfRaModeDs is set to 'dynamicRa'.  If the downstream
+       noise margin is above this value, and stays above it,
+       for more than the time specified by the
+       xdsl2LConfProfRaUsTimeDs, the xTU-R shall attempt to increase
+       the downstream net data rate.  The Downstream Up-Shift Noise
+       Margin ranges from 0 to 310 units of 0.1 dB (physical values
+       are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.3 (RA-USNRMds)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 8 }
+
+xdsl2LConfProfRaUsNrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Upstream Up-Shift Noise Margin value, to be used when
+       xdsl2LConfProfRaModeUs is set to 'dynamicRa'.  If the upstream
+       noise margin is above this value, and stays above it,
+       for more than
+       the time specified by the xdsl2LConfProfRaUsTimeUs, the xTU-C
+       shall attempt to increase the upstream net data rate.
+       The Upstream Up-Shift Noise Margin ranges from 0 to 310 units of
+       0.1 dB (physical values are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.4 (RA-USNRMus)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 9 }
+
+xdsl2LConfProfRaUsTimeDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16383)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Downstream Up-Shift Time Interval, to be used when
+       xdsl2LConfProfRaModeDs is set to 'dynamicRa'.  The interval of
+       time that the downstream noise margin should stay above the
+       Downstream Up-Shift Noise Margin before the xTU-R shall attempt
+       to increase the downstream net data rate.  The time interval
+       ranges from 0 to 16383 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.5 (RA-UTIMEds)"
+   DEFVAL       { 3600 }
+   ::= { xdsl2LineConfProfEntry 10 }
+
+xdsl2LConfProfRaUsTimeUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16383)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Upstream Up-Shift Time Interval, to be used when
+       xdsl2LConfProfRaModeUs is set to 'dynamicRa'.  The interval of
+       time the upstream noise margin should stay above the Upstream
+       Up-Shift Noise Margin before the xTU-C shall attempt to increase
+       the upstream net data rate.  The time interval ranges from 0 to
+       16383 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.6 (RA-UTIMEus)"
+   DEFVAL       { 3600 }
+   ::= { xdsl2LineConfProfEntry 11 }
+
+xdsl2LConfProfRaDsNrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Downstream Down-Shift Noise Margin value, to be used
+       when xdsl2LConfProfRaModeDs is set to 'dynamicRa'.  If the
+       downstream noise margin is below this value and stays
+       below that value, for more than the time specified by the
+       xdsl2LConfProfRaDsTimeDs, the xTU-R shall attempt to decrease
+       the downstream net data rate.  The Downstream Down-Shift Noise
+       Margin ranges from 0 to 310 units of 0.1 dB (physical values
+       are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.7 (RA-DSNRMds)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 12 }
+
+xdsl2LConfProfRaDsNrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Upstream Downshift Noise Margin value, to be used when
+       xdsl2LConfProfRaModeUs is set to 'dynamicRa'.  If the upstream
+       noise margin is below this value and stays below that value,
+       for more than the time specified by the xdsl2LConfProfRaDsTimeUs,
+       the xTU-C shall attempt to decrease the upstream net data rate.
+       The Upstream Down-Shift Noise Margin ranges from 0 to 310 units
+       of 0.1 dB (physical values are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.8 (RA-DSNRMus)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 13 }
+
+xdsl2LConfProfRaDsTimeDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16383)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Downstream Downshift Time Interval, to be used when
+       xdsl2LConfProfRaModeDs is set to 'dynamicRa'.  The interval of
+       time the downstream noise margin should stay below the Downstream
+       Down-Shift Noise Margin before the xTU-R shall attempt to
+       decrease the downstream net data rate.  The time interval ranges
+       from 0 to 16383 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.9 (RA-DTIMEds)"
+   DEFVAL       { 3600 }
+   ::= { xdsl2LineConfProfEntry 14 }
+
+xdsl2LConfProfRaDsTimeUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..16383)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The Upstream Down-Shift Time Interval, to be used when
+       xdsl2LConfProfRaModeUs is set to 'dynamicRa'.  The interval of
+       time the upstream noise margin should stay below the Upstream
+       Down-Shift Noise Margin before the xTU-C shall attempt to
+       decrease the upstream net data rate.  The time interval ranges
+       from 0 to 16383 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.4.10 (RA-DTIMEus)"
+   DEFVAL       { 3600 }
+   ::= { xdsl2LineConfProfEntry 15 }
+
+xdsl2LConfProfTargetSnrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum Noise Margin the xTU-R receiver shall achieve,
+       relative to the BER requirement for each of the downstream bearer
+       channels, to successfully complete initialization.
+       The target noise margin ranges from 0 to 310 units of 0.1 dB
+       (physical values are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.1 (TARSNRMds)"
+   DEFVAL       { 60 }
+   ::= { xdsl2LineConfProfEntry 16 }
+
+xdsl2LConfProfTargetSnrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum Noise Margin the xTU-C receiver shall achieve,
+       relative to the BER requirement for each of the upstream bearer
+       channels, to successfully complete initialization.
+       The target noise margin ranges from 0 to 310 units of 0.1 dB
+       (physical values are 0 to 31 dB)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.2 (TARSNRMus)"
+   DEFVAL       { 60 }
+   ::= { xdsl2LineConfProfEntry 17 }
+
+xdsl2LConfProfMaxSnrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..310 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum Noise Margin the xTU-R receiver shall try to
+       sustain.  If the Noise Margin is above this level, the xTU-R
+       shall request that the xTU-C reduce the xTU-C transmit power to
+       get a noise margin below this limit (if this functionality is
+       supported).  The maximum noise margin ranges from 0 to 310 units
+       of 0.1 dB (physical values are 0 to 31 dB).  A value of
+       0x7FFFFFFF (2147483647) means that there is no maximum."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.3 (MAXSNRMds)"
+   DEFVAL       { 310 }
+   ::= { xdsl2LineConfProfEntry 18 }
+
+xdsl2LConfProfMaxSnrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..310 | 2147483647)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum Noise Margin the xTU-C receiver shall try to
+       sustain.  If the Noise Margin is above this level, the xTU-C
+       shall request that the xTU-R reduce the xTU-R transmit power to
+       get a noise margin below this limit (if this functionality is
+       supported).  The maximum noise margin ranges from 0 to 310 units
+       of 0.1 dB (physical values are 0 to 31 dB).  A value of
+       0x7FFFFFFF (2147483647) means that there is no maximum."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.4 (MAXSNRMus)"
+   DEFVAL       { 310 }
+   ::= { xdsl2LineConfProfEntry 19 }
+
+xdsl2LConfProfMinSnrmDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum Noise Margin the xTU-R receiver shall tolerate.
+       If the noise margin falls below this level, the xTU-R shall
+       request that the xTU-C increase the xTU-C transmit power.
+       If an increase to xTU-C transmit power is not possible, a loss-
+       of-margin (LOM) defect occurs, the xTU-R shall fail and attempt
+       to reinitialize and the NMS shall be notified.  The minimum noise
+       margin ranges from 0 to 310 units of 0.1 dB (physical values are
+       0 to 31 dB).  A value of 0 means that there is no minimum."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.5 (MINSNRMds)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 20 }
+
+xdsl2LConfProfMinSnrmUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..310)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum Noise Margin the xTU-C receiver shall tolerate.
+       If the noise margin falls below this level, the xTU-C shall
+       request that the xTU-R increase the xTU-R transmit power.
+       If an increase of xTU-R transmit power is not possible, a loss-
+       of-margin (LOM) defect occurs, the xTU-C shall fail and attempt
+
+       to re-initialize and the NMS shall be notified.  The minimum
+       noise margin ranges from 0 to 310 units of 0.1 dB (physical
+       values are 0 to 31 dB).  A value of 0 means that there is no
+       minimum."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.3.6 (MINSNRMus)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 21 }
+
+xdsl2LConfProfMsgMinUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(4000..248000)
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Overhead Rate Upstream.  Defines the minimum rate of
+       the message-based overhead that shall be maintained by the xTU in
+       upstream direction.  Expressed in bits per second and ranges from
+       4000 to 248000 bits/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.5.1 (MSGMINus)"
+   DEFVAL       { 4000 }
+  ::= { xdsl2LineConfProfEntry 22 }
+
+xdsl2LConfProfMsgMinDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(4000..248000)
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Overhead Rate Downstream.  Defines the minimum rate
+       of the message-based overhead that shall be maintained by the xTU
+       in the downstream direction.  Expressed in bits per second and
+       ranges from 4000 to 248000 bits/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.5.2 (MSGMINds)"
+   DEFVAL       { 4000 }
+   ::= { xdsl2LineConfProfEntry 23 }
+
+xdsl2LConfProfCeFlag  OBJECT-TYPE
+   SYNTAX      Xdsl2LineCeFlag
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter is a bit that enables the use of the optional
+       cyclic extension values."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.6.1 (CEFLAG)"
+   DEFVAL       { { } }
+   ::= { xdsl2LineConfProfEntry 24 }
+
+xdsl2LConfProfSnrModeDs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSnrMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter enables the transmitter-referred virtual
+       noise in the downstream direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.7.1 (SNRMODEds)"
+   DEFVAL       { virtualNoiseDisabled }
+   ::= { xdsl2LineConfProfEntry 25 }
+
+xdsl2LConfProfSnrModeUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineSnrMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter enables the transmitter-referred virtual
+       noise in the upstream direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.7.2 (SNRMODEus)"
+   DEFVAL       { virtualNoiseDisabled }
+   ::= { xdsl2LineConfProfEntry 26 }
+
+xdsl2LConfProfTxRefVnDs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineTxRefVnDs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the downstream
+       transmitter-referred virtual noise.
+       The TXREFVNds shall be specified through a set of breakpoints.
+       Each breakpoint shall consist of a subcarrier index t, with a
+       subcarrier spacing of 4.3125 kHz, and a noise PSD level
+       (expressed in dBm/Hz) at that subcarrier.  The set of breakpoints
+       can then be represented as:
+       [(t1,PSD1), (t2, PSD2), ... , (tN, PSDN)]."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.7.3 (TXREFVNds)"
+   ::= { xdsl2LineConfProfEntry 27 }
+
+xdsl2LConfProfTxRefVnUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LineTxRefVnUs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the upstream
+       transmitter-referred virtual noise.
+       The TXREFVNus shall be specified through a set of breakpoints.
+       Each breakpoint shall consist of a subcarrier index t, with a
+       subcarrier spacing of 4.3125 kHz, and a noise PSD level
+       (expressed in dBm/Hz) at that subcarrier.  The set of breakpoints
+
+       can then be represented as:
+       [(t1, PSD1), (t2, PSD2), ... , (tN, PSDN)]."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.7.4 (TXREFVNus)"
+   ::= { xdsl2LineConfProfEntry 28 }
+
+xdsl2LConfProfXtuTransSysEna  OBJECT-TYPE
+   SYNTAX      Xdsl2TransmissionModeType
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "xTU Transmission System Enabling (XTSE).  A list of the
+       different coding types enabled in this profile.  It is coded in a
+       bitmap representation with 1 or more bits set.  A bit set to
+       '1' means that the xTUs may apply the respective
+       coding for the DSL line.  A bit set to '0' means that
+       the xTUs cannot apply the respective coding for the ADSL line.
+       All 'reserved' bits should be set to '0'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.1 (XTSE)"
+   ::= { xdsl2LineConfProfEntry 29 }
+
+xdsl2LConfProfPmMode  OBJECT-TYPE
+   SYNTAX      Xdsl2LinePmMode
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Power management state Enabling (PMMode).  Defines the power
+       states the xTU-C or xTU-R may autonomously transition to on
+       this line.
+       This is a set of bits, where any bit with a '1' value
+       means that the xTU is allowed to transit into the respective
+       state and any bit with a '0' value means that the xTU
+       is not allowed to transit into the respective state."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.4 (PMMode)"
+   DEFVAL  { { allowTransitionsToIdle, allowTransitionsToLowPower } }
+   ::= { xdsl2LineConfProfEntry 30 }
+
+xdsl2LConfProfL0Time  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum time (in seconds) between an Exit from the L2
+       state and the next Entry into the L2 state.
+       It ranges from 0 to 255 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.5 (L0-TIME)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfEntry 31 }
+
+xdsl2LConfProfL2Time  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "seconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The minimum time (in seconds) between an Entry into the
+       L2 state and the first Power Trim in the L2 state and between two
+       consecutive Power Trims in the L2 state.
+       It ranges from 0 to 255 seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.6 (L2-TIME)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfEntry 32 }
+
+xdsl2LConfProfL2Atpr  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..31)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum aggregate transmit power reduction (in dB) that
+       can be performed at transition of L0 to L2 state or through a
+       single Power Trim in the L2 state.
+       It ranges from 0 dB to 31 dB."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.7 (L2-ATPR)"
+   DEFVAL       { 10 }
+   ::= { xdsl2LineConfProfEntry 33 }
+
+xdsl2LConfProfL2Atprt  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..31)
+   UNITS       "dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The total maximum aggregate transmit power reduction (in dB)
+       that can be performed in an L2 state.  This is the sum of all
+       reductions of L2 Requests (i.e., at transition of L0 to L2 state)
+       and Power Trims."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.9 (L2-ATPRT)"
+   DEFVAL       { 31 }
+   ::= { xdsl2LineConfProfEntry 34 }
+
+xdsl2LConfProfProfiles  OBJECT-TYPE
+   SYNTAX      Xdsl2LineProfiles
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The configuration parameter contains the G.993.2 profiles
+
+       to be allowed by the near-end xTU on this line.
+       It is coded in a bitmap representation (0 if not allowed, 1 if
+       allowed)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.1.11 (PROFILES)"
+   DEFVAL       { { profile8a,  profile8b,  profile8c,
+                    profile8d,  profile12a, profile12b,
+                    profile17a, profile30a } }
+   ::= { xdsl2LineConfProfEntry 35 }
+
+xdsl2LConfProfDpboEPsd  OBJECT-TYPE
+   SYNTAX      Xdsl2PsdMaskDs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the PSD mask that is
+       assumed to be permitted at the exchange.  This parameter shall
+       use the same format as xdsl2LConfProfPsdMaskDs (PSDMASKds).
+       The maximum number of breakpoints for xdsl2LConfProfDpboEPsd
+       is 16."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOEPSD)"
+   ::= { xdsl2LineConfProfEntry 36 }
+
+xdsl2LConfProfDpboEsEL  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..511)
+   UNITS       "0.5 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the assumed electrical
+       length of cables (E-side cables) connecting exchange-based DSL
+       services to a remote flexibility point (cabinet), that hosts the
+       xTU-C that is subject to spectrally shaped downstream power back-
+       off (DPBO) depending on this length.  The electrical length is
+       defined as the loss (in dB) of an equivalent length of
+       hypothetical cable at a reference frequency defined by the
+       network operator or in spectrum management regulations.
+       This parameter shall be coded as an unsigned integer representing
+       an electrical length from 0 dB (coded as 0) to 255.5 dB (coded as
+       511) in steps of 0.5 dB.  All values in the range are valid.  If
+       this parameter is set to '0', the DPBO shall be disabled."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOESEL)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 37 }
+
+xdsl2LConfProfDpboEsCableModelA  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..640)
+   UNITS       "2^-8"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The E-side Cable Model parameter A (DPBOESCMA) of the cable
+       model (DPBOESCM) for cables connecting exchange-based DSL
+       services to a remote flexibility point (cabinet), that hosts the
+       xTU-C that is subject to spectrally shaped downstream power back-
+       off (DPBO) depending on this value.
+       The cable model is in terms of three scalars
+       xdsl2LConfProfDpboEsCableModelA (DPBOESCMA),
+       xdsl2LConfProfDpboEsCableModelB(DPBOESCMB), and
+       xdsl2LConfProfDpboEsCableModelC (DPBOESCMC), that are used to
+       estimate the frequency dependent loss of E-side cables calculated
+       from the xdsl2LConfProfDpboEsEL (DPBOESEL) parameter.  Possible
+       values shall be coded as unsigned integers representing a scalar
+       value from -1 (coded as 0) to 1.5 (coded as 640) in steps of
+       2^-8.  All values in the range are valid.  This parameter is used
+       only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOESCMA)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 38 }
+
+xdsl2LConfProfDpboEsCableModelB  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..640)
+   UNITS       "2^-8"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The E-side Cable Model parameter B (DPBOESCMB) of the cable
+       model (DPBOESCM) for cables connecting exchange-based DSL
+       services to a remote flexibility point (cabinet), that hosts the
+       xTU-C that is subject to spectrally shaped downstream power back-
+       off (DPBO) depending on this value.
+       The cable model is in terms of three scalars
+       dsl2LConfProfDpboEsCableModelA (DPBOESCMA),
+       xdsl2LConfProfDpboEsCableModelB(DPBOESCMB), and
+       xdsl2LConfProfDpboEsCableModelC (DPBOESCMC), that are used to
+       estimate the frequency dependent loss of E-side cables calculated
+       from the xdsl2LConfProfDpboEsEL (DPBOESEL) parameter.  Possible
+       values shall be coded as unsigned integers representing a scalar
+       value from -1 (coded as 0) to 1.5 (coded as 640) in steps of
+       2^-8.  All values in the range are valid.  This parameter is used
+       only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOESCMB)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 39 }
+
+xdsl2LConfProfDpboEsCableModelC  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..640)
+   UNITS       "2^-8"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The E-side Cable Model parameter C (DPBOESCMC) of the cable
+       model (DPBOESCM) for cables connecting exchange-based DSL
+       services to a remote flexibility point (cabinet), that hosts the
+       xTU-C that is subject to spectrally shaped downstream power back-
+       off (DPBO) depending on this value.
+       The cable model is in terms of three scalars
+       xdsl2LConfProfDpboEsCableModelA (DPBOESCMA),
+       xdsl2LConfProfDpboEsCableModelB(DPBOESCMB), and
+       xdsl2LConfProfDpboEsCableModelC (DPBOESCMC), that are used to
+       estimate the frequency dependent loss of E-side cables calculated
+       from the xdsl2LConfProfDpboEsEL (DPBOESEL) parameter.  Possible
+       values shall be coded as unsigned integers representing a scalar
+       value from -1 (coded as 0) to 1.5 (coded as 640) in steps of
+       2^-8.  All values in the range are valid.  This parameter is used
+       only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOESCMC)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 40 }
+
+xdsl2LConfProfDpboMus OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "0.5 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the assumed Minimum
+       Usable receive PSD mask (in dBm/Hz) for exchange-based services,
+       used to modify parameter xdsl2LConfProfDpboFMax (DPBOFMAX)
+       defined below (to determine the DPBO).  It shall be coded as an
+       unsigned integer representing a PSD mask level from 0 dBm/Hz
+       (coded as 0) to -127.5 dBm/Hz (coded as 255) in steps of 0.5
+       dBm/Hz.  All values in the range are valid.
+       NOTE - The PSD mask level is 3.5 dB above the signal PSD level.
+       This parameter is used only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOMUS)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 41 }
+
+xdsl2LConfProfDpboFMin OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..2048)
+   UNITS       "4.3125 kHz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the minimum frequency
+       from which the DPBO shall be applied.  It ranges from 0 kHz
+       (coded as 0) to 8832 kHz (coded as 2048) in steps of
+       4.3125 kHz.  This parameter is used only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOFMIN)"
+   DEFVAL      { 32 }
+   ::= { xdsl2LineConfProfEntry 42 }
+
+xdsl2LConfProfDpboFMax OBJECT-TYPE
+   SYNTAX      Unsigned32 (32..6956)
+   UNITS       "4.3125 kHz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the maximum frequency
+       at which DPBO may be applied.  It ranges from 138 kHz (coded as
+       32) to 29997.75 kHz (coded as 6956) in steps of 4.3125 kHz.
+       This parameter is used only for G.993.2."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.13 (DPBOFMAX)"
+   DEFVAL      { 512 }
+   ::= { xdsl2LineConfProfEntry 43 }
+
+xdsl2LConfProfUpboKL  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..1280)
+   UNITS       "0.1 dB"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the electrical length
+       expressed in dB at 1 MHz, kl0, configured by the CO-MIB.
+       The value ranges from 0 (coded as 0) to 128 dB (coded as 1280) in
+       steps of 0.1 dB.  This parameter is relevant only if
+       xdsl2LConfProfUpboKLF is set to 'override(2)', which indicates
+       that this parameter's value will override the VTUs'
+       determination of the electrical length.
+       If xdsl2LConfProfUpboKLF is set either to auto(1) or
+       disableUpbo(3), then this parameter will be ignored."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14 (UPBOKL)"
+   DEFVAL      { 0 }
+   ::= { xdsl2LineConfProfEntry 44 }
+
+xdsl2LConfProfUpboKLF OBJECT-TYPE
+   SYNTAX      Xdsl2UpboKLF
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Defines the upstream power backoff force mode."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14 (UPBOKLF)
+   "
+   DEFVAL      { disableUpbo }
+   ::= { xdsl2LineConfProfEntry 45 }
+
+xdsl2LConfProfUs0Mask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineUs0Mask
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The configuration parameter contains the US0 PSD masks to be
+       allowed by the near-end xTU on the line.  This parameter is only
+       defined for G.993.2 Annex A.  It is represented as a bitmap (0
+       if not allowed and 1 if allowed)."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.1.2.18
+                 (US0MASK)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineConfProfEntry 46 }
+
+xdsl2LConfProfForceInp  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+       "This parameter, when set to 'true' indicates that the framer
+        settings of the bearer shall be selected such that the impulse
+        noise protection computed according to the formula specified in
+        the relevant Recommendation is greater than or equal to the
+        minimal impulse noise protection requirement.
+        This flag shall have the same value for all the bearers of one
+        line in the same direction."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.5 (FORCEINP)"
+   DEFVAL       { false }
+   ::= { xdsl2LineConfProfEntry 47 }
+
+xdsl2LConfProfRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A profile is activated by setting this object to 'active'.
+
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all templates.
+
+       A row in this table is said to be unreferenced when there is no
+       instance of xdsl2LConfTempLineProfile that refers to the row.
+
+       When a row is created in this table, the SNMP agent should also
+       create corresponding rows in the tables
+       xdsl2LineConfProfModeSpecTable and
+       xdsl2LineConfProfModeSpecBandUsTable.
+       When a row is deleted in this table, the SNMP agent should also
+       delete corresponding rows in the tables
+       xdsl2LineConfProfModeSpecTable and
+       xdsl2LineConfProfModeSpecBandUsTable."
+   ::= { xdsl2LineConfProfEntry 48 }
+
+------------------------------------------
+--    xdsl2LineConfProfModeSpecTable    --
+------------------------------------------
+
+xdsl2LineConfProfModeSpecTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineConfProfModeSpecEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfModeSpecTable extends the DSL
+       line configuration profile by xDSL Mode-Specific parameters.
+       A row in this table that has an index of xdsl2LConfProfXdslMode
+       == defMode(1), is called a 'mandatory' row or 'default' row.
+       A row in this table that has an index such that
+       xdsl2LConfProfXdslMode is not equal to defMode(1), is called an
+       'optional' row or 'mode-specific' row.
+       When a row in the xdsl2LineConfProfTable table (the parent row)
+       is created, the SNMP agent will automatically create a
+       'mandatory' row in this table.
+       When the parent row is deleted, the SNMP agent will automatically
+       delete all associated rows in this table.
+       Any attempt to delete the 'mandatory' row using the
+       xdsl2LConfProfModeSpecRowStatus object will be rejected by the
+       SNMP agent.
+       The manager MAY create an 'optional' row in this table using the
+       xdsl2LConfProfModeSpecRowStatus object if the parent row
+       exists.
+       The manager MAY delete an 'optional' row in this table using the
+       xdsl2LConfProfModeSpecRowStatus object at any time.
+       If the actual transmission mode of a DSL line does not match one
+       of the 'optional' rows in this table, then the line will use the
+       PSD configuration from the 'mandatory' row.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileLine 3 }
+
+xdsl2LineConfProfModeSpecEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineConfProfModeSpecEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfModeSpecTable extends the
+       DSL line configuration profile by DSL Mode-Specific
+       parameters."
+   INDEX  { xdsl2LConfProfProfileName, xdsl2LConfProfXdslMode }
+   ::= { xdsl2LineConfProfModeSpecTable 1 }
+
+Xdsl2LineConfProfModeSpecEntry  ::=
+   SEQUENCE {
+      xdsl2LConfProfXdslMode             Xdsl2OperationModes,
+      xdsl2LConfProfMaxNomPsdDs          Integer32,
+      xdsl2LConfProfMaxNomPsdUs          Integer32,
+      xdsl2LConfProfMaxNomAtpDs          Unsigned32,
+      xdsl2LConfProfMaxNomAtpUs          Unsigned32,
+      xdsl2LConfProfMaxAggRxPwrUs        Integer32,
+      xdsl2LConfProfPsdMaskDs            Xdsl2PsdMaskDs,
+      xdsl2LConfProfPsdMaskUs            Xdsl2PsdMaskUs,
+      xdsl2LConfProfPsdMaskSelectUs      Xdsl2LinePsdMaskSelectUs,
+      xdsl2LConfProfClassMask            Xdsl2LineClassMask,
+      xdsl2LConfProfLimitMask            Xdsl2LineLimitMask,
+      xdsl2LConfProfUs0Disable           Xdsl2LineUs0Disable,
+      xdsl2LConfProfModeSpecRowStatus    RowStatus
+   }
+
+xdsl2LConfProfXdslMode    OBJECT-TYPE
+   SYNTAX      Xdsl2OperationModes
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The DSL Mode is a way of categorizing the various xDSL
+       transmission modes into groups, each group (xDSL Mode) shares
+       the same PSD configuration.
+       There should be multiple entries in this table for a given line
+       profile in case multiple bits are set in
+       xdsl2LConfProfXtuTransSysEna for that profile."
+   REFERENCE    "DSL Forum TR-129, paragraph #5.5"
+   ::= { xdsl2LineConfProfModeSpecEntry 1 }
+
+xdsl2LConfProfMaxNomPsdDs  OBJECT-TYPE
+   SYNTAX      Integer32(-600..-300)
+   UNITS       "0.1 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum nominal transmit PSD in the downstream direction
+       during initialization and Showtime.  It ranges from -600 to -300
+       units of 0.1 dBm/Hz (physical values are -60 to -30
+       dBm/Hz)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.1 (MAXNOMPSDds)"
+   DEFVAL       { -300 }
+  ::= { xdsl2LineConfProfModeSpecEntry 2 }
+
+xdsl2LConfProfMaxNomPsdUs  OBJECT-TYPE
+   SYNTAX      Integer32(-600..-300)
+   UNITS       "0.1 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum nominal transmit PSD in the upstream direction
+       during initialization and Showtime.  It ranges from -600 to
+       -300 units of 0.1 dBm/Hz (physical values are -60 to -30
+       dBm/Hz)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.2 (MAXNOMPSDus)"
+   DEFVAL       { -300 }
+   ::= { xdsl2LineConfProfModeSpecEntry 3 }
+
+xdsl2LConfProfMaxNomAtpDs  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum nominal aggregate to transmit power in the
+       downstream direction during initialization and Showtime.  It
+       ranges from 0 to 255 units of 0.1 dBm (physical values are 0
+       to 25.5 dBm)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.3 (MAXNOMATPds)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfModeSpecEntry 4 }
+
+xdsl2LConfProfMaxNomAtpUs  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..255)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum nominal aggregate transmit power in the upstream
+       direction during initialization and Showtime.  It ranges from
+       0 to 255 units of 0.1 dBm (physical values are 0 to 25.5
+       dBm)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.4 (MAXNOMATPus)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfModeSpecEntry 5 }
+
+xdsl2LConfProfMaxAggRxPwrUs  OBJECT-TYPE
+   SYNTAX      Integer32(-255..255 | 2147483647)
+   UNITS       "0.1 dBm"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The maximum upstream aggregate receive power over the
+       relevant set of subcarriers.  The xTU-C should verify that the
+       upstream power cutback is such that this maximum aggregate
+       receive power value is honored.  It ranges from -255 to 255
+       units of 0.1 dBm (physical values are -25.5 to 25.5 dBm).
+       A value of 0x7FFFFFFF (2147483647) means that there is no
+       limit."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.5 (MAXRXPWRus)"
+   DEFVAL       { 255 }
+   ::= { xdsl2LineConfProfModeSpecEntry 6 }
+
+xdsl2LConfProfPsdMaskDs   OBJECT-TYPE
+   SYNTAX      Xdsl2PsdMaskDs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "The downstream PSD mask applicable at the U-C2 reference
+      point.
+      This parameter is used only for G.992.5 and it may impose PSD
+      restrictions (breakpoints) in addition to the Limit PSD mask
+      defined in G.992.5.
+      This is a string of 32 pairs of values in the following
+      structure:
+      Octets 0-1 - Index of the first subcarrier used in the context of
+                   a first breakpoint.
+      Octet 2    - The PSD reduction for the subcarrier indicated in
+                   octets 0 and 1.
+      Octets 3-5 - Same, for a second breakpoint.
+      Octets 6-8 - Same, for a third breakpoint.
+      This architecture continues until octets 94-95, which are
+      associated with a 32nd breakpoint.
+      Each subcarrier index is an unsigned number in the range 0 and
+      NSCds-1.  Each PSD reduction value is in the range 0 (0 dBm/Hz) to
+      255 (-127.5 dBm/Hz) with steps of 0.5 dBm/Hz.  Valid values are in
+      the range 0 to 190 (0 to -95 dBm/Hz).
+      When the number of breakpoints is less than 32, all remaining
+      octets are set to the value '0'.  Note that the content of this
+      object should be correlated with the subcarrier mask and with
+
+      the RFI setup."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.9 (PSDMASKds)"
+     ::= { xdsl2LineConfProfModeSpecEntry 7 }
+
+xdsl2LConfProfPsdMaskUs   OBJECT-TYPE
+   SYNTAX      Xdsl2PsdMaskUs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "The upstream PSD mask applicable at the U-R2 reference
+      point.
+      This parameter is used only for G.992.5, and it may impose PSD
+      restrictions (breakpoints) in addition to the Limit PSD mask
+      defined in G.992.5.
+      This is a string of 16 pairs of values in the following
+      structure:
+      Octets 0-1 - Index of the first subcarrier used in the context of
+                   a first breakpoint.
+      Octet 2    - The PSD reduction for the subcarrier indicated in
+                   octets 0 and 1.
+      Octets 3-5 - Same, for a second breakpoint.
+      Octets 6-8 - Same, for a third breakpoint.
+      This architecture continues until octets 9-47, which are
+      associated with a 16th breakpoint.
+      Each subcarrier index is an unsigned number in the range 0 and
+      NSCus-1.  Each PSD reduction value is in the range 0 (0 dBm/Hz) to
+      255 (-127.5 dBm/Hz) with steps of 0.5 dBm/Hz.  Valid values are in
+      the range 0 to 190 (0 to -95 dBm/Hz).
+      When the number of breakpoints is less than 16, all remaining
+      octets are set to the value '0'.  Note that the content of this
+      object should be correlated with the subcarrier mask and with
+      the RFI setup."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.12 (PSDMASKus)"
+     ::= { xdsl2LineConfProfModeSpecEntry 8 }
+
+xdsl2LConfProfPsdMaskSelectUs  OBJECT-TYPE
+   SYNTAX      Xdsl2LinePsdMaskSelectUs
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+     "The selected upstream PSD mask.  This parameter is used only
+      for Annexes J and M of G.992.3 and G.992.5, and the same
+      selection is used for all relevant enabled bits in
+      xdsl2LConfProfXtuTransSysEna."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.11
+                (Upstream PSD mask selection)"
+   DEFVAL       { adlu32Eu32 }
+    ::= { xdsl2LineConfProfModeSpecEntry 9 }
+
+xdsl2LConfProfClassMask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineClassMask
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "In order to reduce the number of configuration
+       possibilities, the limit Power Spectral Density masks (see
+       LIMITMASK) are grouped in PSD mask classes.
+       Each class is designed such that the PSD levels of each limit PSD
+       mask of a specific class are equal in their respective passband
+       above 552 kHz.
+       This parameter is defined per VDSL2 Annex enabled in the
+       xdsl2LConfProfXtuTransSysEna object.  It selects a single PSD
+       mask class per Annex that is activated at the VTU-O."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.1.2.15
+                (CLASSMASK)"
+   DEFVAL       { a998ORb997M1cORc998B }
+   ::= { xdsl2LineConfProfModeSpecEntry 10 }
+
+xdsl2LConfProfLimitMask  OBJECT-TYPE
+   SYNTAX      Xdsl2LineLimitMask
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter contains the G.993.2 limit
+       PSD masks of the selected PSD mask class, enabled by the near-end
+       xTU on this line for each class of profiles.
+       This parameter is defined per VDSL2 Annex enabled in the
+       xdsl2LConfProfXtuTransSysEna object.
+       Through this parameter, several limit PSD masks of the selected
+       PSD mask class (xdsl2LConfProfClassMask) may be enabled.  The
+       enabling parameter is coded in a bitmap representation (0 if the
+       associated mask is not allowed, 1 if it is allowed)."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.1.2.16
+                 (LIMITMASK)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineConfProfModeSpecEntry 11 }
+
+xdsl2LConfProfUs0Disable  OBJECT-TYPE
+   SYNTAX      Xdsl2LineUs0Disable
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter indicates if the use of the US0 is
+       disabled for each limit PSD mask enabled in the
+       xdsl2LConfProfLimitMask parameter.
+       This parameter is defined per VDSL2 Annex enabled in the
+       xdsl2LConfProfXtuTransSysEna object.
+
+       For each limit PSD mask enabled in the xdsl2LConfProfLimitMask
+       parameter, a bit shall indicate if the US0 is disabled.  The
+       disabling parameter is coded as a bitmap.  The bit is set to '1'
+       if the US0 is disabled for the associated limit mask.
+       This parameter and the xdsl2LConfProfLimitMask parameter use the
+       same structure."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.1.2.17 (US0DISABLE)"
+   DEFVAL       { {} }
+   ::= { xdsl2LineConfProfModeSpecEntry 12 }
+
+xdsl2LConfProfModeSpecRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       This row is activated by setting this object to 'active'.
+
+       A 'mandatory' row, as defined in the DESCRIPTION clause of
+       xdsl2LineConfProfModeSpecTable, cannot be deleted at all.
+
+       A 'mandatory' row can be taken out of service
+       (by setting this object to 'notInService') if the parent
+       row in the xdsl2LineConfProfTable table is not in
+       the 'active' state.
+
+       An 'optional' row (or 'mode-specific' row) can be deleted or
+       taken out of service (by setting this object to 'destroy' or
+       'notInService') at any time."
+   ::= { xdsl2LineConfProfModeSpecEntry 13 }
+
+----------------------------------------------
+--   xdsl2LineConfProfModeSpecBandUsTable   --
+----------------------------------------------
+
+xdsl2LineConfProfModeSpecBandUsTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineConfProfModeSpecBandUsEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfModeSpecBandUsTable extends
+       xdsl2LineConfProfModeSpecTable with upstream-band-specific
+       parameters for VDSL2, such as upstream power back-off
+       parameters xdsl2LConfProfUpboPsdA and xdsl2LConfProfUpboPsdB
+       (UPBOPSD-pb).
+
+       When a parent 'mandatory row' is created in
+       xdsl2LineConfProfModeSpecTable, the SNMP agent will automatically
+       create several 'mandatory' rows in this table -- one for each
+       upstream band:
+       Note: A mandatory row is one where xdsl2LConfProfXdslMode =
+       defMode(1).  When the parent row is deleted, the SNMP agent will
+       automatically delete all associated rows in this table.  Any
+       attempt to delete a 'mandatory' row using the
+       xdsl2LConfProfModeSpecBandUsRowStatus object will be rejected
+       by the SNMP agent.  The manager MAY create a new 'optional'
+       row in this table using the xdsl2LConfProfModeSpecBandUsRowStatus
+       object if the associated parent row exists, and the
+       value of xdsl2LConfProfXdslMode is a G.993.2 value.  The manager
+       MAY delete an 'optional' row in this table using the
+       xdsl2LConfProfModeSpecBandUsRowStatus object at any time.
+
+       With respect to the xdsl2LConfProfUpboPsdA and
+       xdsl2LConfProfUpboPsdB parameters, for a given upstream band,
+       if an optional row is missing from this table, then that
+       means upstream power back-off is disabled for that upstream
+       band.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileLine 4 }
+
+xdsl2LineConfProfModeSpecBandUsEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineConfProfModeSpecBandUsEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineConfProfModeSpecBandUsTable extends
+       xdsl2LineConfProfModeSpecTable with upstream-band-specific
+       parameters for VDSL2, such as upstream power back-off parameters
+       xdsl2LConfProfUpboPsdA and xdsl2LConfProfUpboPsdB (UPBOPSD-
+       pb)."
+   INDEX       { xdsl2LConfProfProfileName, xdsl2LConfProfXdslMode,
+                 xdsl2LConfProfXdslBandUs}
+   ::= { xdsl2LineConfProfModeSpecBandUsTable 1 }
+
+Xdsl2LineConfProfModeSpecBandUsEntry  ::=
+   SEQUENCE {
+      xdsl2LConfProfXdslBandUs                 Xdsl2BandUs,
+      xdsl2LConfProfUpboPsdA                   Integer32,
+      xdsl2LConfProfUpboPsdB                   Integer32,
+      xdsl2LConfProfModeSpecBandUsRowStatus    RowStatus
+   }
+
+xdsl2LConfProfXdslBandUs    OBJECT-TYPE
+   SYNTAX      Xdsl2BandUs
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "Each value identifies a specific band in the upstream
+       transmission direction (excluding the US0 band)."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14"
+   ::= { xdsl2LineConfProfModeSpecBandUsEntry 1 }
+
+xdsl2LConfProfUpboPsdA  OBJECT-TYPE
+   SYNTAX      Integer32(4000..8095)
+   UNITS       "0.01 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the 'a' reference
+       parameter of the UPBO reference PSD used to compute the
+       upstream power back-off for the upstream band.  A UPBO PSD
+       defined for each band shall consist of two parameters [a, b].
+       Parameter 'a' (xdsl2LConfProfUpboPsdA) ranges from 40 dBm/Hz
+       (coded as 4000) to 80.95 dBm/Hz (coded as 8095) in steps of 0.01
+       dBm/Hz; and parameter 'b' (xdsl2LConfProfUpboPsdB) ranges from 0
+       dBm/Hz (coded as 0) to 40.95 dBm/Hz (coded as 4095) in steps of
+       0.01 dBm/Hz.  The UPBO reference PSD at the frequency 'f'
+       expressed in MHz shall be equal to '-a-b(SQRT(f))'.  Setting
+       xdsl2LConfProfUpboPsdA to 4000 and xdsl2LConfProfUpboPsdB to 0 is
+       a special configuration to disable UPBO in the respective
+       upstream band."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14 (UPBOPSD-pb)"
+   DEFVAL      { 4000 }
+  ::= { xdsl2LineConfProfModeSpecBandUsEntry 2 }
+
+xdsl2LConfProfUpboPsdB  OBJECT-TYPE
+   SYNTAX      Integer32(0..4095)
+   UNITS       "0.01 dBm/Hz"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This configuration parameter defines the 'b' reference
+       parameter of the UPBO reference PSD used to compute the
+       upstream power back-off for the upstream band.  A UPBO PSD
+       defined for each band shall consist of two parameters [a, b].
+       Parameter 'a' (xdsl2LConfProfUpboPsdA) ranges from 40 dBm/Hz
+       (coded as 4000) to 80.95 dBm/Hz (coded as 8095) in steps of 0.01
+       dBm/Hz; and parameter 'b' (xdsl2LConfProfUpboPsdB) ranges from 0
+       dBm/Hz (coded as 0) to 40.95 dBm/Hz (coded as 4095) in steps of
+       0.01 dBm/Hz.  The UPBO reference PSD at the frequency 'f'
+
+       expressed in MHz shall be equal to '-a-b(SQRT(f))'.  Setting
+       xdsl2LConfProfUpboPsdA to 4000 and xdsl2LConfProfUpboPsdB to 0 is
+       a special configuration to disable UPBO in the respective
+       upstream band."
+   REFERENCE   "ITU-T G.997.1, paragraph #7.3.1.2.14 (UPBOPSD-pb)"
+   DEFVAL      { 0 }
+  ::= { xdsl2LineConfProfModeSpecBandUsEntry 3 }
+
+xdsl2LConfProfModeSpecBandUsRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       This row is activated by setting this object to 'active'.
+
+       A 'mandatory' row, as defined in the DESCRIPTION clause of
+       xdsl2LineConfProfModeSpecBandUsTable, cannot be deleted at all.
+
+       A 'mandatory' row can be taken out of service
+       (by setting this object to 'notInService') if the parent
+       row in the xdsl2LineConfProfModeSpecTable table is not in
+       the 'active' state.
+
+       An 'optional' row (or 'mode-specific' row) can be deleted or
+       taken out of service (by setting this object to 'destroy' or
+       'notInService') at any time."
+   ::= { xdsl2LineConfProfModeSpecBandUsEntry 4 }
+
+------------------------------------------------
+--          xdsl2ChConfProfileTable           --
+------------------------------------------------
+
+xdsl2ChConfProfileTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2ChConfProfileEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2ChConfProfileTable contains DSL channel
+       profile configuration.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+   ::= { xdsl2ProfileChannel 1 }
+
+xdsl2ChConfProfileEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2ChConfProfileEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "A default profile with an index of 'DEFVAL' will always
+      exist, and its parameters will be set to vendor-specific values,
+      unless otherwise specified in this document."
+   INDEX  { xdsl2ChConfProfProfileName }
+   ::= { xdsl2ChConfProfileTable 1 }
+
+Xdsl2ChConfProfileEntry  ::=
+   SEQUENCE {
+      xdsl2ChConfProfProfileName          SnmpAdminString,
+      xdsl2ChConfProfMinDataRateDs        Unsigned32,
+      xdsl2ChConfProfMinDataRateUs        Unsigned32,
+      xdsl2ChConfProfMinResDataRateDs     Unsigned32,
+      xdsl2ChConfProfMinResDataRateUs     Unsigned32,
+      xdsl2ChConfProfMaxDataRateDs        Unsigned32,
+      xdsl2ChConfProfMaxDataRateUs        Unsigned32,
+      xdsl2ChConfProfMinDataRateLowPwrDs  Unsigned32,
+      xdsl2ChConfProfMinDataRateLowPwrUs  Unsigned32,
+      xdsl2ChConfProfMaxDelayDs           Unsigned32,
+      xdsl2ChConfProfMaxDelayUs           Unsigned32,
+      xdsl2ChConfProfMinProtectionDs      Xdsl2SymbolProtection,
+      xdsl2ChConfProfMinProtectionUs      Xdsl2SymbolProtection,
+      xdsl2ChConfProfMinProtection8Ds     Xdsl2SymbolProtection8,
+      xdsl2ChConfProfMinProtection8Us     Xdsl2SymbolProtection8,
+      xdsl2ChConfProfMaxBerDs             Xdsl2MaxBer,
+      xdsl2ChConfProfMaxBerUs             Xdsl2MaxBer,
+      xdsl2ChConfProfUsDataRateDs         Unsigned32,
+      xdsl2ChConfProfDsDataRateDs         Unsigned32,
+      xdsl2ChConfProfUsDataRateUs         Unsigned32,
+      xdsl2ChConfProfDsDataRateUs         Unsigned32,
+      xdsl2ChConfProfImaEnabled           TruthValue,
+      xdsl2ChConfProfMaxDelayVar          Unsigned32,
+      xdsl2ChConfProfInitPolicy           Xdsl2ChInitPolicy,
+      xdsl2ChConfProfRowStatus            RowStatus
+   }
+
+xdsl2ChConfProfProfileName  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "This object identifies a row in this table."
+   ::= { xdsl2ChConfProfileEntry 1 }
+
+xdsl2ChConfProfMinDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Data Rate on Downstream direction.  The minimum net
+       data rate for the bearer channel, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.1
+                 (Minimum data rate)"
+   ::= { xdsl2ChConfProfileEntry 2 }
+
+xdsl2ChConfProfMinDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Data Rate on Upstream direction.  The minimum net
+       data rate for the bearer channel, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.1
+                 (Minimum data rate)"
+   ::= { xdsl2ChConfProfileEntry 3 }
+
+xdsl2ChConfProfMinResDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Reserved Data Rate on Downstream direction.  The
+       minimum reserved net data rate for the bearer channel, coded
+       in bit/s.  This parameter is used only if the Rate Adaptation
+       Mode in the direction of the bearer channel (i.e.,
+       xdsl2LConfProfRaModeDs) is set to 'dynamicRa'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.2
+                 (Minimum reserved data rate)"
+   ::= { xdsl2ChConfProfileEntry 4 }
+
+xdsl2ChConfProfMinResDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Minimum Reserved Data Rate on Upstream direction.  The
+       minimum reserved net data rate for the bearer channel, coded in
+       bit/s.  This parameter is used only if the Rate Adaptation Mode
+       in the direction of the bearer channel (i.e.,
+       xdsl2LConfProfRaModeUs) is set to 'dynamicRa'."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.2
+                 (Minimum reserved data rate)"
+   ::= { xdsl2ChConfProfileEntry 5 }
+
+xdsl2ChConfProfMaxDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Data Rate on Downstream direction.  The maximum net
+       data rate for the bearer channel, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.3
+                 (Maximum data rate)"
+   ::= { xdsl2ChConfProfileEntry 6 }
+
+xdsl2ChConfProfMaxDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Data Rate on Upstream direction.  The maximum net
+       data rate for the bearer channel, coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.3
+                 (Maximum data rate)"
+   ::= { xdsl2ChConfProfileEntry 7 }
+
+xdsl2ChConfProfMinDataRateLowPwrDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum net data rate for
+       the bearer channel as desired by the operator of the system
+       during the low power state (L1/L2).  The power management low
+       power states L1 and L2 are defined in ITU-T Recommendations
+       G.992.2 and G.992.3, respectively.
+       The data rate is coded in steps of bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.5
+                 (Minimum Data Rate in low power state)"
+   ::= { xdsl2ChConfProfileEntry 8 }
+
+xdsl2ChConfProfMinDataRateLowPwrUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum net data rate for
+       the bearer channel as desired by the operator of the system
+       during the low power state (L1/L2).  The power management low
+       power states L1 and L2 are defined in ITU-T Recommendations
+       G.992.2 and G.992.3, respectively.
+       The data rate is coded in steps of bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.1.5
+                 (Minimum Data Rate in low power state)"
+   ::= { xdsl2ChConfProfileEntry 9 }
+
+xdsl2ChConfProfMaxDelayDs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..63)
+   UNITS       "milliseconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Interleave Delay on Downstream direction.  The
+       maximum one-way interleaving delay introduced by the PMS-TC on
+       Downstream direction.  The xTUs shall choose the S (factor) and D
+       (depth) values such that the actual one-way interleaving delay
+       (Xdsl2ChStatusActDelay) is as close as possible to, but less than
+       or equal to, xdsl2ChConfProfMaxDelayDs.  The delay is coded in
+       ms, with the value 0 indicating no delay bound is being
+       imposed."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.2
+                 (Maximum interleaving delay)"
+   ::= { xdsl2ChConfProfileEntry 10 }
+
+xdsl2ChConfProfMaxDelayUs  OBJECT-TYPE
+   SYNTAX      Unsigned32(0..63)
+   UNITS       "milliseconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Interleave Delay on Upstream direction.  The maximum
+       one-way interleaving delay introduced by the PMS-TC on Upstream
+       direction.  The xTUs shall choose the S (factor) and D (depth)
+       values such that the actual one-way interleaving delay
+       (Xdsl2ChStatusActDelay) is as close as possible to, but less than
+       or equal to, xdsl2ChConfProfMaxDelayUs.  The delay is coded in
+       ms, with the value 0 indicating no delay bound is being
+       imposed."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.2
+                 (Maximum interleaving delay)"
+   ::= { xdsl2ChConfProfileEntry 11 }
+
+xdsl2ChConfProfMinProtectionDs  OBJECT-TYPE
+   SYNTAX      Xdsl2SymbolProtection
+   UNITS       "symbols"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum impulse noise
+       protection for the bearer channel if it is transported over DMT
+       symbols with a subcarrier spacing of 4.3125 kHz.  The impulse
+       noise protection is expressed in DMT symbols with a subcarrier
+       spacing of 4.3125 kHz and can take the values 1/2 and any integer
+       from 0 to 16, inclusive.  If the xTU does not support the
+       configured INPMIN value, it shall use the nearest supported
+       impulse noise protection greater than INPMIN."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.3 (INPMINds)"
+   DEFVAL       { noProtection }
+   ::= { xdsl2ChConfProfileEntry 12 }
+
+xdsl2ChConfProfMinProtectionUs  OBJECT-TYPE
+   SYNTAX      Xdsl2SymbolProtection
+   UNITS       "symbols"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum impulse noise
+       protection for the bearer channel if it is transported over DMT
+       symbols with a subcarrier spacing of 4.3125 kHz.  The impulse
+       noise protection is expressed in DMT symbols with a subcarrier
+       spacing of 4.3125 kHz and can take the values 1/2 and any integer
+       from 0 to 16, inclusive.  If the xTU does not support the
+       configured INPMIN value, it shall use the nearest supported
+       impulse noise protection greater than INPMIN."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.3 (INPMINus)"
+   DEFVAL       { noProtection }
+   ::= { xdsl2ChConfProfileEntry 13 }
+
+xdsl2ChConfProfMinProtection8Ds  OBJECT-TYPE
+   SYNTAX      Xdsl2SymbolProtection8
+   UNITS       "symbols"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum impulse noise
+       protection for the bearer channel if it is transported over DMT
+       symbols with a subcarrier spacing of 8.625 kHz.  The impulse
+       noise protection is expressed in DMT symbols with a subcarrier
+       spacing of 8.625 kHz."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.4 (INPMIN8ds)"
+   DEFVAL       { noProtection }
+   ::= { xdsl2ChConfProfileEntry 14 }
+
+xdsl2ChConfProfMinProtection8Us  OBJECT-TYPE
+   SYNTAX      Xdsl2SymbolProtection8
+   UNITS       "symbols"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This parameter specifies the minimum impulse noise
+       protection for the bearer channel if it is transported over DMT
+       symbols with a subcarrier spacing of 8.625 kHz.  The impulse
+       noise protection is expressed in DMT symbols with a subcarrier
+       spacing of 8.625 kHz."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.4 (INPMIN8us)"
+   DEFVAL       { noProtection }
+   ::= { xdsl2ChConfProfileEntry 15 }
+
+xdsl2ChConfProfMaxBerDs  OBJECT-TYPE
+   SYNTAX      Xdsl2MaxBer
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Bit Error Ratio on Downstream direction.  The
+       maximum bit error ratio for the bearer channel."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.6
+                 (Maximum bit error ratio)"
+   DEFVAL       { eminus5 }
+  ::= { xdsl2ChConfProfileEntry 16 }
+
+xdsl2ChConfProfMaxBerUs  OBJECT-TYPE
+   SYNTAX      Xdsl2MaxBer
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum Bit Error Ratio on Upstream direction.  The maximum
+       bit error ratio for the bearer channel."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.6
+                 (Maximum bit error ratio)"
+   DEFVAL       { eminus5 }
+   ::= { xdsl2ChConfProfileEntry 17 }
+
+xdsl2ChConfProfUsDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Data Rate Threshold Upshift for Downstream direction.  An
+       'Up-Shift rate change' event is triggered when the
+       actual downstream data rate exceeds, by more than the threshold,
+       the data rate at the last entry into Showtime.  The parameter is
+       coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.8.1
+                 (Data rate threshold upshift)"
+   ::= { xdsl2ChConfProfileEntry 18 }
+
+xdsl2ChConfProfDsDataRateDs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Data Rate Threshold Downshift for Downstream direction.  A
+       'Down-Shift rate change' event is triggered when the
+       actual downstream data rate is below the data rate at the last
+       entry into Showtime, by more than the threshold.  The parameter
+       is coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.8.2
+                 (Data rate threshold downshift)"
+   ::= { xdsl2ChConfProfileEntry 19 }
+
+xdsl2ChConfProfUsDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Data Rate Threshold Upshift for Upstream direction.  An
+       'Up-Shift rate change' event is triggered when the
+       actual upstream data rate exceeds, by more than the threshold,
+       the data rate at the last entry into Showtime.  The parameter is
+       coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.8.1
+                 (Data rate threshold upshift)"
+   ::= { xdsl2ChConfProfileEntry 20 }
+
+xdsl2ChConfProfDsDataRateUs  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "bits/second"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Data Rate Threshold Downshift for Upstream direction.  A
+       'Down-Shift rate change' event is triggered when the
+       actual upstream data rate is below the data rate at the last
+
+       entry into Showtime, by more than the threshold.  The parameter
+       is coded in bit/s."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.2.8.2
+                 (Data rate threshold downshift)"
+   ::= { xdsl2ChConfProfileEntry 21 }
+
+xdsl2ChConfProfImaEnabled  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "IMA Mode Enable.  The parameter enables the IMA operation
+       mode in the ATM Data Path.  Relevant only if the channel is of
+       ATM Data Path.  When in 'enable' state, the ATM Data
+       Path should comply with the requirements for IMA
+       transmission."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.3.4.1
+                 (IMA operation mode enable parameter)"
+   DEFVAL       { false }
+ ::= { xdsl2ChConfProfileEntry 22 }
+
+xdsl2ChConfProfMaxDelayVar  OBJECT-TYPE
+   SYNTAX      Unsigned32(1..255)
+   UNITS       "0.1 milliseconds"
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Maximum delay variation (DVMAX).
+       This optional VDSL2-specific parameter specifies the maximum
+       value for the delay variation allowed in an OLR procedure.
+       It is ranges from 1 to 254 units of 0.1 milliseconds (i.e., 0.1
+       to 25.4 milliseconds) with the special value 255, which indicates
+       that no delay variation bound is imposed."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.2.9
+                 (DVMAX)"
+   DEFVAL       { 255 }
+ ::= { xdsl2ChConfProfileEntry 23 }
+
+xdsl2ChConfProfInitPolicy  OBJECT-TYPE
+   SYNTAX      Xdsl2ChInitPolicy
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "Channel Initialization Policy Selection (CIPOLICY).
+       This optional parameter indicates which policy shall be applied
+       to determine the transceiver configuration parameters at
+       initialization.  Those policies are defined in the respective
+       Recommendations."
+   REFERENCE    "ITU-T G.997.1 Amendment 1, paragraph #7.3.2.10
+                 (CIPOLICY)"
+   DEFVAL       { policy0 }
+ ::= { xdsl2ChConfProfileEntry 24 }
+
+xdsl2ChConfProfRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A profile is activated by setting this object to 'active'.
+
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated templates.
+
+       A row in xdsl2ChConfProfTable is said to be unreferenced when
+       there is no instance of xdsl2LConfTempChan1ConfProfile,
+       xdsl2LConfTempChan2ConfProfile, xdsl2LConfTempChan3ConfProfile,
+       or xdsl2LConfTempChan4ConfProfile that refers to
+       the row."
+   ::= { xdsl2ChConfProfileEntry 25 }
+
+------------------------------------------------
+--      xdsl2LineAlarmConfTemplateTable       --
+------------------------------------------------
+
+xdsl2LineAlarmConfTemplateTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2LineAlarmConfTemplateEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2LineAlarConfTemplateTable contains DSL
+       line alarm configuration templates.
+
+        Entries in this table MUST be maintained in a persistent
+        manner."
+   ::= { xdsl2ProfileAlarmConf 1 }
+
+xdsl2LineAlarmConfTemplateEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2LineAlarmConfTemplateEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "A default template with an index of 'DEFVAL' will always
+
+       exist, and its parameters will be set to vendor-specific values,
+       unless otherwise specified in this document."
+   INDEX  { xdsl2LAlarmConfTempTemplateName }
+   ::= { xdsl2LineAlarmConfTemplateTable 1 }
+
+Xdsl2LineAlarmConfTemplateEntry  ::=
+   SEQUENCE {
+      xdsl2LAlarmConfTempTemplateName      SnmpAdminString,
+      xdsl2LAlarmConfTempLineProfile       SnmpAdminString,
+      xdsl2LAlarmConfTempChan1ConfProfile  SnmpAdminString,
+      xdsl2LAlarmConfTempChan2ConfProfile  SnmpAdminString,
+      xdsl2LAlarmConfTempChan3ConfProfile  SnmpAdminString,
+      xdsl2LAlarmConfTempChan4ConfProfile  SnmpAdminString,
+      xdsl2LAlarmConfTempRowStatus         RowStatus
+   }
+
+xdsl2LAlarmConfTempTemplateName  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "This object identifies a row in this table."
+   ::= { xdsl2LineAlarmConfTemplateEntry 1 }
+
+xdsl2LAlarmConfTempLineProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL Line
+       Thresholds Configuration Profile Table
+       (xdsl2LineAlarmConfProfileTable) that applies to this line."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.2"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 2 }
+
+xdsl2LAlarmConfTempChan1ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(1..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL
+       Channel Thresholds Configuration Profile Table
+       (xdsl2ChAlarmConfProfileTable) that applies for DSL bearer
+       channel #1.  The channel profile name specified here MUST match
+       the name of an existing row in the xdsl2ChAlarmConfProfileTable
+       table."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.4"
+   DEFVAL       { "DEFVAL" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 3 }
+
+xdsl2LAlarmConfTempChan2ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL
+       Channel Thresholds Configuration Profile Table
+       (xdsl2ChAlarmConfProfileTable) that applies for DSL bearer
+       channel #2.  The channel profile name specified here MUST match
+       the name of an existing row in the xdsl2ChAlarmConfProfileTable
+       table.  If the channel is unused, then the object is set to a
+       zero-length string."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.4"
+   DEFVAL       { "" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 4 }
+
+xdsl2LAlarmConfTempChan3ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL
+       Channel Thresholds Configuration Profile Table
+       (xdsl2ChAlarmConfProfileTable) that applies for DSL bearer
+       channel #3.  The channel profile name specified here MUST match
+       the name of an existing row in the xdsl2ChAlarmConfProfileTable
+       table.
+       This object may be set to a non-zero-length string only if
+       xdsl2LAlarmConfTempChan2ConfProfile contains a non-zero-length
+       string."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.4"
+   DEFVAL       { "" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 5 }
+
+xdsl2LAlarmConfTempChan4ConfProfile  OBJECT-TYPE
+   SYNTAX      SnmpAdminString (SIZE(0..32))
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "The value of this object identifies the row in the DSL
+       Channel Thresholds Configuration Profile Table
+       (xdsl2ChAlarmConfProfileTable) that applies for DSL bearer
+       channel #4.  The channel profile name specified here MUST match
+       the name of an existing row in the xdsl2ChAlarmConfProfileTable
+       table.
+
+       This object may be set to a non-zero-length string only if
+       xdsl2LAlarmConfTempChan3ConfProfile contains a non-zero-length
+       string."
+   REFERENCE    "DSL Forum TR-129, paragraph #8.4"
+   DEFVAL       { "" }
+   ::= { xdsl2LineAlarmConfTemplateEntry 6 }
+
+xdsl2LAlarmConfTempRowStatus  OBJECT-TYPE
+   SYNTAX      RowStatus
+   MAX-ACCESS  read-create
+   STATUS      current
+   DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A template is activated by setting this object to 'active'.
+
+       Before a template can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated lines.
+
+       A row in this table is said to be unreferenced when there is no
+       instance of xdsl2LineAlarmConfTemplate that refers to the
+       row."
+   ::= { xdsl2LineAlarmConfTemplateEntry 7 }
+
+------------------------------------------------
+--      xdsl2LineAlarmConfProfileTable        --
+------------------------------------------------
+
+xdsl2LineAlarmConfProfileTable  OBJECT-TYPE
+     SYNTAX      SEQUENCE  OF  Xdsl2LineAlarmConfProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+      "The table xdsl2LineAlarmConfProfileTable contains DSL
+       line performance threshold values.
+
+       If a performance counter exceeds the threshold value specified
+       in this table, then the SNMP agent will issue a threshold trap.
+       Each performance counter has a unique trap type
+       (see NOTIFICATION-TYPE definitions below).
+       One trap will be sent per interval, per interface, per trap type.
+       A value of 0 will disable the trap.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+     ::= { xdsl2ProfileAlarmConf 2 }
+
+xdsl2LineAlarmConfProfileEntry  OBJECT-TYPE
+     SYNTAX      Xdsl2LineAlarmConfProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+      "A default profile with an index of 'DEFVAL' will always
+       exist, and its parameters will be set to vendor-specific values,
+       unless otherwise specified in this document."
+     INDEX  { xdsl2LineAlarmConfProfileName }
+     ::= { xdsl2LineAlarmConfProfileTable 1 }
+
+Xdsl2LineAlarmConfProfileEntry ::=
+     SEQUENCE {
+     xdsl2LineAlarmConfProfileName                SnmpAdminString,
+     xdsl2LineAlarmConfProfileXtucThresh15MinFecs
+                                          HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXtucThresh15MinEs
+                                          HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXtucThresh15MinSes
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXtucThresh15MinLoss
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXtucThresh15MinUas
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinFecs
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinEs
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinSes
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinLoss
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileXturThresh15MinUas
+                                           HCPerfIntervalThreshold,
+     xdsl2LineAlarmConfProfileThresh15MinFailedFullInt   Unsigned32,
+     xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt   Unsigned32,
+     xdsl2LineAlarmConfProfileRowStatus                   RowStatus
+     }
+
+xdsl2LineAlarmConfProfileName  OBJECT-TYPE
+     SYNTAX      SnmpAdminString (SIZE(1..32))
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "This object identifies a row in this table."
+     ::= { xdsl2LineAlarmConfProfileEntry 1 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinFecs  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MFecs counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 2 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinEs  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MEs counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 3 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinSes  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MSes counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 4 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinLoss  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MLoss counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 5 }
+
+xdsl2LineAlarmConfProfileXtucThresh15MinUas  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MUas counter, when
+      xdsl2PMLCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 6 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinFecs  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MFecs counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 7 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinEs  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MEs counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 8 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinSes  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MSes counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 9 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinLoss  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MLoss counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 10 }
+
+xdsl2LineAlarmConfProfileXturThresh15MinUas  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLCurr15MUas counter, when
+      xdsl2PMLCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 11 }
+
+xdsl2LineAlarmConfProfileThresh15MinFailedFullInt  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLInitCurr15MfailedFullInits
+      counter.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 12 }
+
+xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMLInitCurr15MFailedShortInits
+      counter.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2LineAlarmConfProfileEntry 13 }
+
+xdsl2LineAlarmConfProfileRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A profile is activated by setting this object to 'active'.
+
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated templates.
+
+       A row in this table is said to be unreferenced when there is no
+       instance of xdsl2LAlarmConfTempLineProfile that refers to the
+       row."
+     ::= { xdsl2LineAlarmConfProfileEntry 14 }
+
+------------------------------------------------
+--       xdsl2ChAlarmConfProfileTable         --
+------------------------------------------------
+
+xdsl2ChAlarmConfProfileTable  OBJECT-TYPE
+     SYNTAX      SEQUENCE  OF  Xdsl2ChAlarmConfProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+      "The table xdsl2ChAlarmConfProfileTable contains DSL channel
+       performance threshold values.
+
+       If a performance counter exceeds the threshold value specified
+       in this table, then the SNMP agent will issue a threshold trap.
+       Each performance counter has a unique trap type
+       (see NOTIFICATION-TYPE definitions below).
+       One trap will be sent per interval per interface per trap type.
+       A value of 0 will disable the trap.
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+     ::= { xdsl2ProfileAlarmConf 3 }
+
+xdsl2ChAlarmConfProfileEntry  OBJECT-TYPE
+     SYNTAX      Xdsl2ChAlarmConfProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+      "A default profile with an index of 'DEFVAL' will always
+       exist, and its parameters will be set to vendor-specific values,
+       unless otherwise specified in this document."
+     INDEX  { xdsl2ChAlarmConfProfileName }
+     ::= { xdsl2ChAlarmConfProfileTable 1 }
+
+Xdsl2ChAlarmConfProfileEntry ::=
+     SEQUENCE {
+     xdsl2ChAlarmConfProfileName
+                                                     SnmpAdminString,
+     xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations
+                                                     Unsigned32,
+     xdsl2ChAlarmConfProfileXtucThresh15MinCorrected Unsigned32,
+     xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations
+                                                     Unsigned32,
+     xdsl2ChAlarmConfProfileXturThresh15MinCorrected Unsigned32,
+     xdsl2ChAlarmConfProfileRowStatus                RowStatus
+     }
+
+xdsl2ChAlarmConfProfileName  OBJECT-TYPE
+     SYNTAX      SnmpAdminString (SIZE(1..32))
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+     "This object identifies a row in this table."
+     ::= { xdsl2ChAlarmConfProfileEntry 1 }
+
+xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMChCurr15MCodingViolations
+      counter, when xdsl2PMChCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2ChAlarmConfProfileEntry 2 }
+
+xdsl2ChAlarmConfProfileXtucThresh15MinCorrected  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMChCurr15MCorrectedBlocks
+      counter, when xdsl2PMChCurrUnit is xtuc {1}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2ChAlarmConfProfileEntry 3 }
+
+xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMChCurr15MCodingViolations
+      counter, when xdsl2PMChCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2ChAlarmConfProfileEntry 4 }
+
+xdsl2ChAlarmConfProfileXturThresh15MinCorrected  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+     "A threshold for the xdsl2PMChCurr15MCorrectedBlocks
+      counter, when xdsl2PMChCurrUnit is xtur {2}.
+      The value 0 means that no threshold is specified for the
+      associated counter."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.7.2"
+   DEFVAL       { 0 }
+     ::= { xdsl2ChAlarmConfProfileEntry 5 }
+
+xdsl2ChAlarmConfProfileRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+      "This object is used to create a new row or to modify or
+       delete an existing row in this table.
+
+       A profile is activated by setting this object to 'active'.
+
+       Before a profile can be deleted or taken out of service (by
+       setting this object to 'destroy' or 'notInService'), it MUST be
+       first unreferenced from all associated templates.
+
+       A row in xdsl2ChConfProfTable is said to be unreferenced when
+       there is no instance of xdsl2LAlarmConfTempChan1ConfProfile,
+       xdsl2LAlarmConfTempChan2ConfProfile,
+       xdsl2LAlarmConfTempChan3ConfProfile, or
+       xdsl2LAlarmConfTempChan4ConfProfile that refers to
+       the row."
+     ::= { xdsl2ChAlarmConfProfileEntry 6 }
+
+------------------------------------------------
+--          PM line current counters          --
+------------------------------------------------
+
+xdsl2PMLineCurrTable  OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineCurrTable contains current Performance
+       Monitoring results for DSL lines."
+   ::= { xdsl2PMLine 1 }
+
+xdsl2PMLineCurrEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of vdsl2(251).  A second index of this
+        table is the termination unit."
+   INDEX  { ifIndex, xdsl2PMLCurrUnit }
+   ::= { xdsl2PMLineCurrTable 1 }
+
+Xdsl2PMLineCurrEntry  ::=
+   SEQUENCE {
+      xdsl2PMLCurrUnit                    Xdsl2Unit,
+      xdsl2PMLCurr15MValidIntervals       Unsigned32,
+      xdsl2PMLCurr15MInvalidIntervals     Unsigned32,
+      xdsl2PMLCurr15MTimeElapsed          HCPerfTimeElapsed,
+      xdsl2PMLCurr15MFecs                 Counter32,
+      xdsl2PMLCurr15MEs                   Counter32,
+      xdsl2PMLCurr15MSes                  Counter32,
+      xdsl2PMLCurr15MLoss                 Counter32,
+      xdsl2PMLCurr15MUas                  Counter32,
+      xdsl2PMLCurr1DayValidIntervals      Unsigned32,
+      xdsl2PMLCurr1DayInvalidIntervals    Unsigned32,
+      xdsl2PMLCurr1DayTimeElapsed         HCPerfTimeElapsed,
+      xdsl2PMLCurr1DayFecs                Counter32,
+      xdsl2PMLCurr1DayEs                  Counter32,
+      xdsl2PMLCurr1DaySes                 Counter32,
+      xdsl2PMLCurr1DayLoss                Counter32,
+      xdsl2PMLCurr1DayUas                 Counter32
+   }
+
+xdsl2PMLCurrUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2PMLineCurrEntry 1 }
+
+xdsl2PMLCurr15MValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which data
+       was collected.  The value will typically be equal to the maximum
+       number of 15-minute intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 15-minute intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMLineCurrEntry 2 }
+
+xdsl2PMLCurr15MInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMLineCurrEntry 3 }
+
+xdsl2PMLCurr15MTimeElapsed  OBJECT-TYPE
+   SYNTAX      HCPerfTimeElapsed
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMLineCurrEntry 4 }
+
+xdsl2PMLCurr15MFecs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was at
+       least one FEC correction event for one or more bearer channels in
+       this line.  This parameter is inhibited during UAS or SES."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.1 (FECS-L)
+                 and paragraph #7.2.1.2.1 (FECS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 5 }
+
+xdsl2PMLCurr15MEs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: CRC-8 >= 1 for one or more bearer channels OR
+                 LOS >= 1 OR SEF >=1 OR LPR >= 1.
+          xTU-R: FEBE >= 1 for one or more bearer channels OR
+                 LOS-FE >=1 OR RDI >=1 OR LPR-FE >=1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.2 (ES-L)
+                 and paragraph #7.2.1.2.2 (ES-LFE)"
+   ::= { xdsl2PMLineCurrEntry 6 }
+
+xdsl2PMLCurr15MSes  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: (CRC-8 anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS >= 1
+                 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: (FEBE anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS-FE >= 1
+                 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.3 (SES-L)
+                 and paragraph #7.2.1.2.3 (SES-LFE)"
+   ::= { xdsl2PMLineCurrEntry 7 }
+
+xdsl2PMLCurr15MLoss  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was LOS (or
+       LOS-FE for xTU-R)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.4 (LOSS-L)
+                 and paragraph #7.2.1.2.4 (LOSS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 8 }
+
+xdsl2PMLCurr15MUas  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds in Unavailability State during this
+       interval.  Unavailability begins at the onset of 10 contiguous
+       severely errored seconds, and ends at the onset of 10 contiguous
+       seconds with no severely errored seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.5 (UAS-L)
+                 and paragraph #7.2.1.2.5 (UAS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 9 }
+
+xdsl2PMLCurr1DayValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which data was
+       collected.  The value will typically be equal to the maximum
+       number of 24-hour intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 24-hour intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMLineCurrEntry 10 }
+
+xdsl2PMLCurr1DayInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMLineCurrEntry 11 }
+
+xdsl2PMLCurr1DayTimeElapsed  OBJECT-TYPE
+   SYNTAX      HCPerfTimeElapsed
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMLineCurrEntry 12 }
+
+xdsl2PMLCurr1DayFecs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was at
+       least one FEC correction event for one or more bearer channels in
+       this line.  This parameter is inhibited during UAS or SES."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.1 (FECS-L)
+                 and paragraph #7.2.1.2.1 (FECS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 13 }
+
+xdsl2PMLCurr1DayEs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: CRC-8 >= 1 for one or more bearer channels OR
+                 LOS >= 1 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: FEBE >= 1 for one or more bearer channels OR
+                 LOS-FE >= 1 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.2 (ES-L)
+                 and paragraph #7.2.1.2.2 (ES-LFE)"
+   ::= { xdsl2PMLineCurrEntry 14 }
+
+xdsl2PMLCurr1DaySes  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: (CRC-8 anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS >= 1
+                 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: (FEBE anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS-FE >= 1.
+                 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.3 (SES-L)
+                 and paragraph #7.2.1.2.3 (SES-LFE)"
+   ::= { xdsl2PMLineCurrEntry 15 }
+
+xdsl2PMLCurr1DayLoss  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was LOS (or
+       LOS-FE for xTU-R)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.4 (LOSS-L)
+                 and paragraph #7.2.1.2.4 (LOSS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 16 }
+
+xdsl2PMLCurr1DayUas  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds in Unavailability State during this
+       interval.
+       Unavailability begins at the onset of 10 contiguous severely
+       errored seconds, and ends at the onset of 10 contiguous seconds
+       with no severely errored seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.5 (UAS-L)
+                 and paragraph #7.2.1.2.5 (UAS-LFE)"
+   ::= { xdsl2PMLineCurrEntry 17 }
+
+------------------------------------------------
+--          PM line init current counters     --
+------------------------------------------------
+
+xdsl2PMLineInitCurrTable   OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineInitCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineInitCurrTable contains current
+       initialization counters for DSL lines."
+   ::= { xdsl2PMLine 2 }
+
+xdsl2PMLineInitCurrEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineInitCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The index of this table is an interface index where the
+       interface has an ifType of vdsl2(251)."
+   INDEX  { ifIndex }
+   ::= { xdsl2PMLineInitCurrTable 1 }
+
+Xdsl2PMLineInitCurrEntry  ::=
+   SEQUENCE {
+      xdsl2PMLInitCurr15MValidIntervals       Unsigned32,
+      xdsl2PMLInitCurr15MInvalidIntervals     Unsigned32,
+      xdsl2PMLInitCurr15MTimeElapsed          Unsigned32,
+      xdsl2PMLInitCurr15MFullInits            Unsigned32,
+      xdsl2PMLInitCurr15MFailedFullInits      Unsigned32,
+      xdsl2PMLInitCurr15MShortInits           Unsigned32,
+      xdsl2PMLInitCurr15MFailedShortInits     Unsigned32,
+      xdsl2PMLInitCurr1DayValidIntervals      Unsigned32,
+      xdsl2PMLInitCurr1DayInvalidIntervals    Unsigned32,
+      xdsl2PMLInitCurr1DayTimeElapsed         Unsigned32,
+      xdsl2PMLInitCurr1DayFullInits           Unsigned32,
+      xdsl2PMLInitCurr1DayFailedFullInits     Unsigned32,
+      xdsl2PMLInitCurr1DayShortInits          Unsigned32,
+      xdsl2PMLInitCurr1DayFailedShortInits    Unsigned32
+   }
+
+xdsl2PMLInitCurr15MValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which data
+       was collected.  The value will typically be equal to the maximum
+       number of 15-minute intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 15-minute intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMLineInitCurrEntry 1 }
+
+xdsl2PMLInitCurr15MInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMLineInitCurrEntry 2 }
+
+xdsl2PMLInitCurr15MTimeElapsed  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMLineInitCurrEntry 3 }
+
+xdsl2PMLInitCurr15MFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of full initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.1"
+   ::= { xdsl2PMLineInitCurrEntry 4 }
+
+xdsl2PMLInitCurr15MFailedFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed full initializations on the line during this
+       interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.2"
+   ::= { xdsl2PMLineInitCurrEntry 5 }
+
+xdsl2PMLInitCurr15MShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of short initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.3"
+   ::= { xdsl2PMLineInitCurrEntry 6 }
+
+xdsl2PMLInitCurr15MFailedShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed short initializations on the line during
+       this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.4"
+   ::= { xdsl2PMLineInitCurrEntry 7 }
+
+xdsl2PMLInitCurr1DayValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which data was
+       collected.  The value will typically be equal to the maximum
+       number of 24-hour intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 24-hour intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMLineInitCurrEntry 8 }
+
+xdsl2PMLInitCurr1DayInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMLineInitCurrEntry 9 }
+
+xdsl2PMLInitCurr1DayTimeElapsed  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMLineInitCurrEntry 10 }
+
+xdsl2PMLInitCurr1DayFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of full initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.1"
+   ::= { xdsl2PMLineInitCurrEntry 11 }
+
+xdsl2PMLInitCurr1DayFailedFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed full initializations on the line during this
+       interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.2"
+   ::= { xdsl2PMLineInitCurrEntry 12 }
+
+xdsl2PMLInitCurr1DayShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of short initializations attempted on the line
+
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.3"
+   ::= { xdsl2PMLineInitCurrEntry 13 }
+
+xdsl2PMLInitCurr1DayFailedShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed short initializations on the line during
+       this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.4"
+   ::= { xdsl2PMLineInitCurrEntry 14 }
+
+-------------------------------------------
+--       PM line history 15 Minutes      --
+-------------------------------------------
+
+xdsl2PMLineHist15MinTable    OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineHist15MinTable contains PM line history
+       for 15-minute intervals of DSL line."
+   ::= { xdsl2PMLine 3 }
+
+xdsl2PMLineHist15MinEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+      interface has an ifType of vdsl2(251).  A second index of this
+      table is the transmission unit.  The third index is the interval
+      number."
+   INDEX  { ifIndex,
+            xdsl2PMLHist15MUnit,
+            xdsl2PMLHist15MInterval }
+   ::= { xdsl2PMLineHist15MinTable 1 }
+
+Xdsl2PMLineHist15MinEntry  ::=
+   SEQUENCE {
+      xdsl2PMLHist15MUnit                 Xdsl2Unit,
+      xdsl2PMLHist15MInterval             Unsigned32,
+      xdsl2PMLHist15MMonitoredTime        Unsigned32,
+      xdsl2PMLHist15MFecs                 Counter32,
+      xdsl2PMLHist15MEs                   Counter32,
+      xdsl2PMLHist15MSes                  Counter32,
+      xdsl2PMLHist15MLoss                 Counter32,
+      xdsl2PMLHist15MUas                  Counter32,
+      xdsl2PMLHist15MValidInterval        TruthValue
+   }
+
+xdsl2PMLHist15MUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2PMLineHist15MinEntry 1 }
+
+xdsl2PMLHist15MInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..96)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMLineHist15MinEntry 2 }
+
+xdsl2PMLHist15MMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMLineHist15MinEntry 3 }
+
+xdsl2PMLHist15MFecs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was at
+       least one FEC correction event for one or more bearer channels in
+       this line.  This parameter is inhibited during UAS or SES."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.1 (FECS-L)
+                 and paragraph #7.2.1.2.1 (FECS-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 4 }
+
+xdsl2PMLHist15MEs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: CRC-8 >= 1 for one or more bearer channels OR
+                 LOS >= 1 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: FEBE >= 1 for one or more bearer channels OR
+                 LOS-FE >= 1 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.2 (ES-L)
+                 and paragraph #7.2.1.2.2 (ES-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 5 }
+
+xdsl2PMLHist15MSes  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: (CRC-8 anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS >= 1
+                 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: (FEBE anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS-FE >= 1
+                 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.3 (SES-L)
+                 and paragraph #7.2.1.2.3 (SES-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 6 }
+
+xdsl2PMLHist15MLoss  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was LOS (or
+       LOS-FE for xTU-R)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.4 (LOSS-L)
+                 and paragraph #7.2.1.2.4 (LOSS-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 7 }
+
+xdsl2PMLHist15MUas  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds in Unavailability State during this
+       interval.
+       Unavailability begins at the onset of 10 contiguous severely
+       errored seconds, and ends at the onset of 10 contiguous seconds
+       with no severely errored seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.5 (UAS-L)
+                 and paragraph #7.2.1.2.5 (UAS-LFE)"
+   ::= { xdsl2PMLineHist15MinEntry 8 }
+
+xdsl2PMLHist15MValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMLineHist15MinEntry 9 }
+
+---------------------------------------
+--       PM line history 1 Day       --
+---------------------------------------
+
+xdsl2PMLineHist1DayTable     OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineHist1DayEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineHist1DayTable contains PM line history
+       for 24-hour intervals of DSL line."
+   ::= { xdsl2PMLine 4 }
+
+xdsl2PMLineHist1DayEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineHist1DayEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+      interface has an ifType of vdsl2(251).  A second index of this
+      table is the transmission unit.The third index is the interval
+      number."
+   INDEX  { ifIndex,
+            xdsl2PMLHist1DUnit,
+            xdsl2PMLHist1DInterval }
+   ::= { xdsl2PMLineHist1DayTable 1 }
+
+Xdsl2PMLineHist1DayEntry  ::=
+   SEQUENCE {
+      xdsl2PMLHist1DUnit              Xdsl2Unit,
+      xdsl2PMLHist1DInterval          Unsigned32,
+      xdsl2PMLHist1DMonitoredTime     Unsigned32,
+      xdsl2PMLHist1DFecs              Counter32,
+      xdsl2PMLHist1DEs                Counter32,
+      xdsl2PMLHist1DSes               Counter32,
+      xdsl2PMLHist1DLoss              Counter32,
+      xdsl2PMLHist1DUas               Counter32,
+      xdsl2PMLHist1DValidInterval     TruthValue
+   }
+
+xdsl2PMLHist1DUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2PMLineHist1DayEntry 1 }
+
+xdsl2PMLHist1DInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..30)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMLineHist1DayEntry 2 }
+
+xdsl2PMLHist1DMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMLineHist1DayEntry 3 }
+
+xdsl2PMLHist1DFecs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was at
+       least one FEC correction event for one or more bearer channels in
+       this line.  This parameter is inhibited during UAS or SES."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.1 (FECS-L)
+                 and paragraph #7.2.1.2.1 (FECS-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 4 }
+
+xdsl2PMLHist1DEs  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: CRC-8 >= 1 for one or more bearer channels OR
+                 LOS >= 1 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: FEBE >= 1 for one or more bearer channels OR
+                 LOS-FE >= 1 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.2 (ES-L)
+                 and paragraph #7.2.1.2.2 (ES-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 5 }
+
+xdsl2PMLHist1DSes  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was:
+          xTU-C: (CRC-8 anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS >= 1
+                 OR SEF >= 1 OR LPR >= 1.
+          xTU-R: (FEBE anomalies in one or more of the
+                 received bearer channels) >= 18 OR LOS-FE >= 1
+                 OR RDI >= 1 OR LPR-FE >= 1.
+       This parameter is inhibited during UAS."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.3 (SES-L)
+                 and paragraph #7.2.1.2.3 (SES-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 6 }
+
+xdsl2PMLHist1DLoss  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds during this interval that there was LOS (or
+       LOS-FE for xTU-R)."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.4 (LOSS-L)
+                 and paragraph #7.2.1.2.4 (LOSS-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 7 }
+
+xdsl2PMLHist1DUas  OBJECT-TYPE
+   SYNTAX      Counter32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of seconds in Unavailability State during this
+       interval.
+       Unavailability begins at the onset of 10 contiguous severely
+       errored seconds, and ends at the onset of 10 contiguous seconds
+       with no severely errored seconds."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.1.5 (UAS-L)
+                 and paragraph #7.2.1.2.5 (UAS-LFE)"
+   ::= { xdsl2PMLineHist1DayEntry 8 }
+
+xdsl2PMLHist1DValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMLineHist1DayEntry 9 }
+
+-------------------------------------------
+--     PM line init history 15 Minutes   --
+-------------------------------------------
+
+xdsl2PMLineInitHist15MinTable      OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineInitHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineInitHist15MinTable contains PM line
+       initialization history for 15-minute intervals of DSL
+       line."
+   ::= { xdsl2PMLine 5 }
+
+xdsl2PMLineInitHist15MinEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineInitHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of vdsl2(251).  A second index is the
+        interval number."
+   INDEX  { ifIndex,
+            xdsl2PMLInitHist15MInterval }
+   ::= { xdsl2PMLineInitHist15MinTable 1 }
+
+Xdsl2PMLineInitHist15MinEntry  ::=
+   SEQUENCE {
+      xdsl2PMLInitHist15MInterval              Unsigned32,
+      xdsl2PMLInitHist15MMonitoredTime         Unsigned32,
+      xdsl2PMLInitHist15MFullInits             Unsigned32,
+      xdsl2PMLInitHist15MFailedFullInits       Unsigned32,
+      xdsl2PMLInitHist15MShortInits            Unsigned32,
+      xdsl2PMLInitHist15MFailedShortInits      Unsigned32,
+      xdsl2PMLInitHist15MValidInterval         TruthValue
+   }
+
+xdsl2PMLInitHist15MInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..96)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMLineInitHist15MinEntry 1 }
+
+xdsl2PMLInitHist15MMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMLineInitHist15MinEntry 2 }
+
+xdsl2PMLInitHist15MFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of full initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.1"
+   ::= { xdsl2PMLineInitHist15MinEntry 3 }
+
+xdsl2PMLInitHist15MFailedFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed full initializations on the line during this
+       interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.2"
+   ::= { xdsl2PMLineInitHist15MinEntry 4 }
+
+xdsl2PMLInitHist15MShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of short initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.3"
+   ::= { xdsl2PMLineInitHist15MinEntry 5 }
+
+xdsl2PMLInitHist15MFailedShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed short initializations on the line during
+       this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.4"
+   ::= { xdsl2PMLineInitHist15MinEntry 6 }
+
+xdsl2PMLInitHist15MValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMLineInitHist15MinEntry 7 }
+
+-------------------------------------------
+--       PM line init history 1 Day      --
+-------------------------------------------
+
+xdsl2PMLineInitHist1DayTable       OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMLineInitHist1DayEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMLineInitHist1DayTable contains PM line
+       initialization history for 24-hour intervals for DSL
+       lines."
+   ::= { xdsl2PMLine 6 }
+
+xdsl2PMLineInitHist1DayEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMLineInitHist1DayEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+        interface has an ifType of vdsl2(251).  A second index is the
+        interval number."
+   INDEX  { ifIndex,
+            xdsl2PMLInitHist1DInterval }
+   ::= { xdsl2PMLineInitHist1DayTable 1 }
+
+Xdsl2PMLineInitHist1DayEntry  ::=
+   SEQUENCE {
+      xdsl2PMLInitHist1DInterval              Unsigned32,
+      xdsl2PMLInitHist1DMonitoredTime         Unsigned32,
+      xdsl2PMLInitHist1DFullInits             Unsigned32,
+      xdsl2PMLInitHist1DFailedFullInits       Unsigned32,
+      xdsl2PMLInitHist1DShortInits            Unsigned32,
+      xdsl2PMLInitHist1DFailedShortInits      Unsigned32,
+      xdsl2PMLInitHist1DValidInterval         TruthValue
+   }
+
+xdsl2PMLInitHist1DInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..30)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMLineInitHist1DayEntry 1 }
+
+xdsl2PMLInitHist1DMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMLineInitHist1DayEntry 2 }
+
+xdsl2PMLInitHist1DFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of full initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.1"
+    ::= { xdsl2PMLineInitHist1DayEntry 3 }
+
+xdsl2PMLInitHist1DFailedFullInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed full initializations on the line during this
+       interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.2"
+   ::= { xdsl2PMLineInitHist1DayEntry 4 }
+
+xdsl2PMLInitHist1DShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of short initializations attempted on the line
+       (successful and failed) during this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.3"
+   ::= { xdsl2PMLineInitHist1DayEntry 5 }
+
+xdsl2PMLInitHist1DFailedShortInits  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of failed short initializations on the line during
+       this interval."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.1.3.4"
+   ::= { xdsl2PMLineInitHist1DayEntry 6 }
+
+xdsl2PMLInitHist1DValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMLineInitHist1DayEntry 7 }
+
+---------------------------------------------------
+--          PM channel current counters          --
+---------------------------------------------------
+
+xdsl2PMChCurrTable        OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMChCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMChCurrTable contains current Performance
+       Monitoring results for DSL channels."
+   ::= { xdsl2PMChannel 1 }
+
+xdsl2PMChCurrEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMChCurrEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+       "One index of this table is an interface index where the
+       interface has an ifType of a DSL channel.  A second index of
+       this table is the termination unit."
+   INDEX  { ifIndex, xdsl2PMChCurrUnit }
+   ::= { xdsl2PMChCurrTable 1 }
+
+Xdsl2PMChCurrEntry  ::=
+   SEQUENCE {
+      xdsl2PMChCurrUnit                     Xdsl2Unit,
+      xdsl2PMChCurr15MValidIntervals        Unsigned32,
+      xdsl2PMChCurr15MInvalidIntervals      Unsigned32,
+      xdsl2PMChCurr15MTimeElapsed           HCPerfTimeElapsed,
+      xdsl2PMChCurr15MCodingViolations      Unsigned32,
+      xdsl2PMChCurr15MCorrectedBlocks       Unsigned32,
+      xdsl2PMChCurr1DayValidIntervals       Unsigned32,
+      xdsl2PMChCurr1DayInvalidIntervals     Unsigned32,
+      xdsl2PMChCurr1DayTimeElapsed          HCPerfTimeElapsed,
+      xdsl2PMChCurr1DayCodingViolations     Unsigned32,
+      xdsl2PMChCurr1DayCorrectedBlocks      Unsigned32
+   }
+
+xdsl2PMChCurrUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+   "The termination unit."
+   ::= { xdsl2PMChCurrEntry 1 }
+
+xdsl2PMChCurr15MValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which data
+       was collected.  The value will typically be equal to the maximum
+       number of 15-minute intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 15-minute intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+
+       maximum interval number for which data is available."
+   ::= { xdsl2PMChCurrEntry 2 }
+
+xdsl2PMChCurr15MInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..96)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 15-minute PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+    ::= { xdsl2PMChCurrEntry 3 }
+
+xdsl2PMChCurr15MTimeElapsed  OBJECT-TYPE
+   SYNTAX      HCPerfTimeElapsed
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMChCurrEntry 4 }
+
+xdsl2PMChCurr15MCodingViolations  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of CRC-8 (FEBE for xTU-R) anomalies occurring in the
+       channel during the interval.  This parameter is inhibited during
+       UAS or SES.  If the CRC is applied over multiple channels, then
+       each related CRC-8 (or FEBE) anomaly SHOULD increment each of the
+       counters related to the individual channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.1 (CV-C)
+                 and paragraph #7.2.2.2.1 (CV-CFE)"
+  ::= { xdsl2PMChCurrEntry 5 }
+
+xdsl2PMChCurr15MCorrectedBlocks  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of FEC (FFEC for xTU-R) anomalies (corrected code
+       words) occurring in the channel during the interval.  This
+       parameter is inhibited during UAS or SES.  If the FEC is applied
+       over multiple channels, then each related FEC (or FFEC) anomaly
+       SHOULD increment each of the counters related to the individual
+       channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.2 (FEC-C)
+                 and paragraph #7.2.2.2.2 (FEC-CFE)"
+   ::= { xdsl2PMChCurrEntry 6 }
+
+xdsl2PMChCurr1DayValidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which data was
+       collected.  The value will typically be equal to the maximum
+       number of 24-hour intervals the implementation is planned to
+       store (i.e., beyond the scope of this MIB module) unless the
+       measurement was (re-)started recently, in which case the value
+       will be the number of complete 24-hour intervals for which
+       the agent has at least some data.  In certain cases (e.g., in
+       the case where the agent is a proxy), it is possible that some
+       intervals are unavailable.  In this case, this interval is the
+       maximum interval number for which data is available."
+   ::= { xdsl2PMChCurrEntry 7 }
+
+xdsl2PMChCurr1DayInvalidIntervals  OBJECT-TYPE
+   SYNTAX      Unsigned32 (0..30)
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "The number of 24-hour PM intervals for which no data is
+       available.  The value will typically be zero except in cases
+       where the data for some intervals are not available (e.g.,
+       in proxy situations)."
+   ::= { xdsl2PMChCurrEntry 8 }
+
+xdsl2PMChCurr1DayTimeElapsed  OBJECT-TYPE
+   SYNTAX      HCPerfTimeElapsed
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total elapsed seconds in this interval."
+   ::= { xdsl2PMChCurrEntry 9 }
+
+xdsl2PMChCurr1DayCodingViolations  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of CRC-8 (FEBE for xTU-R) anomalies occurring in the
+       channel during the interval.  This parameter is inhibited during
+
+       UAS or SES.  If the CRC is applied over multiple channels, then
+       each related CRC-8 (or FEBE) anomaly SHOULD increment each of the
+       counters related to the individual channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.1 (CV-C)
+                 and paragraph #7.2.2.2.1 (CV-CFE)"
+   ::= { xdsl2PMChCurrEntry 10 }
+
+xdsl2PMChCurr1DayCorrectedBlocks  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of FEC (FFEC for xTU-R) anomalies (corrected code
+       words) occurring in the channel during the interval.  This
+       parameter is inhibited during UAS or SES.  If the FEC is applied
+       over multiple channels, then each related FEC (or FFEC) anomaly
+       SHOULD increment each of the counters related to the individual
+       channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.2 (FEC-C)
+                 and paragraph #7.2.2.2.2 (FEC-CFE)"
+   ::= { xdsl2PMChCurrEntry 11 }
+
+-------------------------------------------
+--    PM channel history 15 Minutes      --
+-------------------------------------------
+
+xdsl2PMChHist15MinTable         OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMChHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMChHist15MinTable contains Performance
+       Monitoring (PM) history for 15-minute intervals for DSL channels
+       PM."
+   ::= { xdsl2PMChannel 2 }
+
+xdsl2PMChHist15MinEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMChHist15MinEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+       interface has an ifType of a DSL channel.  A second index of
+       this table is the transmission unit.  The third index is the
+       interval number."
+   INDEX  { ifIndex,
+            xdsl2PMChHist15MUnit,
+            xdsl2PMChHist15MInterval }
+   ::= { xdsl2PMChHist15MinTable 1 }
+
+Xdsl2PMChHist15MinEntry  ::=
+   SEQUENCE {
+      xdsl2PMChHist15MUnit                     Xdsl2Unit,
+      xdsl2PMChHist15MInterval                 Unsigned32,
+      xdsl2PMChHist15MMonitoredTime            Unsigned32,
+      xdsl2PMChHist15MCodingViolations         Unsigned32,
+      xdsl2PMChHist15MCorrectedBlocks          Unsigned32,
+      xdsl2PMChHist15MValidInterval            TruthValue
+   }
+
+xdsl2PMChHist15MUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+   ::= { xdsl2PMChHist15MinEntry 1 }
+
+xdsl2PMChHist15MInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..96)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMChHist15MinEntry 2 }
+
+xdsl2PMChHist15MMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMChHist15MinEntry 3 }
+
+xdsl2PMChHist15MCodingViolations  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of CRC-8 (FEBE for xTU-R) anomalies occurring in the
+       channel during the interval.  This parameter is inhibited during
+       UAS or SES.  If the CRC is applied over multiple channels, then
+       each related CRC-8 (or FEBE) anomaly SHOULD increment each of the
+       counters related to the individual channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.1 (CV-C)
+
+                 and paragraph #7.2.2.2.1 (CV-CFE)"
+  ::= { xdsl2PMChHist15MinEntry 4 }
+
+xdsl2PMChHist15MCorrectedBlocks  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of FEC (FFEC for xTU-R) anomalies (corrected code
+       words) occurring in the channel during the interval.  This
+       parameter is inhibited during UAS or SES.  If the FEC is applied
+       over multiple channels, then each related FEC (or FFEC) anomaly
+       SHOULD increment each of the counters related to the individual
+       channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.2 (FEC-C)
+                 and paragraph #7.2.2.2.2 (FEC-CFE)"
+   ::= { xdsl2PMChHist15MinEntry 5 }
+
+xdsl2PMChHist15MValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMChHist15MinEntry 6 }
+
+------------------------------------------
+--        PM channel history 1 Day      --
+------------------------------------------
+
+xdsl2PMChHist1DTable         OBJECT-TYPE
+   SYNTAX      SEQUENCE  OF  Xdsl2PMChHist1DEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The table xdsl2PMChHist1DTable contains Performance
+       Monitoring (PM) history for 1-day intervals for DSL channels
+       PM."
+   ::= { xdsl2PMChannel 3 }
+
+xdsl2PMChHist1DEntry  OBJECT-TYPE
+   SYNTAX      Xdsl2PMChHist1DEntry
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "One index of this table is an interface index where the
+       interface has an ifType of a DSL channel.  A second index of
+
+       this table is the transmission unit.  The third index is the
+       interval number."
+   INDEX  { ifIndex,
+            xdsl2PMChHist1DUnit,
+            xdsl2PMChHist1DInterval }
+   ::= { xdsl2PMChHist1DTable 1 }
+
+Xdsl2PMChHist1DEntry  ::=
+   SEQUENCE {
+      xdsl2PMChHist1DUnit                      Xdsl2Unit,
+      xdsl2PMChHist1DInterval                  Unsigned32,
+      xdsl2PMChHist1DMonitoredTime             Unsigned32,
+      xdsl2PMChHist1DCodingViolations          Unsigned32,
+      xdsl2PMChHist1DCorrectedBlocks           Unsigned32,
+      xdsl2PMChHist1DValidInterval             TruthValue
+   }
+
+xdsl2PMChHist1DUnit  OBJECT-TYPE
+   SYNTAX      Xdsl2Unit
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The termination unit."
+    ::= { xdsl2PMChHist1DEntry 1 }
+
+xdsl2PMChHist1DInterval  OBJECT-TYPE
+   SYNTAX      Unsigned32 (1..30)
+   MAX-ACCESS  not-accessible
+   STATUS      current
+   DESCRIPTION
+      "The interval number."
+   ::= { xdsl2PMChHist1DEntry 2 }
+
+xdsl2PMChHist1DMonitoredTime  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   UNITS       "seconds"
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Total seconds monitored in this interval."
+   ::= { xdsl2PMChHist1DEntry 3 }
+
+xdsl2PMChHist1DCodingViolations  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of CRC-8 (FEBE for xTU-R) anomalies occurring in the
+
+       channel during the interval.  This parameter is inhibited during
+       UAS or SES.  If the CRC is applied over multiple channels, then
+       each related CRC-8 (or FEBE) anomaly SHOULD increment each of the
+       counters related to the individual channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.1 (CV-C)
+                 and paragraph #7.2.2.2.1 (CV-CFE)"
+   ::= { xdsl2PMChHist1DEntry 4 }
+
+xdsl2PMChHist1DCorrectedBlocks  OBJECT-TYPE
+   SYNTAX      Unsigned32
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "Count of FEC (FFEC for xTU-R) anomalies (corrected code
+       words) occurring in the channel during the interval.  This
+       parameter is inhibited during UAS or SES.  If the FEC is applied
+       over multiple channels, then each related FEC (or FFEC) anomaly
+       SHOULD increment each of the counters related to the individual
+       channels."
+   REFERENCE    "ITU-T G.997.1, paragraph #7.2.2.1.2 (FEC-C)
+                 and paragraph #7.2.2.2.2 (FEC-CFE)"
+   ::= { xdsl2PMChHist1DEntry 5 }
+
+xdsl2PMChHist1DValidInterval  OBJECT-TYPE
+   SYNTAX      TruthValue
+   MAX-ACCESS  read-only
+   STATUS      current
+   DESCRIPTION
+      "This variable indicates if the data for this interval is
+       valid."
+   ::= { xdsl2PMChHist1DEntry 6 }
+
+-------------------------------------------
+--          Notifications Group          --
+-------------------------------------------
+
+xdsl2LinePerfFECSThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MFecs,
+   xdsl2LineAlarmConfProfileXtucThresh15MinFecs
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the FEC seconds threshold
+      has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 1 }
+
+xdsl2LinePerfFECSThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MFecs,
+   xdsl2LineAlarmConfProfileXturThresh15MinFecs
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the FEC seconds threshold
+      has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 2 }
+
+xdsl2LinePerfESThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MEs,
+   xdsl2LineAlarmConfProfileXtucThresh15MinEs
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the errored seconds
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 3 }
+
+xdsl2LinePerfESThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MEs,
+   xdsl2LineAlarmConfProfileXturThresh15MinEs
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the errored seconds
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 4 }
+
+xdsl2LinePerfSESThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MSes,
+   xdsl2LineAlarmConfProfileXtucThresh15MinSes
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the severely errored seconds
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 5 }
+
+xdsl2LinePerfSESThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MSes,
+   xdsl2LineAlarmConfProfileXturThresh15MinSes
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the severely errored seconds
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 6 }
+
+xdsl2LinePerfLOSSThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MLoss,
+   xdsl2LineAlarmConfProfileXtucThresh15MinLoss
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the LOS seconds
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 7 }
+
+xdsl2LinePerfLOSSThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MLoss,
+   xdsl2LineAlarmConfProfileXturThresh15MinLoss
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the LOS seconds
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 8 }
+
+xdsl2LinePerfUASThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MUas,
+   xdsl2LineAlarmConfProfileXtucThresh15MinUas
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the unavailable seconds
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 9 }
+
+xdsl2LinePerfUASThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLCurr15MUas,
+   xdsl2LineAlarmConfProfileXturThresh15MinUas
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the unavailable seconds
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 10 }
+
+xdsl2LinePerfCodingViolationsThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMChCurr15MCodingViolations,
+   xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the coding violations
+      threshold has been reached/exceeded for the referred xTU-C."
+   ::= { xdsl2Notifications 11 }
+
+xdsl2LinePerfCodingViolationsThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMChCurr15MCodingViolations,
+   xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the coding violations
+      threshold has been reached/exceeded for the referred xTU-R."
+   ::= { xdsl2Notifications 12 }
+
+xdsl2LinePerfCorrectedThreshXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMChCurr15MCorrectedBlocks,
+   xdsl2ChAlarmConfProfileXtucThresh15MinCorrected
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the corrected blocks
+      (FEC events) threshold has been reached/exceeded for the
+      referred xTU-C."
+   ::= { xdsl2Notifications 13 }
+
+xdsl2LinePerfCorrectedThreshXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMChCurr15MCorrectedBlocks,
+   xdsl2ChAlarmConfProfileXturThresh15MinCorrected
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the corrected blocks
+      (FEC events) threshold has been reached/exceeded for the
+      referred xTU-R."
+   ::= { xdsl2Notifications 14 }
+
+xdsl2LinePerfFailedFullInitThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLInitCurr15MFailedFullInits,
+   xdsl2LineAlarmConfProfileThresh15MinFailedFullInt
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the failed full
+      initializations threshold has been reached/exceeded for the
+      referred ADSL/ADSL2 or ADSL2 line."
+   ::= { xdsl2Notifications 15 }
+
+xdsl2LinePerfFailedShortInitThresh NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2PMLInitCurr15MFailedShortInits,
+   xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that the failed short
+      initializations threshold has been reached/exceeded for the
+      referred VDSL2/ADSL/ADSL2 or ADSL2+ line."
+   ::= { xdsl2Notifications 16 }
+
+xdsl2LineStatusChangeXtuc NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2LineStatusXtuc
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that a status change is
+      detected for the referred xTU-C."
+   ::= { xdsl2Notifications 17 }
+
+xdsl2LineStatusChangeXtur NOTIFICATION-TYPE
+   OBJECTS
+   {
+   xdsl2LineStatusXtur
+   }
+   STATUS     current
+   DESCRIPTION
+     "This notification indicates that a status change is
+      detected for the referred xTU-R."
+   ::= { xdsl2Notifications 18 }
+
+   -- conformance information
+
+   xdsl2Groups OBJECT IDENTIFIER ::= { xdsl2Conformance 1 }
+   xdsl2Compliances OBJECT IDENTIFIER ::= { xdsl2Conformance 2 }
+
+   xdsl2LineMibCompliance MODULE-COMPLIANCE
+      STATUS  current
+      DESCRIPTION
+         "The compliance statement for SNMP entities which
+          manage VDSL2/ADSL/ADSL2 and ADSL2+ interfaces."
+      MODULE  -- this module
+      MANDATORY-GROUPS
+          {
+          xdsl2LineGroup,
+          xdsl2ChannelStatusGroup,
+          xdsl2SCStatusGroup,
+          xdsl2LineInventoryGroup,
+          xdsl2LineConfTemplateGroup,
+          xdsl2LineConfProfGroup,
+          xdsl2LineConfProfModeSpecGroup,
+          xdsl2LineConfProfModeSpecBandUsGroup,
+          xdsl2ChConfProfileGroup,
+          xdsl2LineAlarmConfTemplateGroup,
+          xdsl2PMLineCurrGroup,
+          xdsl2PMLineInitCurrGroup,
+          xdsl2PMLineHist15MinGroup,
+          xdsl2PMLineHist1DayGroup,
+          xdsl2PMLineInitHist15MinGroup,
+          xdsl2PMLineInitHist1DayGroup,
+          xdsl2PMChCurrGroup,
+          xdsl2PMChHist15MinGroup,
+          xdsl2PMChHist1DGroup
+          }
+
+   GROUP  xdsl2LineFallbackGroup
+      DESCRIPTION
+        "The group of configuration, status, and commands
+         objects on the line level that are associated with the fallback
+         feature."
+
+   GROUP  xdsl2LineBpscGroup
+      DESCRIPTION
+        "The group of configuration, status, and commands objects
+         on the line level that are associated with requesting a bits
+         per subcarrier measurement."
+
+   GROUP  xdsl2LineSegmentGroup
+      DESCRIPTION
+        "The group of status and commands objects on the line
+         level that are used to hold the results of the
+         bits-per-subcarrier measurement."
+
+   GROUP  xdsl2ChannelStatusAtmGroup
+      DESCRIPTION
+        "The group of status objects required when the data path
+         is ATM."
+
+   GROUP  xdsl2ChannelStatusPtmGroup
+      DESCRIPTION
+        "The group of status objects required when the data path
+         is PTM."
+
+   GROUP  xdsl2LineConfProfRaGroup
+      DESCRIPTION
+        "The group of objects required for controlling the
+         rate-adaptive behavior of the line."
+
+   GROUP  xdsl2LineConfProfMsgMinGroup
+      DESCRIPTION
+        "The group of objects required for controlling the rate
+         reserved for Overhead traffic."
+
+   GROUP  xdsl2LineAlarmConfProfileGroup
+      DESCRIPTION
+        "The group of objects that define the alarm thresholds
+         on line-level PM counters."
+
+   GROUP  xdsl2ChAlarmConfProfileGroup
+      DESCRIPTION
+        "The group of objects that define the alarm thresholds
+        on channel-level PM counters."
+
+   GROUP  xdsl2ChConfProfileAtmGroup
+      DESCRIPTION
+        "The group of configuration objects required when the data
+         path is ATM."
+
+   GROUP  xdsl2ChConfProfileMinResGroup
+      DESCRIPTION
+        "The group of configuration objects required for the
+         reserved data rate."
+
+   GROUP  xdsl2ChConfProfileOptAttrGroup
+      DESCRIPTION
+        "The group of various optional channel configuration
+        objects."
+
+   GROUP  xdsl2PMLineInitCurrShortGroup
+      DESCRIPTION
+        "The group of PM counters for the current intervals short
+         initializations."
+
+   GROUP  xdsl2PMLineInitHist15MinShortGroup
+      DESCRIPTION
+        "The group of PM counters for the previous 15-minute
+         intervals short initializations."
+
+   GROUP  xdsl2PMLineInitHist1DayShortGroup
+      DESCRIPTION
+        "The group of PM counters for the previous 24-hour
+         intervals short initializations."
+
+   GROUP  xdsl2ScalarSCGroup
+      DESCRIPTION
+        "The group of objects that report the available memory
+         resources for the DELT processes."
+
+   GROUP  xdsl2ThreshNotificationGroup
+      DESCRIPTION
+        "The group of thresholds crossing notifications."
+
+   GROUP  xdsl2StatusChangeNotificationGroup
+      DESCRIPTION
+        "The group of status change notifications."
+      ::= { xdsl2Compliances 1 }
+
+   -- units of conformance
+
+   xdsl2LineGroup OBJECT-GROUP
+
+      OBJECTS
+          {
+          xdsl2LineConfTemplate,
+          xdsl2LineAlarmConfTemplate,
+          xdsl2LineCmndConfPmsf,
+          xdsl2LineCmndConfLdsf,
+          xdsl2LineCmndConfLdsfFailReason,
+          xdsl2LineCmndAutomodeColdStart,
+          xdsl2LineCmndConfReset,
+          xdsl2LineStatusXtuTransSys,
+          xdsl2LineStatusPwrMngState,
+          xdsl2LineStatusInitResult,
+          xdsl2LineStatusLastStateDs,
+          xdsl2LineStatusLastStateUs,
+          xdsl2LineStatusXtur,
+          xdsl2LineStatusXtuc,
+          xdsl2LineStatusAttainableRateDs,
+          xdsl2LineStatusAttainableRateUs,
+          xdsl2LineStatusActPsdDs,
+          xdsl2LineStatusActPsdUs,
+          xdsl2LineStatusActAtpDs,
+          xdsl2LineStatusActAtpUs,
+          xdsl2LineStatusActProfile,
+          xdsl2LineStatusActLimitMask,
+          xdsl2LineStatusActUs0Mask,
+          xdsl2LineStatusActSnrModeDs,
+          xdsl2LineStatusActSnrModeUs,
+          xdsl2LineStatusElectricalLength,
+          xdsl2LineStatusTssiDs,
+          xdsl2LineStatusTssiUs,
+          xdsl2LineStatusMrefPsdDs,
+          xdsl2LineStatusMrefPsdUs,
+          xdsl2LineStatusTrellisDs,
+          xdsl2LineStatusTrellisUs,
+          xdsl2LineStatusActualCe,
+          xdsl2LineBandStatusLnAtten,
+          xdsl2LineBandStatusSigAtten,
+          xdsl2LineBandStatusSnrMargin
+           }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration, status, and commands objects
+          on the line level."
+      ::= { xdsl2Groups 1 }
+
+   xdsl2LineFallbackGroup OBJECT-GROUP
+      OBJECTS
+          {
+
+          xdsl2LineConfFallbackTemplate,
+          xdsl2LineStatusActTemplate
+           }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration, status, and commands
+          objects on the line level that are associated with the
+          fallback feature."
+      ::= { xdsl2Groups 2 }
+
+   xdsl2LineBpscGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LineCmndConfBpsc,
+          xdsl2LineCmndConfBpscFailReason,
+          xdsl2LineCmndConfBpscRequests
+           }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration, status, and commands
+          objects on the line level that are associated with requesting
+          a bits-per-subcarrier measurement."
+      ::= { xdsl2Groups 3 }
+
+   xdsl2LineSegmentGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LineSegmentBitsAlloc,
+          xdsl2LineSegmentRowStatus
+           }
+      STATUS     current
+      DESCRIPTION
+         "The group of status and commands objects on the line
+          level that are used to hold the results of the
+          bits-per-subcarrier measurement."
+      ::= { xdsl2Groups 4 }
+
+   xdsl2ChannelStatusGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChStatusActDataRate,
+          xdsl2ChStatusPrevDataRate,
+          xdsl2ChStatusActDelay,
+          xdsl2ChStatusActInp,
+          xdsl2ChStatusInpReport,
+          xdsl2ChStatusNFec,
+          xdsl2ChStatusRFec,
+          xdsl2ChStatusLSymb,
+          xdsl2ChStatusIntlvDepth,
+          xdsl2ChStatusIntlvBlock,
+          xdsl2ChStatusLPath
+          }
+      STATUS     current
+      DESCRIPTION
+          "The group of status objects on the channel level."
+      ::= { xdsl2Groups 5 }
+
+   xdsl2ChannelStatusAtmGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChStatusAtmStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of status objects on the data path level
+          when it is ATM."
+      ::= { xdsl2Groups 6 }
+
+   xdsl2ChannelStatusPtmGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChStatusPtmStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of status objects on the data path level
+          when it is PTM."
+      ::= { xdsl2Groups 7 }
+
+   xdsl2SCStatusGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2SCStatusLinScale,
+          xdsl2SCStatusLinScGroupSize,
+          xdsl2SCStatusLogMt,
+          xdsl2SCStatusLogScGroupSize,
+          xdsl2SCStatusQlnMt,
+          xdsl2SCStatusQlnScGroupSize,
+          xdsl2SCStatusSnrMtime,
+          xdsl2SCStatusSnrScGroupSize,
+          xdsl2SCStatusBandLnAtten,
+          xdsl2SCStatusBandSigAtten,
+          xdsl2SCStatusAttainableRate,
+          xdsl2SCStatusRowStatus,
+          xdsl2SCStatusSegmentLinReal,
+          xdsl2SCStatusSegmentLinImg,
+          xdsl2SCStatusSegmentLog,
+          xdsl2SCStatusSegmentQln,
+          xdsl2SCStatusSegmentSnr,
+          xdsl2SCStatusSegmentBitsAlloc,
+          xdsl2SCStatusSegmentGainAlloc
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of status objects on the subcarrier level.
+          They are updated as a result of a DELT process."
+      ::= { xdsl2Groups 8 }
+
+   xdsl2LineInventoryGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LInvG994VendorId,
+          xdsl2LInvSystemVendorId,
+          xdsl2LInvVersionNumber,
+          xdsl2LInvSerialNumber,
+          xdsl2LInvSelfTestResult,
+          xdsl2LInvTransmissionCapabilities
+          }
+      STATUS     current
+      DESCRIPTION
+          "The group of inventory objects per xTU."
+      ::= { xdsl2Groups 9 }
+
+   xdsl2LineConfTemplateGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfTempLineProfile,
+          xdsl2LConfTempChan1ConfProfile,
+          xdsl2LConfTempChan1RaRatioDs,
+          xdsl2LConfTempChan1RaRatioUs,
+          xdsl2LConfTempChan2ConfProfile,
+          xdsl2LConfTempChan2RaRatioDs,
+          xdsl2LConfTempChan2RaRatioUs,
+          xdsl2LConfTempChan3ConfProfile,
+          xdsl2LConfTempChan3RaRatioDs,
+          xdsl2LConfTempChan3RaRatioUs,
+          xdsl2LConfTempChan4ConfProfile,
+          xdsl2LConfTempChan4RaRatioDs,
+          xdsl2LConfTempChan4RaRatioUs,
+          xdsl2LConfTempRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line configuration
+
+          template."
+      ::= { xdsl2Groups 10 }
+
+   xdsl2LineConfProfGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfScMaskDs,
+          xdsl2LConfProfScMaskUs,
+          xdsl2LConfProfVdsl2CarMask,
+          xdsl2LConfProfRfiBands,
+          xdsl2LConfProfRaModeDs,
+          xdsl2LConfProfRaModeUs,
+          xdsl2LConfProfTargetSnrmDs,
+          xdsl2LConfProfTargetSnrmUs,
+          xdsl2LConfProfMaxSnrmDs,
+          xdsl2LConfProfMaxSnrmUs,
+          xdsl2LConfProfMinSnrmDs,
+          xdsl2LConfProfMinSnrmUs,
+          xdsl2LConfProfCeFlag,
+          xdsl2LConfProfSnrModeDs,
+          xdsl2LConfProfSnrModeUs,
+          xdsl2LConfProfTxRefVnDs,
+          xdsl2LConfProfTxRefVnUs,
+          xdsl2LConfProfXtuTransSysEna,
+          xdsl2LConfProfPmMode,
+          xdsl2LConfProfL0Time,
+          xdsl2LConfProfL2Time,
+          xdsl2LConfProfL2Atpr,
+          xdsl2LConfProfL2Atprt,
+          xdsl2LConfProfProfiles,
+          xdsl2LConfProfDpboEPsd,
+          xdsl2LConfProfDpboEsEL,
+          xdsl2LConfProfDpboEsCableModelA,
+          xdsl2LConfProfDpboEsCableModelB,
+          xdsl2LConfProfDpboEsCableModelC,
+          xdsl2LConfProfDpboMus,
+          xdsl2LConfProfDpboFMin,
+          xdsl2LConfProfDpboFMax,
+          xdsl2LConfProfUpboKL,
+          xdsl2LConfProfUpboKLF,
+          xdsl2LConfProfUs0Mask,
+          xdsl2LConfProfForceInp,
+          xdsl2LConfProfRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line configuration
+          profile."
+      ::= { xdsl2Groups 11 }
+
+   xdsl2LineConfProfRaGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfRaUsNrmDs,
+          xdsl2LConfProfRaUsNrmUs,
+          xdsl2LConfProfRaUsTimeDs,
+          xdsl2LConfProfRaUsTimeUs,
+          xdsl2LConfProfRaDsNrmDs,
+          xdsl2LConfProfRaDsNrmUs,
+          xdsl2LConfProfRaDsTimeDs,
+          xdsl2LConfProfRaDsTimeUs
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects required for controlling the
+          rate-adaptive behavior of the line."
+      ::= { xdsl2Groups 12 }
+
+   xdsl2LineConfProfMsgMinGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfMsgMinUs,
+          xdsl2LConfProfMsgMinDs
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects required for controlling the rate
+          reserved for Overhead traffic."
+      ::= { xdsl2Groups 13 }
+
+   xdsl2LineConfProfModeSpecGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfMaxNomPsdDs,
+          xdsl2LConfProfMaxNomPsdUs,
+          xdsl2LConfProfMaxNomAtpDs,
+          xdsl2LConfProfMaxNomAtpUs,
+          xdsl2LConfProfMaxAggRxPwrUs,
+          xdsl2LConfProfPsdMaskDs,
+          xdsl2LConfProfPsdMaskUs,
+          xdsl2LConfProfPsdMaskSelectUs,
+          xdsl2LConfProfClassMask,
+          xdsl2LConfProfLimitMask,
+          xdsl2LConfProfUs0Disable,
+          xdsl2LConfProfModeSpecRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line configuration profile
+          that have an instance for each operation mode allowed."
+      ::= { xdsl2Groups 14 }
+
+   xdsl2LineConfProfModeSpecBandUsGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LConfProfUpboPsdA,
+          xdsl2LConfProfUpboPsdB,
+          xdsl2LConfProfModeSpecBandUsRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line configuration profile
+          that have several per-upstream-band instances for each
+          operation mode allowed."
+      ::= { xdsl2Groups 15 }
+
+   xdsl2ChConfProfileGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChConfProfMinDataRateDs,
+          xdsl2ChConfProfMinDataRateUs,
+          xdsl2ChConfProfMaxDataRateDs,
+          xdsl2ChConfProfMaxDataRateUs,
+          xdsl2ChConfProfMinDataRateLowPwrDs,
+          xdsl2ChConfProfMinDataRateLowPwrUs,
+          xdsl2ChConfProfMaxDelayDs,
+          xdsl2ChConfProfMaxDelayUs,
+          xdsl2ChConfProfMinProtectionDs,
+          xdsl2ChConfProfMinProtectionUs,
+          xdsl2ChConfProfMinProtection8Ds,
+          xdsl2ChConfProfMinProtection8Us,
+          xdsl2ChConfProfMaxBerDs,
+          xdsl2ChConfProfMaxBerUs,
+          xdsl2ChConfProfUsDataRateDs,
+          xdsl2ChConfProfDsDataRateDs,
+          xdsl2ChConfProfUsDataRateUs,
+          xdsl2ChConfProfDsDataRateUs,
+          xdsl2ChConfProfRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a channel configuration
+          profile."
+      ::= { xdsl2Groups 16 }
+
+   xdsl2ChConfProfileAtmGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChConfProfImaEnabled,
+          xdsl2ChStatusAtmStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration objects required when the data
+          path is ATM."
+      ::= { xdsl2Groups 17 }
+
+   xdsl2ChConfProfileMinResGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChConfProfMinResDataRateDs,
+          xdsl2ChConfProfMinResDataRateUs
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of configuration objects required for the
+          reserved data rate."
+      ::= { xdsl2Groups 18 }
+   xdsl2ChConfProfileOptAttrGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChConfProfMaxDelayVar,
+          xdsl2ChConfProfInitPolicy
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of various optional channel configuration
+          parameters."
+      ::= { xdsl2Groups 19 }
+
+   xdsl2LineAlarmConfTemplateGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LAlarmConfTempLineProfile,
+          xdsl2LAlarmConfTempChan1ConfProfile,
+          xdsl2LAlarmConfTempChan2ConfProfile,
+          xdsl2LAlarmConfTempChan3ConfProfile,
+          xdsl2LAlarmConfTempChan4ConfProfile,
+          xdsl2LAlarmConfTempRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line alarm template."
+      ::= { xdsl2Groups 20 }
+
+   xdsl2LineAlarmConfProfileGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2LineAlarmConfProfileXtucThresh15MinFecs,
+          xdsl2LineAlarmConfProfileXtucThresh15MinEs,
+          xdsl2LineAlarmConfProfileXtucThresh15MinSes,
+          xdsl2LineAlarmConfProfileXtucThresh15MinLoss,
+          xdsl2LineAlarmConfProfileXtucThresh15MinUas,
+          xdsl2LineAlarmConfProfileXturThresh15MinFecs,
+          xdsl2LineAlarmConfProfileXturThresh15MinEs,
+          xdsl2LineAlarmConfProfileXturThresh15MinSes,
+          xdsl2LineAlarmConfProfileXturThresh15MinLoss,
+          xdsl2LineAlarmConfProfileXturThresh15MinUas,
+          xdsl2LineAlarmConfProfileThresh15MinFailedFullInt,
+          xdsl2LineAlarmConfProfileThresh15MinFailedShrtInt,
+          xdsl2LineAlarmConfProfileRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a line alarm profile."
+      ::= { xdsl2Groups 21 }
+
+   xdsl2ChAlarmConfProfileGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ChAlarmConfProfileXtucThresh15MinCodingViolations,
+          xdsl2ChAlarmConfProfileXtucThresh15MinCorrected,
+          xdsl2ChAlarmConfProfileXturThresh15MinCodingViolations,
+          xdsl2ChAlarmConfProfileXturThresh15MinCorrected,
+          xdsl2ChAlarmConfProfileRowStatus
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects in a channel alarm profile."
+      ::= { xdsl2Groups 22 }
+
+   xdsl2PMLineCurrGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLCurr15MValidIntervals,
+          xdsl2PMLCurr15MInvalidIntervals,
+          xdsl2PMLCurr15MTimeElapsed,
+          xdsl2PMLCurr15MFecs,
+          xdsl2PMLCurr15MEs,
+          xdsl2PMLCurr15MSes,
+          xdsl2PMLCurr15MLoss,
+          xdsl2PMLCurr15MUas,
+          xdsl2PMLCurr1DayValidIntervals,
+          xdsl2PMLCurr1DayInvalidIntervals,
+          xdsl2PMLCurr1DayTimeElapsed,
+          xdsl2PMLCurr1DayFecs,
+          xdsl2PMLCurr1DayEs,
+          xdsl2PMLCurr1DaySes,
+          xdsl2PMLCurr1DayLoss,
+          xdsl2PMLCurr1DayUas
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the line-level
+          counters for current PM intervals."
+      ::= { xdsl2Groups 23 }
+
+   xdsl2PMLineInitCurrGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitCurr15MValidIntervals,
+          xdsl2PMLInitCurr15MInvalidIntervals,
+          xdsl2PMLInitCurr15MTimeElapsed,
+          xdsl2PMLInitCurr15MFullInits,
+          xdsl2PMLInitCurr15MFailedFullInits,
+          xdsl2PMLInitCurr1DayValidIntervals,
+          xdsl2PMLInitCurr1DayInvalidIntervals,
+          xdsl2PMLInitCurr1DayTimeElapsed,
+          xdsl2PMLInitCurr1DayFullInits,
+          xdsl2PMLInitCurr1DayFailedFullInits
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the full
+          initialization counters for current PM intervals."
+      ::= { xdsl2Groups 24 }
+
+   xdsl2PMLineInitCurrShortGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitCurr15MShortInits,
+          xdsl2PMLInitCurr15MFailedShortInits,
+          xdsl2PMLInitCurr1DayShortInits,
+          xdsl2PMLInitCurr1DayFailedShortInits
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the short
+          initialization counters for current PM intervals."
+      ::= { xdsl2Groups 25 }
+
+   xdsl2PMLineHist15MinGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLHist15MMonitoredTime,
+          xdsl2PMLHist15MFecs,
+          xdsl2PMLHist15MEs,
+          xdsl2PMLHist15MSes,
+          xdsl2PMLHist15MLoss,
+          xdsl2PMLHist15MUas,
+          xdsl2PMLHist15MValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of line-level PM counters for the previous
+          15-minute intervals."
+      ::= { xdsl2Groups 26 }
+
+   xdsl2PMLineHist1DayGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLHist1DMonitoredTime,
+          xdsl2PMLHist1DFecs,
+          xdsl2PMLHist1DEs,
+          xdsl2PMLHist1DSes,
+          xdsl2PMLHist1DLoss,
+          xdsl2PMLHist1DUas,
+          xdsl2PMLHist1DValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of line-level PM counters for the previous
+          24-hour intervals."
+      ::= { xdsl2Groups 27 }
+
+   xdsl2PMLineInitHist15MinGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitHist15MMonitoredTime,
+          xdsl2PMLInitHist15MFullInits,
+          xdsl2PMLInitHist15MFailedFullInits,
+          xdsl2PMLInitHist15MValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of PM counters for the previous 15-minute
+          interval full initializations."
+      ::= { xdsl2Groups 28 }
+
+   xdsl2PMLineInitHist15MinShortGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitHist15MShortInits,
+          xdsl2PMLInitHist15MFailedShortInits
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of PM counters for the previous 15-minute
+          interval short initializations."
+      ::= { xdsl2Groups 29 }
+
+   xdsl2PMLineInitHist1DayGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitHist1DMonitoredTime,
+          xdsl2PMLInitHist1DFullInits,
+          xdsl2PMLInitHist1DFailedFullInits,
+          xdsl2PMLInitHist1DValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of PM counters for the previous 24-hour
+          interval full initializations."
+      ::= { xdsl2Groups 30 }
+
+   xdsl2PMLineInitHist1DayShortGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMLInitHist1DShortInits,
+          xdsl2PMLInitHist1DFailedShortInits
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of PM counters for the previous 24-hour
+          interval short initializations."
+      ::= { xdsl2Groups 31 }
+
+   xdsl2PMChCurrGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMChCurr15MValidIntervals,
+          xdsl2PMChCurr15MInvalidIntervals,
+          xdsl2PMChCurr15MTimeElapsed,
+          xdsl2PMChCurr15MCodingViolations,
+          xdsl2PMChCurr15MCorrectedBlocks,
+          xdsl2PMChCurr1DayValidIntervals,
+          xdsl2PMChCurr1DayInvalidIntervals,
+          xdsl2PMChCurr1DayTimeElapsed,
+          xdsl2PMChCurr1DayCodingViolations,
+          xdsl2PMChCurr1DayCorrectedBlocks
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the channel-level
+          counters for current PM intervals."
+      ::= { xdsl2Groups 32 }
+
+   xdsl2PMChHist15MinGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMChHist15MMonitoredTime,
+          xdsl2PMChHist15MCodingViolations,
+          xdsl2PMChHist15MCorrectedBlocks,
+          xdsl2PMChHist15MValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the channel-level
+          counters for previous 15-minute PM intervals."
+      ::= { xdsl2Groups 33 }
+
+   xdsl2PMChHist1DGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2PMChHist1DMonitoredTime,
+          xdsl2PMChHist1DCodingViolations,
+          xdsl2PMChHist1DCorrectedBlocks,
+          xdsl2PMChHist1DValidInterval
+          }
+      STATUS     current
+      DESCRIPTION
+        "The group of objects that report the channel-level
+        counters for previous 24-hour PM intervals."
+      ::= { xdsl2Groups 34 }
+
+   xdsl2ScalarSCGroup OBJECT-GROUP
+      OBJECTS
+          {
+          xdsl2ScalarSCMaxInterfaces,
+          xdsl2ScalarSCAvailInterfaces
+          }
+      STATUS     current
+      DESCRIPTION
+         "The group of objects that report the available memory
+          resources for DELT processes."
+      ::= { xdsl2Groups 35 }
+
+   xdsl2ThreshNotificationGroup NOTIFICATION-GROUP
+      NOTIFICATIONS
+      {
+      xdsl2LinePerfFECSThreshXtuc,
+      xdsl2LinePerfFECSThreshXtur,
+      xdsl2LinePerfESThreshXtuc,
+      xdsl2LinePerfESThreshXtur,
+      xdsl2LinePerfSESThreshXtuc,
+      xdsl2LinePerfSESThreshXtur,
+      xdsl2LinePerfLOSSThreshXtuc,
+      xdsl2LinePerfLOSSThreshXtur,
+      xdsl2LinePerfUASThreshXtuc,
+      xdsl2LinePerfUASThreshXtur,
+      xdsl2LinePerfCodingViolationsThreshXtuc,
+      xdsl2LinePerfCodingViolationsThreshXtur,
+      xdsl2LinePerfCorrectedThreshXtuc,
+      xdsl2LinePerfCorrectedThreshXtur,
+      xdsl2LinePerfFailedFullInitThresh,
+      xdsl2LinePerfFailedShortInitThresh
+      }
+      STATUS      current
+      DESCRIPTION
+         "This group supports notifications of significant
+          conditions associated with DSL lines."
+      ::= { xdsl2Groups 36 }
+
+   xdsl2StatusChangeNotificationGroup NOTIFICATION-GROUP
+      NOTIFICATIONS
+      {
+      xdsl2LineStatusChangeXtuc,
+      xdsl2LineStatusChangeXtur
+      }
+      STATUS      current
+      DESCRIPTION
+         "This group supports notifications of thresholds crossing
+          associated with DSL lines."
+      ::= { xdsl2Groups 37 }
+
+END

--- a/services/monitoring/assets/snmp/mibs/VDSL2-LINE-TC-MIB
+++ b/services/monitoring/assets/snmp/mibs/VDSL2-LINE-TC-MIB
@@ -1,0 +1,1479 @@
+VDSL2-LINE-TC-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+   MODULE-IDENTITY,
+   transmission
+      FROM SNMPv2-SMI
+
+   TEXTUAL-CONVENTION
+      FROM SNMPv2-TC;
+
+vdsl2TCMIB MODULE-IDENTITY
+   LAST-UPDATED "200909300000Z" -- September 30, 2009
+   ORGANIZATION "ADSLMIB Working Group"
+   CONTACT-INFO "WG-email:  adslmib@ietf.org
+   Info:      https://www1.ietf.org/mailman/listinfo/adslmib
+
+             Chair:     Mike Sneed
+                        Sand Channel Systems
+             Postal:    P.O. Box 37324
+                        Raleigh NC 27627-732
+             Email:     sneedmike@hotmail.com
+             Phone:     +1 206 600 7022
+
+             Co-Chair:  Menachem Dodge
+
+                        ECI Telecom Ltd.
+             Postal:    30 Hasivim St.
+                        Petach Tikva 49517,
+                        Israel.
+             Email:     mbdodge@ieee.org
+             Phone:     +972 3 926 8421
+
+             Co-editor: Moti Morgenstern
+                        ECI Telecom Ltd.
+             Postal:    30 Hasivim St.
+                        Petach Tikva 49517,
+                        Israel.
+             Email:     moti.morgenstern@ecitele.com
+             Phone:     +972 3 926 6258
+
+             Co-editor: Scott Baillie
+                        NEC Australia
+             Postal:    649-655 Springvale Road,
+                        Mulgrave, Victoria 3170,
+                        Australia.
+             Email:     scott.baillie@nec.com.au
+             Phone:     +61 3 9264 3986
+
+             Co-editor: Umberto Bonollo
+                        NEC Australia
+             Postal:    649-655 Springvale Road,
+                        Mulgrave, Victoria 3170,
+                        Australia.
+             Email:     umberto.bonollo@nec.com.au
+             Phone:     +61 3 9264 3385
+            "
+   DESCRIPTION
+        "This MIB Module provides Textual Conventions to be
+         used by the VDSL2-LINE-MIB module for the purpose of
+         managing VDSL2, ADSL, ADSL2, and ADSL2+ lines.
+
+         Copyright (c) 2009 IETF Trust and the persons
+         identified as authors of the code.  All rights
+         reserved.
+
+         Redistribution and use in source and binary
+         forms, with or without modification, are
+         permitted provided that the following
+         conditions are met:
+
+         - Redistributions of source code must retain the
+           above copyright notice, this list of conditions
+           and the following disclaimer.
+
+         - Redistributions in binary form must reproduce
+           the above copyright notice, this list of
+           conditions and the following disclaimer in
+           the documentation and/or other materials provided
+           with the distribution.
+
+         - Neither the name of Internet Society, IETF or
+           IETF Trust, nor the names of specific contributors,
+           may be used to endorse or promote products derived
+           from this software without specific prior written
+           permission.
+
+         THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+         CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED
+         WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+         WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+         PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+         THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+         DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+         CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+         PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+         DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+         AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+         LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+         ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+         ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+         This version of this MIB module is part of RFC 5650;
+         see the RFC itself for full legal notices."
+
+   REVISION "200909300000Z" -- September 30, 2009
+   DESCRIPTION "Initial version, published as RFC 5650."
+      ::= { transmission 251 3} -- vdsl2MIB 3
+
+------------------------------------------------
+--          Textual Conventions               --
+------------------------------------------------
+
+Xdsl2Unit ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Identifies a transceiver as being either xTU-C or xTU-R.
+       A VDSL2/ADSL/ADSL2 or ADSL2+ line consists of two
+       transceivers: an xTU-C and an xTU-R.
+       In the case of ADSL/ADSL2 and ADSL2+, those two transceivers are
+       also called atuc and atur.
+       In the case of VDSL2, those two transceivers are also called
+       vtuc and vtur.
+
+       Specified as an INTEGER, the two values are:
+        xtuc(1)  -- central office transceiver
+        xtur(2)  -- remote site transceiver"
+   SYNTAX      INTEGER {
+                  xtuc(1),
+                  xtur(2)
+               }
+
+Xdsl2Direction ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "Identifies the direction of a band in a VDSL2/ADSL/ADSL2/
+         ADSL2+ link.
+         The upstream direction is a transmission from the remote end
+         (xTU-R) towards the central office end (xTU-C).  The downstream
+         direction is a transmission from the xTU-C towards the xTU-R.
+         Specified as an INTEGER, the values are defined as
+         follows:"
+     SYNTAX INTEGER {
+        upstream(1),   -- Transmission from the xTU-R to the xTU-C.
+        downstream(2)  -- Transmission from the xTU-C to the xTU-R.
+            }
+
+Xdsl2Band ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "Identifies a band in a VDSL2/ADSL/ADSL2/ADSL2+ link.
+         For a band in the upstream direction, transmission is from the
+         remote end (xTU-R) towards the central office end (xTU-C).
+         For a band in the downstream direction, transmission is from
+         the xTU-C towards the xTU-R.
+         For ADSL, ADSL2 and ADSL2+, which use a single band in the
+         upstream direction and a single band
+         in the downstream direction,
+         the only relevant values are upstream(1) and downstream(2).
+         For VDSL2, which uses multiple bands in each transmission
+         direction, a band in the upstream direction is indicated by any
+         of us0(3), us1(5), us2(7), us3(9), or us4(11), and a band in
+         the downstream direction is indicated by any of ds1(4),
+         ds2(6), ds3(8), or ds4(10).
+         For VDSL2, the values upstream(1) and downstream(2) may be used
+         when there is a need to refer to the whole upstream or
+         downstream traffic (e.g., report the average signal-to-noise
+         ratio on any transmission direction).
+         Specified as an INTEGER, the values are defined as
+         follows:"
+     SYNTAX INTEGER {
+        upstream(1),   -- Transmission from the xTU-R to the xTU-C
+
+                       -- (refers to the single upstream band for
+                       -- ADSL/ADSL2/ADSL2+ or to the whole
+                       -- upstream traffic for VDSL2).
+        downstream(2), -- Transmission from the xTU-C to the xTU-R
+                       -- (refers to the single downstream band
+                       -- for ADSL/ADSL2/ADSL2+ or to the whole
+                       -- downstream traffic for VDSL2).
+        us0(3),        -- Upstream band number 0   (US0) (VDSL2).
+        ds1(4),        -- Downstream band number 1 (DS1) (VDSL2).
+        us1(5),        -- Upstream band number 1   (US1) (VDSL2).
+        ds2(6),        -- Downstream band number 2 (DS2) (VDSL2).
+        us2(7),        -- Upstream band number 2   (US2) (VDSL2).
+        ds3(8),        -- Downstream band number 3 (DS3) (VDSL2).
+        us3(9),        -- Upstream band number 3   (US3) (VDSL2).
+        ds4(10),       -- Downstream band number 4 (DS4) (VDSL2).
+        us4(11)        -- Upstream band number 4   (US4) (VDSL2).
+            }
+
+Xdsl2TransmissionModeType ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "A set of xDSL line transmission modes, with one bit
+       per mode.  The notes (F) and (L) denote Full-Rate and
+       Lite/splitterless, respectively:
+          Bit 00 : Regional Std. (ANSI T1.413) (F)
+          Bit 01 : Regional Std. (ETSI DTS/TM06006) (F)
+          Bit 02 : G.992.1 POTS non-overlapped (F)
+          Bit 03 : G.992.1 POTS overlapped (F)
+          Bit 04 : G.992.1 ISDN non-overlapped (F)
+          Bit 05 : G.992.1 ISDN overlapped (F)
+          Bit 06 : G.992.1 TCM-ISDN non-overlapped (F)
+          Bit 07 : G.992.1 TCM-ISDN overlapped (F)
+          Bit 08 : G.992.2 POTS non-overlapped (L)
+          Bit 09 : G.992.2 POTS overlapped (L)
+          Bit 10 : G.992.2 with TCM-ISDN non-overlapped (L)
+          Bit 11 : G.992.2 with TCM-ISDN overlapped (L)
+          Bit 12 : G.992.1 TCM-ISDN symmetric (F) --- not in G.997.1
+          Bit 13-17: Reserved
+          Bit 18 : G.992.3 POTS non-overlapped (F)
+          Bit 19 : G.992.3 POTS overlapped (F)
+          Bit 20 : G.992.3 ISDN non-overlapped (F)
+          Bit 21 : G.992.3 ISDN overlapped (F)
+          Bit 22-23: Reserved
+          Bit 24 : G.992.4 POTS non-overlapped (L)
+          Bit 25 : G.992.4 POTS overlapped (L)
+          Bit 26-27: Reserved
+          Bit 28 : G.992.3 Annex I All-Digital non-overlapped (F)
+          Bit 29 : G.992.3 Annex I All-Digital overlapped (F)
+
+          Bit 30 : G.992.3 Annex J All-Digital non-overlapped (F)
+          Bit 31 : G.992.3 Annex J All-Digital overlapped (F)
+          Bit 32 : G.992.4 Annex I All-Digital non-overlapped (L)
+          Bit 33 : G.992.4 Annex I All-Digital overlapped (L)
+          Bit 34 : G.992.3 Annex L POTS non-overlapped, mode 1,
+                                   wide U/S (F)
+          Bit 35 : G.992.3 Annex L POTS non-overlapped, mode 2,
+                                   narrow U/S(F)
+          Bit 36 : G.992.3 Annex L POTS overlapped, mode 3,
+                                   wide U/S (F)
+          Bit 37 : G.992.3 Annex L POTS overlapped, mode 4,
+                                   narrow U/S (F)
+          Bit 38 : G.992.3 Annex M POTS non-overlapped (F)
+          Bit 39 : G.992.3 Annex M POTS overlapped (F)
+          Bit 40 : G.992.5 POTS non-overlapped (F)
+          Bit 41 : G.992.5 POTS overlapped (F)
+          Bit 42 : G.992.5 ISDN non-overlapped (F)
+          Bit 43 : G.992.5 ISDN overlapped (F)
+          Bit 44-45: Reserved
+          Bit 46 : G.992.5 Annex I All-Digital non-overlapped (F)
+          Bit 47 : G.992.5 Annex I All-Digital overlapped (F)
+          Bit 48 : G.992.5 Annex J All-Digital non-overlapped (F)
+          Bit 49 : G.992.5 Annex J All-Digital overlapped (F)
+          Bit 50 : G.992.5 Annex M POTS non-overlapped (F)
+          Bit 51 : G.992.5 Annex M POTS overlapped (F)
+          Bit 52-55: Reserved
+          Bit 56 : G.993.2 Annex A
+          Bit 57 : G.993.2 Annex B
+          Bit 58 : G.993.2 Annex C
+          Bit 59-63: Reserved"
+   SYNTAX      BITS {
+                  ansit1413(0),
+                  etsi(1),
+                  g9921PotsNonOverlapped(2),
+                  g9921PotsOverlapped(3),
+                  g9921IsdnNonOverlapped(4),
+                  g9921isdnOverlapped(5),
+                  g9921tcmIsdnNonOverlapped(6),
+                  g9921tcmIsdnOverlapped(7),
+                  g9922potsNonOverlapped(8),
+                  g9922potsOverlapped(9),
+                  g9922tcmIsdnNonOverlapped(10),
+                  g9922tcmIsdnOverlapped(11),
+                  g9921tcmIsdnSymmetric(12),
+                  reserved1(13),
+                  reserved2(14),
+                  reserved3(15),
+                  reserved4(16),
+                  reserved5(17),
+                  g9923PotsNonOverlapped(18),
+                  g9923PotsOverlapped(19),
+                  g9923IsdnNonOverlapped(20),
+                  g9923isdnOverlapped(21),
+                  reserved6(22),
+                  reserved7(23),
+                  g9924potsNonOverlapped(24),
+                  g9924potsOverlapped(25),
+                  reserved8(26),
+                  reserved9(27),
+                  g9923AnnexIAllDigNonOverlapped(28),
+                  g9923AnnexIAllDigOverlapped(29),
+                  g9923AnnexJAllDigNonOverlapped(30),
+                  g9923AnnexJAllDigOverlapped(31),
+                  g9924AnnexIAllDigNonOverlapped(32),
+                  g9924AnnexIAllDigOverlapped(33),
+                  g9923AnnexLMode1NonOverlapped(34),
+                  g9923AnnexLMode2NonOverlapped(35),
+                  g9923AnnexLMode3Overlapped(36),
+                  g9923AnnexLMode4Overlapped(37),
+                  g9923AnnexMPotsNonOverlapped(38),
+                  g9923AnnexMPotsOverlapped(39),
+                  g9925PotsNonOverlapped(40),
+                  g9925PotsOverlapped(41),
+                  g9925IsdnNonOverlapped(42),
+                  g9925isdnOverlapped(43),
+                  reserved10(44),
+                  reserved11(45),
+                  g9925AnnexIAllDigNonOverlapped(46),
+                  g9925AnnexIAllDigOverlapped(47),
+                  g9925AnnexJAllDigNonOverlapped(48),
+                  g9925AnnexJAllDigOverlapped(49),
+                  g9925AnnexMPotsNonOverlapped(50),
+                  g9925AnnexMPotsOverlapped(51),
+                  reserved12(52),
+                  reserved13(53),
+                  reserved14(54),
+                  reserved15(55),
+                  g9932AnnexA(56),
+                  g9932AnnexB(57),
+                  g9932AnnexC(58),
+                  reserved16(59),
+                  reserved17(60),
+                  reserved18(61),
+                  reserved19(62),
+                  reserved20(63)
+
+               }
+
+Xdsl2RaMode ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Specifies the rate adaptation behavior for the line.
+       The three possible behaviors are:
+        manual (1)   - No Rate-Adaptation.  The initialization
+                       process attempts to synchronize to a
+                       specified rate.
+        raInit (2)   - Rate-Adaptation during initialization process
+                       only, which attempts to synchronize to a rate
+                       between minimum and maximum specified values.
+        dynamicRa (3)- Dynamic Rate-Adaptation during initialization
+                       process as well as during Showtime."
+   SYNTAX      INTEGER {
+                  manual(1),
+                  raInit(2),
+                  dynamicRa(3)
+               }
+
+Xdsl2InitResult ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Specifies the result of full initialization attempt; the
+       six possible result values are:
+        noFail (0)            - Successful initialization
+        configError (1)       - Configuration failure
+        configNotFeasible (2) - Configuration details not supported
+        commFail (3)          - Communication failure
+        noPeerAtu (4)         - Peer ATU not detected
+        otherCause (5)        - Other initialization failure reason"
+   SYNTAX      INTEGER {
+                  noFail(0),
+                  configError(1),
+                  configNotFeasible(2),
+                  commFail(3),
+                  noPeerAtu(4),
+                  otherCause(5)
+               }
+
+Xdsl2OperationModes ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "The VDSL2 management model specified includes an xDSL Mode
+       object that identifies an instance of xDSL Mode-Specific
+       PSD Configuration object in the xDSL Line Profile.  The
+
+       following classes of xDSL operating mode are defined.
+       The notes (F) and (L) denote Full-Rate and Lite/splitterless,
+       respectively:
+       +-------+--------------------------------------------------+
+       | Value |         xDSL operation mode description          |
+       +-------+--------------------------------------------------+
+           1   - The default/generic PSD configuration.  Default
+                 configuration will be used when no other matching
+                 mode-specific configuration can be found.
+           2   - Regional Std. (ANSI T1.413) (F)
+           3   - Regional Std. (ETSI DTS/TM06006) (F)
+           4   - G.992.1 POTS non-overlapped (F)
+           5   - G.992.1 POTS overlapped (F)
+           6   - G.992.1 ISDN non-overlapped (F)
+           7   - G.992.1 ISDN overlapped (F)
+           8   - G.992.1 TCM-ISDN non-overlapped (F)
+           9   - G.992.1 TCM-ISDN overlapped (F)
+          10   - G.992.2 POTS non-overlapped (L)
+          11   - G.992.2 POTS overlapped (L)
+          12   - G.992.2 with TCM-ISDN non-overlapped (L)
+          13   - G.992.2 with TCM-ISDN overlapped (L)
+          14   - G.992.1 TCM-ISDN symmetric (F) --- not in G.997.1
+        15-19  - Unused. Reserved for future ITU-T specification.
+          20   - G.992.3 POTS non-overlapped (F)
+          21   - G.992.3 POTS overlapped (F)
+          22   - G.992.3 ISDN non-overlapped (F)
+          23   - G.992.3 ISDN overlapped (F)
+        24-25  - Unused. Reserved for future ITU-T specification.
+          26   - G.992.4 POTS non-overlapped (L)
+          27   - G.992.4 POTS overlapped (L)
+        28-29  - Unused. Reserved for future ITU-T specification.
+          30   - G.992.3 Annex I All-Digital non-overlapped (F)
+          31   - G.992.3 Annex I All-Digital overlapped (F)
+          32   - G.992.3 Annex J All-Digital non-overlapped (F)
+          33   - G.992.3 Annex J All-Digital overlapped (F)
+          34   - G.992.4 Annex I All-Digital non-overlapped (L)
+          35   - G.992.4 Annex I All-Digital overlapped (L)
+          36   - G.992.3 Annex L POTS non-overlapped, mode 1,
+                 wide U/S (F)
+          37   - G.992.3 Annex L POTS non-overlapped, mode 2,
+                 narrow U/S(F)
+          38   - G.992.3 Annex L POTS overlapped, mode 3,
+                 wide U/S (F)
+          39   - G.992.3 Annex L POTS overlapped, mode 4,
+                 narrow U/S (F)
+          40   - G.992.3 Annex M POTS non-overlapped (F)
+          41   - G.992.3 Annex M POTS overlapped (F)
+          42   - G.992.5 POTS non-overlapped (F)
+
+          43   - G.992.5 POTS overlapped (F)
+          44   - G.992.5 ISDN non-overlapped (F)
+          45   - G.992.5 ISDN overlapped (F)
+        46-47  - Unused. Reserved for future ITU-T specification.
+          48   - G.992.5 Annex I All-Digital non-overlapped (F)
+          49   - G.992.5 Annex I All-Digital overlapped (F)
+          50   - G.992.5 Annex J All-Digital non-overlapped (F)
+          51   - G.992.5 Annex J All-Digital overlapped (F)
+          52   - G.992.5 Annex M POTS non-overlapped (F)
+          53   - G.992.5 Annex M POTS overlapped (F)
+        54-57  - Unused. Reserved for future ITU-T specification.
+          58   - G.993.2 Annex A
+          59   - G.993.2 Annex B
+          60   - G.993.2 Annex C
+      "
+   SYNTAX      INTEGER {
+                  defMode(1),
+                  ansit1413(2),
+                  etsi(3),
+                  g9921PotsNonOverlapped(4),
+                  g9921PotsOverlapped(5),
+                  g9921IsdnNonOverlapped(6),
+                  g9921isdnOverlapped(7),
+                  g9921tcmIsdnNonOverlapped(8),
+                  g9921tcmIsdnOverlapped(9),
+                  g9922potsNonOverlapped(10),
+                  g9922potsOverlapped(11),
+                  g9922tcmIsdnNonOverlapped(12),
+                  g9922tcmIsdnOverlapped(13),
+                  g9921tcmIsdnSymmetric(14),
+                  g9923PotsNonOverlapped(20),
+                  g9923PotsOverlapped(21),
+                  g9923IsdnNonOverlapped(22),
+                  g9923isdnOverlapped(23),
+                  g9924potsNonOverlapped(26),
+                  g9924potsOverlapped(27),
+                  g9923AnnexIAllDigNonOverlapped(30),
+                  g9923AnnexIAllDigOverlapped(31),
+                  g9923AnnexJAllDigNonOverlapped(32),
+                  g9923AnnexJAllDigOverlapped(33),
+                  g9924AnnexIAllDigNonOverlapped(34),
+                  g9924AnnexIAllDigOverlapped(35),
+                  g9923AnnexLMode1NonOverlapped(36),
+                  g9923AnnexLMode2NonOverlapped(37),
+                  g9923AnnexLMode3Overlapped(38),
+                  g9923AnnexLMode4Overlapped(39),
+                  g9923AnnexMPotsNonOverlapped(40),
+                  g9923AnnexMPotsOverlapped(41),
+                  g9925PotsNonOverlapped(42),
+                  g9925PotsOverlapped(43),
+                  g9925IsdnNonOverlapped(44),
+                  g9925isdnOverlapped(45),
+                  g9925AnnexIAllDigNonOverlapped(48),
+                  g9925AnnexIAllDigOverlapped(49),
+                  g9925AnnexJAllDigNonOverlapped(50),
+                  g9925AnnexJAllDigOverlapped(51),
+                  g9925AnnexMPotsNonOverlapped(52),
+                  g9925AnnexMPotsOverlapped(53),
+                  g9932AnnexA(58),
+                  g9932AnnexB(59),
+                  g9932AnnexC(60)
+               }
+
+Xdsl2PowerMngState ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax uniquely identify each power
+       management state defined for the VDSL2/ADSL/ADSL2 or ADSL2+
+       link.
+       In VDSL2, only L0 and L3 states are defined.
+       The possible values are:
+         l0(1)              - L0: Full power.  Synchronized and
+                                  full transmission (i.e., Showtime).
+         l1(2)              - L1: Low power with reduced net data rate
+                                  (for G.992.2 only).
+         l2(3)              - L2: Low power with reduced net data rate
+                                  (for G.992.3, G.992.4 and G.992.5).
+         l3(4)              - L3: Idle power management state / No
+         power."
+   SYNTAX      INTEGER {
+                  l0(1),
+                  l1(2),
+                  l2(3),
+                  l3(4)
+               }
+
+Xdsl2ConfPmsForce ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that specify the desired power management state transition
+       for the VDSL2/ADSL/ADSL2 or ADSL2+ link.
+       In VDSL2, only L0 and L3 states are defined:
+         l3toL0 (0)         - Perform a transition from L3 to L0
+                              (Full power management state).
+
+         l0toL2 (2)         - Perform a transition from L0 to L2
+                              (Low power management state).
+         l0orL2toL3 (3)     - Perform a transition into L3 (Idle
+                              power management state)."
+   SYNTAX      INTEGER {
+                  l3toL0 (0),
+                  l0toL2 (2),
+                  l0orL2toL3 (3)
+               }
+
+Xdsl2LinePmMode ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that reference the power modes/states into which the xTU-C or
+       xTU-R may autonomously transit.
+
+       It is a BITS structure that allows control of the following
+       transit options:
+        allowTransitionsToIdle (0)    - xTU may autonomously transit
+                                        to idle (L3) state.
+        allowTransitionsToLowPower (1)- xTU may autonomously transit
+                                        to low-power (L1/L2)
+                                        state."
+   SYNTAX BITS {
+       allowTransitionsToIdle(0),
+       allowTransitionsToLowPower(1)
+     }
+
+Xdsl2LineLdsf ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that control the Loop Diagnostic mode for a VDSL2/ADSL/ADSL2
+       or ADSL2+ link.  The possible values are:
+         inhibit (0)  - Inhibit Loop Diagnostic mode
+         force   (1)  - Force/Initiate Loop Diagnostic mode"
+   SYNTAX INTEGER {
+       inhibit(0),
+       force(1)
+     }
+
+Xdsl2LdsfResult ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "Possible failure reasons associated with performing
+         Dual Ended Loop Test (DELT) on a DSL line.
+         Possible values are:
+          none        (1) - The default value in case LDSF was never
+                            requested for the associated line.
+          success     (2) - The recent command completed
+                            successfully.
+          inProgress  (3) - The Loop Diagnostics process is in
+                            progress.
+          unsupported (4) - The NE or the line card doesn't support
+                            LDSF.
+          cannotRun   (5) - The NE cannot initiate the command, due
+                            to a nonspecific reason.
+          aborted     (6) - The Loop Diagnostics process aborted.
+          failed      (7) - The Loop Diagnostics process failed.
+          illegalMode (8) - The NE cannot initiate the command, due
+                            to the specific mode of the relevant
+                            line.
+          adminUp     (9) - The NE cannot initiate the command, as
+                            the relevant line is administratively
+                            'Up'.
+          tableFull   (10)- The NE cannot initiate the command, due
+                            to reaching the maximum number of rows
+                            in the results table.
+          noResources (11)- The NE cannot initiate the command, due
+                            to lack of internal memory resources."
+     SYNTAX INTEGER {
+          none (1),
+          success (2),
+          inProgress (3),
+          unsupported (4),
+          cannotRun (5),
+          aborted (6),
+          failed (7),
+          illegalMode (8),
+          adminUp (9),
+          tableFull (10),
+          noResources (11)
+     }
+
+Xdsl2LineBpsc ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that control the bits per subcarrier measurement for a
+       VDSL2/ADSL/ADSL2 or ADSL2+ link.  The possible values are:
+         idle    (1)  - Idle state
+         measure (2)  - Measure the bits per subcarrier"
+   SYNTAX INTEGER {
+       idle(1),
+       measure(2)
+     }
+
+Xdsl2BpscResult ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "Possible failure reasons associated with performing
+         a bits per subcarrier measurement on a DSL line.
+         Possible values are:
+
+          none        (1) - The default value, in case a measurement
+                            was never requested for the associated
+                            line.
+          success     (2) - The recent measurement request completed
+                            successfully.
+          inProgress  (3) - The bits per subcarrier measurement is
+                            in progress.
+          unsupported (4) - The bits per subcarrier request
+                            mechanism is not supported.
+          failed      (5) - The measurement request has failed and no
+                            results are available.
+          noResources (6) - The NE cannot initiate the command, due
+                            to lack of internal memory resources."
+     SYNTAX INTEGER {
+          none(1),
+          success(2),
+          inProgress(3),
+          unsupported(4),
+          failed(5),
+          noResources(6)
+     }
+
+Xdsl2LineReset ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "This type is used to request a line reset to occur.
+          idle        (1) - This state indicates that there is
+                            currently no request for a line reset.
+          reset       (2) - This state indicates that a line reset
+                            request has been issued."
+   SYNTAX INTEGER {
+       idle(1),
+       reset(2)
+     }
+
+Xdsl2LineProfiles ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "Objects with this syntax reference the list of
+      ITU-T G.993.2 implementation profiles supported by an
+      xTU, enabled on the VDSL2 line or active on that line."
+      SYNTAX BITS {
+          profile8a(0),
+          profile8b(1),
+          profile8c(2),
+          profile8d(3),
+          profile12a(4),
+          profile12b(5),
+          profile17a(6),
+          profile30a(7)
+     }
+
+Xdsl2LineClassMask ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "VDSL2 PSD Mask Class.
+       The limit Power Spectral Density masks are grouped in
+       the following PSD mask classes:
+
+       Class 998     Annex A: D-32, D-48, D-64, D-128.
+       Class 997-M1c Annex B: 997-M1c-A-7.
+       Class 997-M1x Annex B: 997-M1x-M-8, 997-M1x-M.
+       Class 997-M2x Annex B: 997-M2x-M-8, 997-M2x-A, 997-M2x-M,
+                              997E17-M2x-NUS0, 997E30-M2x-NUS0.
+       Class 998-M1x Annex B: 998-M1x-A, 998-M1x-B, 998-M1x-NUS0.
+       Class 998-M2x Annex B: 998-M2x-A, 998-M2x-M, 998-M2x-B,
+                              998-M2x-NUS0, 998E17-M2x-NUS0,
+                              998E17-M2x-NUS0-M, 998E30-M2x-NUS0,
+                              998E30-M2x-NUS0-M.
+       Class 998ADE-M2x Annex B: Annex B: 998-M2x-A, 998-M2x-M,
+                              998-M2x-B, 998-M2x-NUS0,
+                              998ADE17-M2x-A, 998ADE17-M2x-B,
+                              998ADE17-M2x-NUS0-M,
+                              998ADE30-M2x-NUS0-A,
+                              998ADE30-M2x-NUS0-M.
+       Class 998-B   Annex C: POTS-138b, POTS-276b per C.2.1.1
+                              in G.993.2, TCM-ISDN per C.2.1.2
+                              in G.993.2.
+       Class 998-CO  Annex C: POTS-138co, POTS-276co per C.2.1.1
+                              in G.993.2.
+       Class HPE-M1  Annex B: HPE17-M1-NUS0, HPE30-M1-NUS0."
+   SYNTAX      INTEGER {
+
+                  none(1),
+                  a998ORb997M1cORc998B(2),
+                  b997M1xOR998co(3),
+                  b997M2x(4),
+                  b998M1x(5),
+                  b998M2x(6),
+                  b998AdeM2x(7),
+                  bHpeM1(8)
+               }
+
+Xdsl2LineLimitMask ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "The G.993.2 limit PSD mask for each class of profile.
+      The profiles are grouped in following profile classes:
+      - Class 8: Profiles 8a, 8b, 8c, 8d.
+      - Class 12: Profiles 12a, 12b.
+      - Class 17: Profile 17a.
+      - Class 30: Profile 30a."
+      SYNTAX BITS {
+          profile8Limit1(0),
+          profile8Limit2(1),
+          profile8Limit3(2),
+          profile8Limit4(3),
+          profile8Limit5(4),
+          profile8Limit6(5),
+          profile8Limit7(6),
+          profile8Limit8(7),
+          profile8Limit9(8),
+          profile8Limit10(9),
+          profile8Limit11(10),
+          profile8Limit12(11),
+          profile8Limit13(12),
+          profile8Limit14(13),
+          profile8Limit15(14),
+          profile8Limit16(15),
+          --
+          profile12Limit1(16),
+          profile12Limit2(17),
+          profile12Limit3(18),
+          profile12Limit4(19),
+          profile12Limit5(20),
+          profile12Limit6(21),
+          profile12Limit7(22),
+          profile12Limit8(23),
+          profile12Limit9(24),
+          profile12Limit10(25),
+          profile12Limit11(26),
+          profile12Limit12(27),
+          profile12Limit13(28),
+          profile12Limit14(29),
+          profile12Limit15(30),
+          profile12Limit16(31),
+          --
+          profile17Limit1(32),
+          profile17Limit2(33),
+          profile17Limit3(34),
+          profile17Limit4(35),
+          profile17Limit5(36),
+          profile17Limit6(37),
+          profile17Limit7(38),
+          profile17Limit8(39),
+          profile17Limit9(40),
+          profile17Limit10(41),
+          profile17Limit11(42),
+          profile17Limit12(43),
+          profile17Limit13(44),
+          profile17Limit14(45),
+          profile17Limit15(46),
+          profile17Limit16(47),
+          --
+          profile30Limit1(48),
+          profile30Limit2(49),
+          profile30Limit3(50),
+          profile30Limit4(51),
+          profile30Limit5(52),
+          profile30Limit6(53),
+          profile30Limit7(54),
+          profile30Limit8(55),
+          profile30Limit9(56),
+          profile30Limit10(57),
+          profile30Limit11(58),
+          profile30Limit12(59),
+          profile30Limit13(60),
+          profile30Limit14(61),
+          profile30Limit15(62),
+          profile30Limit16(63)
+     }
+
+Xdsl2LineUs0Disable ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "Indicates if US0 is disabled for each limit PSD mask.
+      The profiles are grouped in following profile classes:
+      - Class 8: Profiles 8a, 8b, 8c, 8d.
+
+      - Class 12: Profiles 12a, 12b.
+      - Class 17: Profile 17a.
+      - Class 30: Profile 30a."
+      SYNTAX BITS {
+          profile8Us0Disable1(0),
+          profile8Us0Disable2(1),
+          profile8Us0Disable3(2),
+          profile8Us0Disable4(3),
+          profile8Us0Disable5(4),
+          profile8Us0Disable6(5),
+          profile8Us0Disable7(6),
+          profile8Us0Disable8(7),
+          profile8Us0Disable9(8),
+          profile8Us0Disable10(9),
+          profile8Us0Disable11(10),
+          profile8Us0Disable12(11),
+          profile8Us0Disable13(12),
+          profile8Us0Disable14(13),
+          profile8Us0Disable15(14),
+          profile8Us0Disable16(15),
+          --
+          profile12Us0Disable1(16),
+          profile12Us0Disable2(17),
+          profile12Us0Disable3(18),
+          profile12Us0Disable4(19),
+          profile12Us0Disable5(20),
+          profile12Us0Disable6(21),
+          profile12Us0Disable7(22),
+          profile12Us0Disable8(23),
+          profile12Us0Disable9(24),
+          profile12Us0Disable10(25),
+          profile12Us0Disable11(26),
+          profile12Us0Disable12(27),
+          profile12Us0Disable13(28),
+          profile12Us0Disable14(29),
+          profile12Us0Disable15(30),
+          profile12Us0Disable16(31),
+          --
+          profile17Us0Disable1(32),
+          profile17Us0Disable2(33),
+          profile17Us0Disable3(34),
+          profile17Us0Disable4(35),
+          profile17Us0Disable5(36),
+          profile17Us0Disable6(37),
+          profile17Us0Disable7(38),
+          profile17Us0Disable8(39),
+          profile17Us0Disable9(40),
+          profile17Us0Disable10(41),
+          profile17Us0Disable11(42),
+          profile17Us0Disable12(43),
+          profile17Us0Disable13(44),
+          profile17Us0Disable14(45),
+          profile17Us0Disable15(46),
+          profile17Us0Disable16(47),
+          --
+          profile30Us0Disable1(48),
+          profile30Us0Disable2(49),
+          profile30Us0Disable3(50),
+          profile30Us0Disable4(51),
+          profile30Us0Disable5(52),
+          profile30Us0Disable6(53),
+          profile30Us0Disable7(54),
+          profile30Us0Disable8(55),
+          profile30Us0Disable9(56),
+          profile30Us0Disable10(57),
+          profile30Us0Disable11(58),
+          profile30Us0Disable12(59),
+          profile30Us0Disable13(60),
+          profile30Us0Disable14(61),
+          profile30Us0Disable15(62),
+          profile30Us0Disable16(63)
+     }
+
+Xdsl2LineUs0Mask ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "The US0 PSD masks to be allowed by the near-end xTU on
+      the line.  This parameter is only defined for G.993.2 Annex A.
+      It is represented as a bitmap (0 if not allowed and 1 if
+      allowed) with the following definitions."
+      SYNTAX BITS {
+          eu32(0),
+          eu36(1),
+          eu40(2),
+          eu44(3),
+          eu48(4),
+          eu52(5),
+          eu56(6),
+          eu60(7),
+          --
+          eu64(8),
+          eu128(9),
+          reserved1(10),
+          reserved2(11),
+          reserved3(12),
+          reserved4(13),
+          reserved5(14),
+          reserved6(15),
+          --
+          adlu32(16),
+          adlu36(17),
+          adlu40(18),
+          adlu44(19),
+          adlu48(20),
+          adlu52(21),
+          adlu56(22),
+          adlu60(23),
+          --
+          adlu64(24),
+          adlu128(25),
+          reserved7(26),
+          reserved8(27),
+          reserved9(28),
+          reserved10(29),
+          reserved11(30),
+          reserved12(31)
+     }
+
+Xdsl2SymbolProtection ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type specifies the minimum impulse noise protection
+       for the bearer channel if it is transported over DMT symbols
+       with a subcarrier spacing of 4.3125 kHz.
+       The possible values are:
+       'noProtection' (i.e., INP not required), 'halfSymbol' (i.e., INP
+       length is 1/2 symbol), and 1-16 symbols in steps of 1
+       symbol."
+   SYNTAX      INTEGER {
+               noProtection (1),
+               halfSymbol (2),
+               singleSymbol (3),
+               twoSymbols (4),
+               threeSymbols (5),
+               fourSymbols (6),
+               fiveSymbols (7),
+               sixSymbols (8),
+               sevenSymbols (9),
+               eightSymbols (10),
+               nineSymbols (11),
+               tenSymbols (12),
+               elevenSymbols (13),
+               twelveSymbols (14),
+               thirteeSymbols (15),
+               fourteenSymbols (16),
+               fifteenSymbols (17),
+               sixteenSymbols (18)
+             }
+
+Xdsl2SymbolProtection8 ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type specifies the minimum impulse noise protection
+       for the bearer channel if it is transported over DMT symbols
+       with a subcarrier spacing of 8.625 kHz.
+       The possible values are:
+       'noProtection' (i.e., INP not required) and 1-16 symbols in
+       steps of 1 symbol."
+   SYNTAX      INTEGER {
+               noProtection (1),
+               singleSymbol (2),
+               twoSymbols (3),
+               threeSymbols (4),
+               fourSymbols (5),
+               fiveSymbols (6),
+               sixSymbols (7),
+               sevenSymbols (8),
+               eightSymbols (9),
+               nineSymbols (10),
+               tenSymbols (11),
+               elevenSymbols (12),
+               twelveSymbols (13),
+               thirteeSymbols (14),
+               fourteenSymbols (15),
+               fifteenSymbols (16),
+               sixteenSymbols (17)
+             }
+
+Xdsl2MaxBer ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax are configuration parameters
+       that reference the maximum Bit Error Rate (BER).
+       The possible values are:
+         eminus3 (1)  - Maximum BER=E^-3
+         eminus5 (2)  - Maximum BER=E^-5
+         eminus7 (3)  - Maximum BER=E^-7"
+   SYNTAX      INTEGER {
+
+                  eminus3(1),
+                  eminus5(2),
+                  eminus7(3)
+               }
+
+Xdsl2ChInitPolicy ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This syntax serves for channel configuration parameters
+       that reference the channel initialization policy.
+       The possible values are:
+         policy0 (1) - Policy 0 according to the applicable standard.
+         policy1 (2) - Policy 1 according to the applicable
+                       standard."
+   SYNTAX      INTEGER {
+                  policy0(1),
+                  policy1(2)
+               }
+
+Xdsl2ScMaskDs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Each one of the 4096 bits in this OCTET STRING array
+       represents the corresponding subcarrier in the downstream
+       direction.
+       A bit value of one indicates that a subcarrier is masked."
+   SYNTAX      OCTET STRING (SIZE(0..512))
+
+Xdsl2ScMaskUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Each one of the 4096 bits in this OCTET STRING array
+       represents the corresponding subcarrier in the upstream
+       direction.  A bit value of one indicates that a subcarrier
+       is masked."
+   SYNTAX      OCTET STRING (SIZE(0..512))
+
+Xdsl2CarMask ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type defines an array of bands.  Each band is
+       represented by 4 octets and there is a maximum of 32 bands
+       allowed.
+       Each band consists of a 16-bit start subcarrier index followed by
+       a 16-bit stop subcarrier index.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSC-1."
+   SYNTAX      OCTET STRING (SIZE(0..128))
+
+Xdsl2RfiBands ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type defines a subset of downstream PSD mask
+       breakpoints used to notch radio frequency interference (RFI)
+       bands.
+       Each RFI band is represented by 4 octets: a 16-bit start
+       subcarrier index followed by a 16-bit stop subcarrier
+       index.
+       There is a maximum of 16 RFI bands allowed.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSC-1."
+   SYNTAX      OCTET STRING (SIZE(0..64))
+
+Xdsl2PsdMaskDs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 32 PSD mask
+       breakpoints.
+       Each breakpoint occupies 3 octets: The first
+       two octets hold the index of the subcarrier associated with the
+       breakpoint.  The third octet holds the PSD reduction at the
+       breakpoint from 0 (0 dBm/Hz) to 255 (-127.5 dBm/Hz) using units
+       of 0.5 dBm/Hz.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSCds-1."
+   SYNTAX      OCTET STRING (SIZE(0..96))
+
+Xdsl2PsdMaskUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 16 PSD mask
+       breakpoints.
+       Each breakpoint occupies 3 octets: The first two octets hold the
+       index of the subcarrier associated with the breakpoint.  The
+       third octet holds the PSD reduction at the breakpoint from 0
+       (0 dBm/Hz) to 255 (-127.5 dBm/Hz) using units of
+       0.5 dBm/Hz.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSCus-1."
+   SYNTAX      OCTET STRING (SIZE(0..48))
+
+Xdsl2Tssi ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 32 transmit
+       spectrum shaping (TSSi) breakpoints.
+       Each breakpoint is a pair of values occupying 3 octets with the
+
+       following structure:
+       First 2 octets - Index of the subcarrier used in the context of
+                        the breakpoint.
+       Third octet    - The shaping parameter at the breakpoint.
+       The shaping parameter value is in the range 0 to 126 (units of
+       -0.5 dB).  The special value 127 indicates that the subcarrier is
+       not transmitted.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSC-1."
+   SYNTAX      OCTET STRING (SIZE(0..96))
+
+Xdsl2LastTransmittedState ::= TEXTUAL-CONVENTION
+     STATUS current
+     DESCRIPTION
+        "This parameter represents the last successful transmitted
+         initialization state in the last full initialization performed
+         on the line.  States are per the specific xDSL technology and
+         are numbered from 0 (if G.994.1 is used) or 1 (if G.994.1 is
+         not used) up to Showtime."
+     SYNTAX      INTEGER {
+       -- ADSL family ATU-C side --
+       atucG9941(0),
+       atucQuiet1(1),
+       atucComb1(2),
+       atucQuiet2(3),
+       atucComb2(4),
+       atucIcomb1(5),
+       atucLineprob(6),
+       atucQuiet3(7),
+       atucComb3(8),
+       atucIComb2(9),
+       atucMsgfmt(10),
+       atucMsgpcb(11),
+       atucQuiet4(12),
+       atucReverb1(13),
+       atucTref1(14),
+       atucReverb2(15),
+       atucEct(16),
+       atucReverb3(17),
+       atucTref2(18),
+       atucReverb4(19),
+       atucSegue1(20),
+       atucMsg1(21),
+       atucReverb5(22),
+       atucSegue2(23),
+       atucMedley(24),
+       atucExchmarker(25),
+       atucMsg2(26),
+       atucReverb6(27),
+       atucSegue3(28),
+       atucParams(29),
+       atucReverb7(30),
+       atucSegue4(31),
+       atucShowtime(32),
+       -- ADSL family ATU-R side --
+       aturG9941(100),
+       aturQuiet1(101),
+       aturComb1(102),
+       aturQuiet2(103),
+       aturComb2(104),
+       aturIcomb1(105),
+       aturLineprob(106),
+       aturQuiet3(107),
+       aturComb3(108),
+       aturIcomb2(109),
+       aturMsgfmt(110),
+       aturMsgpcb(111),
+       aturReverb1(112),
+       aturQuiet4(113),
+       aturReverb2(114),
+       aturQuiet5(115),
+       aturReverb3(116),
+       aturEct(117),
+       aturReverb4(118),
+       aturSegue1(119),
+       aturReverb5(120),
+       aturSegue2(121),
+       aturMsg1(122),
+       aturMedley(123),
+       aturExchmarker(124),
+       aturMsg2(125),
+       aturReverb6(126),
+       aturSegue3(127),
+       aturParams(128),
+       aturReverb7(129),
+       aturSegue4(130),
+       aturShowtime(131),
+       -- VDSL2 VTU-C side --
+       vtucG9941(200),
+       vtucQuiet1(201),
+       vtucChDiscov1(202),
+       vtucSynchro1(203),
+       vtucPilot1(204),
+       vtucQuiet2(205),
+       vtucPeriodic1(206),
+       vtucSynchro2(207),
+       vtucChDiscov2(208),
+       vtucSynchro3(209),
+       vtucTraining1(210),
+       vtucSynchro4(211),
+       vtucPilot2(212),
+       vtucTeq(213),
+       vtucEct(214),
+       vtucPilot3(215),
+       vtucPeriodic2(216),
+       vtucTraining2(217),
+       vtucSynchro5(218),
+       vtucMedley(219),
+       vtucSynchro6(220),
+       vtucShowtime(221),
+       -- VDSL2 VTU-R side --
+       vturG9941(300),
+       vturQuiet1(301),
+       vturChDiscov1(302),
+       vturSynchro1(303),
+       vturLineprobe(304),
+       vturPeriodic1(305),
+       vturSynchro2(306),
+       vturChDiscov2(307),
+       vturSynchro3(308),
+       vturQuiet2(309),
+       vturTraining1(310),
+       vturSynchro4(311),
+       vturTeq(312),
+       vturQuiet3(313),
+       vturEct(314),
+       vturPeriodic2(315),
+       vturTraining2(316),
+       vturSynchro5(317),
+       vturMedley(318),
+       vturSynchro6(319),
+       vturShowtime(320)
+     }
+
+Xdsl2LineStatus ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+      "Objects with this syntax are status parameters
+       that reflect the failure status for a given endpoint of a
+       VDSL2/ADSL/ADSL2 or ADSL2+ link.
+
+       This BITS structure can report the following failures:
+
+        noDefect (0)      - This bit position positively reports
+
+                            that no defect or failure exist.
+        lossOfFraming (1) - Loss of frame synchronization.
+        lossOfSignal (2)  - Loss of signal.
+        lossOfPower (3)   - Loss of power.  Usually this failure may
+                            be reported for CPE units only.
+        initFailure (4)   - Recent initialization process failed.
+                            Never active on xTU-R."
+   SYNTAX BITS {
+       noDefect(0),
+       lossOfFraming(1),
+       lossOfSignal(2),
+       lossOfPower(3),
+        initFailure(4)
+     }
+
+Xdsl2ChInpReport ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type is used to indicate the method used to compute the
+       Actual Impulse Noise Protection (ACTINP).  If set to
+       'inpComputedUsingFormula', the ACTINP is computed
+       according to the INP_no_erasure formula (9.6/G.993.2).
+       If set to 'inpEstimatedByXtur', the ACTINP is the value
+       estimated by the xTU receiver.
+        inpComputedUsingFormula (1) - ACTINP computed using
+                                      INP_no_erasure formula.
+        inpEstimatedByXtur (2)      - ACTINP estimated by
+                                      the xTU receiver."
+   SYNTAX      INTEGER {
+                  inpComputedUsingFormula(1),
+                  inpEstimatedByXtur(2)
+               }
+
+Xdsl2ChAtmStatus ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "Objects with this syntax are status parameters that
+      reflect the failure status for the Transmission Convergence (TC)
+      layer of a given ATM interface (data path over a VDSL2/ADSL/
+      ADSL2 or ADSL2+ link).
+
+      This BITS structure can report the following failures:
+       noDefect (0)             - This bit position positively
+                                  reports that no defect or failure
+                                  exists.
+       noCellDelineation (1)    - The link was successfully
+                                  initialized, but cell delineation
+                                  was never acquired on the
+
+                                  associated ATM data path.
+       lossOfCellDelineation (2)- Loss of cell delineation on the
+                                  associated ATM data path."
+   SYNTAX BITS {
+       noDefect(0),
+       noCellDelineation(1),
+       lossOfCellDelineation(2)
+     }
+
+Xdsl2ChPtmStatus ::= TEXTUAL-CONVENTION
+   STATUS current
+   DESCRIPTION
+     "Objects with this syntax are status parameters that
+      reflect the failure status for a given PTM interface (packet
+      data path over a VDSL2/ADSL/ADSL2 or ADSL2+ link).
+
+      This BITS structure can report the following failures:
+          noDefect (0)    - This bit position positively
+                            reports that no defect or failure exists.
+          outOfSync (1)   - Out of synchronization."
+   SYNTAX BITS {
+          noDefect(0),
+          outOfSync(1)
+     }
+
+Xdsl2UpboKLF ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Defines the upstream power backoff force mode (UPBOKLF).
+       The three possible mode values are:
+          auto(1)         - The VDSL Transceiver Unit (VTUs) will
+                            autonomously determine the
+                            electrical length.
+          override(2)     - Forces the VTU-R to use the electrical
+                            length, kl0, of the CO-MIB (UPBOKL) to
+                            compute the UPBO.
+          disableUpbo(3)  - Disables UPBO such that UPBO is not
+                            utilized."
+   SYNTAX INTEGER {
+     auto(1),
+     override(2),
+     disableUpbo(3)
+     }
+
+Xdsl2BandUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Each value identifies a specific band in the upstream
+
+       transmission direction (excluding the US0 band.).
+       The possible values that identify a band are as follows:
+          us1(5)          - Upstream band number 1 (US1).
+          us2(7)          - Upstream band number 2 (US2).
+          us3(9)          - Upstream band number 3 (US3).
+          us4(11)         - Upstream band number 4 (US4)."
+   SYNTAX        INTEGER {
+     us1(5),
+     us2(7),
+     us3(9),
+     us4(11)
+     }
+
+Xdsl2LinePsdMaskSelectUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type is used to define which upstream PSD mask is
+       enabled.  This type is used only for Annexes J and M of ITU-T
+       Recommendations G.992.3 and G.992.5.
+
+       adlu32Eu32 (1),   - ADLU-32 / EU-32
+       adlu36Eu36 (2),   - ADLU-36 / EU-36
+       adlu40Eu40 (3),   - ADLU-40 / EU-40
+       adlu44Eu44 (4),   - ADLU-44 / EU-44
+       adlu48Eu48 (5),   - ADLU-48 / EU-48
+       adlu52Eu52 (6),   - ADLU-52 / EU-52
+       adlu56Eu56 (7),   - ADLU-56 / EU-56
+       adlu60Eu60 (8),   - ADLU-60 / EU-60
+       adlu64Eu64 (9)    - ADLU-64 / EU-64"
+   SYNTAX        INTEGER {
+     adlu32Eu32(1),
+     adlu36Eu36(2),
+     adlu40Eu40(3),
+     adlu44Eu44(4),
+     adlu48Eu48(5),
+     adlu52Eu52(6),
+     adlu56Eu56(7),
+     adlu60Eu60(8),
+     adlu64Eu64(9)
+     }
+
+Xdsl2LineCeFlag ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type is used to enable the use of the optional
+       cyclic extension values.  If the bit is set to '1', the optional
+       cyclic extension values may be used.  Otherwise, the cyclic
+       extension shall be forced to the mandatory length (5N/32).
+
+       enableCyclicExtension (0) - Enable use of optional
+                                   Cyclic Extension values."
+   SYNTAX        BITS {
+     enableCyclicExtension(0)
+     }
+
+Xdsl2LineSnrMode ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type is used to enable the transmitter-referred
+       virtual noise.  The value of 1, indicates that virtual
+       noise is disabled.  The value of 2, indicates that virtual
+       noise is enabled.
+
+      virtualNoiseDisabled (1) - virtual noise is disabled.
+      virtualNoiseEnabled (2)  - virtual noise is enabled."
+   SYNTAX        INTEGER {
+     virtualNoiseDisabled(1),
+     virtualNoiseEnabled(2)
+     }
+
+Xdsl2LineTxRefVnDs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 32 PSD mask
+       breakpoints.
+       Each breakpoint occupies 3 octets: The first two octets hold the
+       index of the subcarrier associated with the breakpoint.  The
+       third octet holds the PSD reduction at the breakpoint from 0
+       (-140 dBm/Hz) to 200 (-40 dBm/Hz) using units of 0.5 dBm/Hz.
+       A special value of 255 indicates a noise level of 0 W/Hz.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSCds-1."
+   SYNTAX      OCTET STRING (SIZE(0..96))
+
+Xdsl2LineTxRefVnUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This is a structure that represents up to 16 PSD mask
+       breakpoints.
+       Each breakpoint occupies 3 octets: The first two octets hold the
+       index of the subcarrier associated with the breakpoint.  The
+       third octet holds the PSD reduction at the breakpoint from 0
+       (-140 dBm/Hz) to 200 (-40 dBm/Hz) using units of 0.5 dBm/Hz.
+       A special value of 255 indicates a noise level of 0 W/Hz.
+       The subcarrier index is an unsigned number in the range 0 to
+       NSCus-1."
+   SYNTAX      OCTET STRING (SIZE(0..48))
+
+Xdsl2BitsAlloc ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "This type specifies an array of nibbles, where each nibble
+       indicates the bits allocation for a subcarrier.
+       Each nibble has a value in the range 0 to 15 to indicate
+       the bits allocation."
+   SYNTAX      OCTET STRING (SIZE(0..256))
+
+Xdsl2MrefPsdDs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax are MEDLEY Reference PSD status
+       parameters in the downstream direction.  This is expressed as
+       the set of
+       breakpoints exchanged at initialization.
+       The OCTET STRING contains up to 48 pairs of values in the
+       following structure:
+       Octets 0-1 -- Index of the first subcarrier used in the
+                   context of a first breakpoint.
+       Octets 2-3 -- The PSD level for the subcarrier indicated
+                   in octets 0-1.
+       Octets 4-7 -- Same, for a second breakpoint
+       Octets 8-11 -- Same, for a third breakpoint
+       And so on until
+       Octets 188-191 -- Same, for a 48th breakpoint.
+       The subcarrier index is an unsigned number in the range 0
+       to NSCds-1.
+       The PSD level is an integer value in the 0 to 4095 range.  It is
+       represented in units of 0.1 dB offset from -140 dBm/Hz."
+   SYNTAX      OCTET STRING (SIZE(0..192))
+
+Xdsl2MrefPsdUs ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Objects with this syntax are MEDLEY Reference PSD status
+       parameters in the upstream direction.  This is expressed
+       as the set of
+       breakpoints exchanged at initialization.
+       The OCTET STRING contains up to 32 pairs of values in the
+       following structure:
+       Octets 0-1 -- Index of the first subcarrier used in the
+                   context of a first breakpoint.
+       Octets 2-3 -- The PSD level for the subcarrier indicated
+                   in octets 0-1.
+       Octets 4-7 -- Same, for a second breakpoint
+       Octets 8-11 -- Same, for a third breakpoint
+       And so on until
+
+       Octets 124-127 -- Same, for a 32nd breakpoint.
+       The subcarrier index is an unsigned number in the range 0
+       to NSCus-1.
+       The PSD level is an integer value in the 0 to 4095 range.  It is
+       represented in units of 0.1 dB offset from -140 dBm/Hz."
+   SYNTAX      OCTET STRING (SIZE(0..128))
+
+END

--- a/services/monitoring/assets/snmp/snmp.yml
+++ b/services/monitoring/assets/snmp/snmp.yml
@@ -1,0 +1,138 @@
+# WARNING: This file was auto-generated using snmp_exporter generator, manual changes will be lost.
+auths:
+  public_v2:
+    community: public
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 2
+modules:
+  draytek:
+    walk:
+    - 1.3.6.1.2.1.10.251.1.2.2.1.2
+    - 1.3.6.1.2.1.10.251.1.2.2.1.3
+    - 1.3.6.1.2.1.10.251.1.2.2.1.7
+    - 1.3.6.1.2.1.10.251.1.2.2.1.8
+    - 1.3.6.1.2.1.10.94.1.1.2.1.4
+    - 1.3.6.1.2.1.10.94.1.1.2.1.5
+    - 1.3.6.1.2.1.10.94.1.1.2.1.8
+    - 1.3.6.1.2.1.10.94.1.1.3.1.4
+    - 1.3.6.1.2.1.10.94.1.1.3.1.5
+    - 1.3.6.1.2.1.10.94.1.1.3.1.6
+    - 1.3.6.1.2.1.10.94.1.1.3.1.8
+    get:
+    - 1.3.6.1.2.1.1.5.0
+    metrics:
+    - name: sysName
+      oid: 1.3.6.1.2.1.1.5
+      type: DisplayString
+      help: An administratively-assigned name for this managed node - 1.3.6.1.2.1.1.5
+    - name: xdsl2ChStatusActDataRate
+      oid: 1.3.6.1.2.1.10.251.1.2.2.1.2
+      type: gauge
+      help: The actual net data rate at which the bearer channel is operating, if
+        in L0 power management state - 1.3.6.1.2.1.10.251.1.2.2.1.2
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      - labelname: xdsl2ChStatusUnit
+        type: gauge
+        enum_values:
+          1: xtuc
+          2: xtur
+    - name: xdsl2ChStatusPrevDataRate
+      oid: 1.3.6.1.2.1.10.251.1.2.2.1.3
+      type: gauge
+      help: The previous net data rate that the bearer channel was operating at just
+        before the latest rate change event - 1.3.6.1.2.1.10.251.1.2.2.1.3
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      - labelname: xdsl2ChStatusUnit
+        type: gauge
+        enum_values:
+          1: xtuc
+          2: xtur
+    - name: xdsl2ChStatusNFec
+      oid: 1.3.6.1.2.1.10.251.1.2.2.1.7
+      type: gauge
+      help: Actual size of Reed-Solomon codeword - 1.3.6.1.2.1.10.251.1.2.2.1.7
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      - labelname: xdsl2ChStatusUnit
+        type: gauge
+        enum_values:
+          1: xtuc
+          2: xtur
+    - name: xdsl2ChStatusRFec
+      oid: 1.3.6.1.2.1.10.251.1.2.2.1.8
+      type: gauge
+      help: Actual number of Reed-Solomon redundancy bytes - 1.3.6.1.2.1.10.251.1.2.2.1.8
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      - labelname: xdsl2ChStatusUnit
+        type: gauge
+        enum_values:
+          1: xtuc
+          2: xtur
+    - name: adslAtucCurrSnrMgn
+      oid: 1.3.6.1.2.1.10.94.1.1.2.1.4
+      type: gauge
+      help: Noise Margin as seen by this ATU with respect to its received signal in
+        tenth dB. - 1.3.6.1.2.1.10.94.1.1.2.1.4
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+    - name: adslAtucCurrAtn
+      oid: 1.3.6.1.2.1.10.94.1.1.2.1.5
+      type: gauge
+      help: Measured difference in the total power transmitted by the peer ATU and
+        the total power received by this ATU. - 1.3.6.1.2.1.10.94.1.1.2.1.5
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+    - name: adslAtucCurrAttainableRate
+      oid: 1.3.6.1.2.1.10.94.1.1.2.1.8
+      type: gauge
+      help: Indicates the maximum currently attainable data rate by the ATU - 1.3.6.1.2.1.10.94.1.1.2.1.8
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+    - name: adslAturCurrSnrMgn
+      oid: 1.3.6.1.2.1.10.94.1.1.3.1.4
+      type: gauge
+      help: Noise Margin as seen by this ATU with respect to its received signal in
+        tenth dB. - 1.3.6.1.2.1.10.94.1.1.3.1.4
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+    - name: adslAturCurrAtn
+      oid: 1.3.6.1.2.1.10.94.1.1.3.1.5
+      type: gauge
+      help: Measured difference in the total power transmitted by the peer ATU and
+        the total power received by this ATU. - 1.3.6.1.2.1.10.94.1.1.3.1.5
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+    - name: adslAturCurrStatus
+      oid: 1.3.6.1.2.1.10.94.1.1.3.1.6
+      type: Bits
+      help: Indicates current state of the ATUR line - 1.3.6.1.2.1.10.94.1.1.3.1.6
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      enum_values:
+        0: noDefect
+        1: lossOfFraming
+        2: lossOfSignal
+        3: lossOfPower
+        4: lossOfSignalQuality
+    - name: adslAturCurrAttainableRate
+      oid: 1.3.6.1.2.1.10.94.1.1.3.1.8
+      type: gauge
+      help: Indicates the maximum currently attainable data rate by the ATU - 1.3.6.1.2.1.10.94.1.1.3.1.8
+      indexes:
+      - labelname: ifIndex
+        type: gauge

--- a/services/monitoring/monitoring/alloy.py
+++ b/services/monitoring/monitoring/alloy.py
@@ -81,6 +81,19 @@ class Alloy(p.ComponentResource):
             opts=k8s_opts,
         )
 
+        # Create ConfigMap with SNMP configuration
+        snmp_config_path = get_assets_path().parent / 'assets' / 'snmp' / 'snmp.yml'
+        snmp_config_map = k8s.core.v1.ConfigMap(
+            'alloy-snmp-config',
+            metadata={
+                'namespace': namespace.metadata.name,
+            },
+            data={
+                'snmp.yml': snmp_config_path.read_text(),
+            },
+            opts=k8s_opts,
+        )
+
         # Create ServiceAccount for Alloy
         service_account = k8s.core.v1.ServiceAccount(
             'alloy-serviceaccount',
@@ -231,6 +244,10 @@ class Alloy(p.ComponentResource):
                                         'mount_path': '/etc/alloy',
                                     },
                                     {
+                                        'name': 'snmp-config',
+                                        'mount_path': '/etc/alloy/snmp',
+                                    },
+                                    {
                                         'name': 'data',
                                         'mount_path': '/var/lib/alloy/data',
                                     },
@@ -264,6 +281,12 @@ class Alloy(p.ComponentResource):
                                 'name': 'config',
                                 'config_map': {
                                     'name': config_map.metadata.name,
+                                },
+                            },
+                            {
+                                'name': 'snmp-config',
+                                'config_map': {
+                                    'name': snmp_config_map.metadata.name,
                                 },
                             },
                             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SNMP device monitoring support added
  * Enables collection of metrics from SNMP-enabled network devices
  * Supports monitoring of network interface status, VDSL2, and ADSL device metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->