### PR TITLE
Use esc for kubeconfig

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,9 @@ dependencies = [
     "pulumi-minio==0.16.6",
     "pulumi-onepassword==1.1.3",
     "pulumi-proxmoxve==7.7.0",
+    "pulumi-pulumiservice>=0.32.0",
     "pulumi-random==4.18.4",
     "pulumi==3.203.0",
-
     # Workspaces
     "backup",
     "ingress",

--- a/services/backup/Pulumi.prod.yaml
+++ b/services/backup/Pulumi.prod.yaml
@@ -1,8 +1,8 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   backup:config:
-    kubeconfig:
-      ref: op://Pulumi/Kubeconfig prod/password
-
     restic:
       # renovate: datasource=github-releases packageName=restic/restic versioning=semver
       version: "0.18.1"

--- a/services/backup/__main__.py
+++ b/services/backup/__main__.py
@@ -3,11 +3,12 @@ import pulumi_kubernetes as k8s
 
 from backup.backup import Backup
 from backup.config import ComponentConfig
+from utils.k8s import get_k8s_provider
 
 config = p.Config()
 component_config = ComponentConfig.model_validate(config.get_object('config'))
 
-k8s_provider = k8s.Provider('k8s', kubeconfig=component_config.kubeconfig.value)
+k8s_provider = get_k8s_provider()
 
 namespace = k8s.core.v1.Namespace(
     'backup',

--- a/services/backup/backup/config.py
+++ b/services/backup/backup/config.py
@@ -25,7 +25,6 @@ class ResticConfig(utils.model.LocalBaseModel):
 
 
 class ComponentConfig(utils.model.LocalBaseModel):
-    kubeconfig: utils.model.OnePasswordRef
     restic: ResticConfig
     schedule: str = pydantic.Field(default='0 1 * * *')
     retention_daily: int = pydantic.Field(default=14)
@@ -45,4 +44,5 @@ class StackConfig(utils.model.LocalBaseModel):
 
 
 class PulumiConfigRoot(utils.model.LocalBaseModel):
+    environment: list[str] | None
     config: StackConfig

--- a/services/immich/Pulumi.prod.yaml
+++ b/services/immich/Pulumi.prod.yaml
@@ -1,3 +1,6 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   immich:config:
     cloudflare:
@@ -5,8 +8,6 @@ config:
         ref: op://Pulumi/Cloudflare Global API Key/password
       email: tobias_henkel@gmx.de
       zone: tobiash.net
-    kubeconfig:
-      ref: op://Pulumi/Kubeconfig prod/password
     immich:
       # renovate: datasource=github-releases packageName=immich-app/immich versioning=semver
       version: 2.1.0

--- a/services/immich/__main__.py
+++ b/services/immich/__main__.py
@@ -6,15 +6,12 @@ import utils.postgres
 
 from immich.config import ComponentConfig
 from immich.immich import create_immich
+from utils.k8s import get_k8s_provider
 
 config = p.Config()
 component_config = ComponentConfig.model_validate(config.get_object('config'))
 
-stack = p.get_stack()
-org = p.get_organization()
-k8s_stack_ref = p.StackReference(f'{org}/kubernetes/{stack}')
-
-k8s_provider = k8s.Provider('k8s', kubeconfig=k8s_stack_ref.get_output('kubeconfig'))
+k8s_provider = get_k8s_provider()
 
 namespace = k8s.core.v1.Namespace(
     'immich-namespace',

--- a/services/immich/immich/config.py
+++ b/services/immich/immich/config.py
@@ -23,7 +23,6 @@ class PostgresConfig(utils.model.LocalBaseModel):
 
 
 class ComponentConfig(utils.model.LocalBaseModel):
-    kubeconfig: utils.model.OnePasswordRef
     cloudflare: utils.model.CloudflareConfig
     immich: ImmichConfig
     postgres: PostgresConfig
@@ -37,4 +36,5 @@ class StackConfig(utils.model.LocalBaseModel):
 
 
 class PulumiConfigRoot(utils.model.LocalBaseModel):
+    environment: list[str] | None
     config: StackConfig

--- a/services/ingress/Pulumi.prod.yaml
+++ b/services/ingress/Pulumi.prod.yaml
@@ -1,3 +1,6 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   ingress:config:
     cloudflare:

--- a/services/ingress/__main__.py
+++ b/services/ingress/__main__.py
@@ -1,9 +1,9 @@
 import pulumi as p
 import pulumi_cloudflare as cloudflare
-import pulumi_kubernetes as k8s
 
 from ingress.cloudflared import create_cloudflared
 from ingress.config import ComponentConfig
+from utils.k8s import get_k8s_provider
 
 component_config = ComponentConfig.model_validate(p.Config().get_object('config'))
 
@@ -13,10 +13,6 @@ cloudflare_provider = cloudflare.Provider(
     email=component_config.cloudflare.email,
 )
 
-stack = p.get_stack()
-org = p.get_organization()
-k8s_stack_ref = p.StackReference(f'{org}/kubernetes/{stack}')
-
-k8s_provider = k8s.Provider('k8s', kubeconfig=k8s_stack_ref.get_output('kubeconfig'))
+k8s_provider = get_k8s_provider()
 
 create_cloudflared(component_config, k8s_provider, cloudflare_provider)

--- a/services/iot/Pulumi.prod.yaml
+++ b/services/iot/Pulumi.prod.yaml
@@ -1,8 +1,8 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   iot:config:
-    kubeconfig:
-      ref: op://Pulumi/Kubeconfig prod/password
-
     proxmox:
       username: root@pam
       password:

--- a/services/iot/iot/config.py
+++ b/services/iot/iot/config.py
@@ -55,7 +55,6 @@ class ZwaveControllerConfig(utils.model.LocalBaseModel):
 
 
 class ComponentConfig(utils.model.LocalBaseModel):
-    kubeconfig: utils.model.OnePasswordRef
     proxmox: ProxmoxConfig
 
     cloudflare: utils.model.CloudflareConfig | None = None
@@ -72,4 +71,5 @@ class StackConfig(utils.model.LocalBaseModel):
 
 
 class PulumiConfigRoot(utils.model.LocalBaseModel):
+    environment: list[str] | None
     config: StackConfig

--- a/services/iot/iot/main.py
+++ b/services/iot/iot/main.py
@@ -1,6 +1,7 @@
 import pulumi as p
-import pulumi_kubernetes as k8s
 import pulumi_proxmoxve as proxmoxve
+
+from utils.k8s import get_k8s_provider
 
 from iot.config import ComponentConfig
 from iot.mosquitto import Mosquitto
@@ -12,7 +13,7 @@ def main():
     config = p.Config()
     component_config = ComponentConfig.model_validate(config.get_object('config'))
 
-    k8s_provider = k8s.Provider('k8s', kubeconfig=component_config.kubeconfig.value)
+    k8s_provider = get_k8s_provider()
     proxmox_provider = proxmoxve.Provider(
         'proxmox',
         endpoint=component_config.proxmox.api_endpoint,

--- a/services/monitoring/Pulumi.prod.yaml
+++ b/services/monitoring/Pulumi.prod.yaml
@@ -1,3 +1,6 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   monitoring:config:
     alloy:

--- a/services/monitoring/monitoring/config.py
+++ b/services/monitoring/monitoring/config.py
@@ -53,4 +53,5 @@ class StackConfig(utils.model.LocalBaseModel):
 
 
 class PulumiConfigRoot(utils.model.LocalBaseModel):
+    environment: list[str] | None
     config: StackConfig

--- a/services/monitoring/monitoring/main.py
+++ b/services/monitoring/monitoring/main.py
@@ -1,5 +1,6 @@
 import pulumi as p
-import pulumi_kubernetes as k8s
+
+from utils.k8s import get_k8s_provider
 
 from monitoring.alloy import Alloy
 from monitoring.config import ComponentConfig
@@ -11,11 +12,7 @@ def main():
     config = p.Config()
     component_config = ComponentConfig.model_validate(config.get_object('config'))
 
-    stack = p.get_stack()
-    org = p.get_organization()
-    k8s_stack_ref = p.StackReference(f'{org}/kubernetes/{stack}')
-
-    k8s_provider = k8s.Provider('k8s', kubeconfig=k8s_stack_ref.get_output('kubeconfig'))
+    k8s_provider = get_k8s_provider()
 
     assert component_config
     assert k8s_provider

--- a/services/n8n/Pulumi.prod.yaml
+++ b/services/n8n/Pulumi.prod.yaml
@@ -1,3 +1,6 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   n8n:config:
     cloudflare:

--- a/services/n8n/n8n/config.py
+++ b/services/n8n/n8n/config.py
@@ -26,4 +26,5 @@ class StackConfig(utils.model.LocalBaseModel):
 
 
 class PulumiConfigRoot(utils.model.LocalBaseModel):
+    environment: list[str] | None = None
     config: StackConfig

--- a/services/n8n/n8n/main.py
+++ b/services/n8n/n8n/main.py
@@ -1,5 +1,6 @@
 import pulumi as p
-import pulumi_kubernetes as k8s
+
+from utils.k8s import get_k8s_provider
 
 from n8n.config import ComponentConfig
 from n8n.n8n import create_n8n
@@ -9,13 +10,4 @@ def main() -> None:
     config = p.Config()
     component_config = ComponentConfig.model_validate(config.get_object('config'))
 
-    stack = p.get_stack()
-    org = p.get_organization()
-    k8s_stack_ref = p.StackReference(f'{org}/kubernetes/{stack}')
-
-    k8s_provider = k8s.Provider('k8s', kubeconfig=k8s_stack_ref.get_output('kubeconfig'))
-
-    assert component_config
-    assert k8s_provider
-
-    create_n8n(component_config, k8s_provider)
+    create_n8n(component_config, get_k8s_provider())

--- a/services/ollama/Pulumi.prod.yaml
+++ b/services/ollama/Pulumi.prod.yaml
@@ -1,3 +1,6 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   ollama:config:
     cloudflare:

--- a/services/ollama/ollama/config.py
+++ b/services/ollama/ollama/config.py
@@ -25,4 +25,5 @@ class StackConfig(utils.model.LocalBaseModel):
 
 
 class PulumiConfigRoot(utils.model.LocalBaseModel):
+    environment: list[str] | None
     config: StackConfig

--- a/services/ollama/ollama/main.py
+++ b/services/ollama/ollama/main.py
@@ -1,5 +1,6 @@
 import pulumi as p
-import pulumi_kubernetes as k8s
+
+from utils.k8s import get_k8s_provider
 
 from ollama.config import ComponentConfig
 from ollama.ollama import create_ollama
@@ -9,11 +10,7 @@ def main():
     config = p.Config()
     component_config = ComponentConfig.model_validate(config.get_object('config'))
 
-    stack = p.get_stack()
-    org = p.get_organization()
-    k8s_stack_ref = p.StackReference(f'{org}/kubernetes/{stack}')
-
-    k8s_provider = k8s.Provider('k8s', kubeconfig=k8s_stack_ref.get_output('kubeconfig'))
+    k8s_provider = get_k8s_provider()
 
     assert component_config
     assert k8s_provider

--- a/services/paperless/Pulumi.prod.yaml
+++ b/services/paperless/Pulumi.prod.yaml
@@ -1,3 +1,6 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   paperless:config:
     cloudflare:
@@ -5,8 +8,6 @@ config:
         ref: op://Pulumi/Cloudflare Global API Key/password
       email: tobias_henkel@gmx.de
       zone: tobiash.net
-    kubeconfig:
-      ref: op://Pulumi/Kubeconfig prod/password
     entraid:
       client-id: a02dcdca-dd0d-4b11-8a92-e7c8307ad547
       client-secret:

--- a/services/paperless/__main__.py
+++ b/services/paperless/__main__.py
@@ -4,11 +4,12 @@ import utils.postgres
 
 from paperless.config import ComponentConfig
 from paperless.paperless import Paperless
+from utils.k8s import get_k8s_provider
 
 config = p.Config()
 component_config = ComponentConfig.model_validate(config.get_object('config'))
 
-k8s_provider = k8s.Provider('k8s', kubeconfig=component_config.kubeconfig.value)
+k8s_provider = get_k8s_provider()
 
 namespace = k8s.core.v1.Namespace(
     'paperless-namespace',

--- a/services/paperless/paperless/config.py
+++ b/services/paperless/paperless/config.py
@@ -74,7 +74,6 @@ class BackupConfig(utils.model.LocalBaseModel):
 
 
 class ComponentConfig(utils.model.LocalBaseModel):
-    kubeconfig: utils.model.OnePasswordRef
     cloudflare: utils.model.CloudflareConfig
     paperless: PaperlessConfig
     backup: BackupConfig
@@ -95,4 +94,5 @@ class StackConfig(utils.model.LocalBaseModel):
 
 
 class PulumiConfigRoot(utils.model.LocalBaseModel):
+    environment: list[str] | None
     config: StackConfig

--- a/services/svn/Pulumi.prod.yaml
+++ b/services/svn/Pulumi.prod.yaml
@@ -1,3 +1,6 @@
+environment:
+  - kubernetes/kubeconfig-prod
+
 config:
   svn:config:
     cloudflare:
@@ -5,8 +8,6 @@ config:
         ref: op://Pulumi/Cloudflare Global API Key/password
       email: tobias_henkel@gmx.de
       zone: tobiash.net
-    kubeconfig:
-      ref: op://Pulumi/Kubeconfig prod/password
     svn:
       # renovate: datasource=docker packageName=obslib/subversion versioning=semver
       version: httpd_svn-1.14-1

--- a/services/svn/svn/config.py
+++ b/services/svn/svn/config.py
@@ -25,7 +25,6 @@ class SvnConfig(utils.model.LocalBaseModel):
 
 class ComponentConfig(utils.model.LocalBaseModel):
     cloudflare: utils.model.CloudflareConfig
-    kubeconfig: utils.model.OnePasswordRef
     svn: SvnConfig
 
 

--- a/services/svn/svn/main.py
+++ b/services/svn/svn/main.py
@@ -1,5 +1,6 @@
 import pulumi as p
-import pulumi_kubernetes as k8s
+
+from utils.k8s import get_k8s_provider
 
 from svn.config import ComponentConfig
 from svn.svn import create_svn
@@ -9,7 +10,7 @@ def main() -> None:
     config = p.Config()
     component_config = ComponentConfig.model_validate(config.get_object('config'))
 
-    k8s_provider = k8s.Provider('k8s', kubeconfig=component_config.kubeconfig.value)
+    k8s_provider = get_k8s_provider()
 
     assert component_config
     assert k8s_provider

--- a/utils/src/utils/k8s.py
+++ b/utils/src/utils/k8s.py
@@ -1,0 +1,6 @@
+import pulumi as p
+import pulumi_kubernetes as k8s
+
+
+def get_k8s_provider() -> k8s.Provider:
+    return k8s.Provider('k8s', kubeconfig=p.Config().require_secret('kubeconfig'))

--- a/uv.lock
+++ b/uv.lock
@@ -455,6 +455,7 @@ dependencies = [
     { name = "pulumi-minio" },
     { name = "pulumi-onepassword" },
     { name = "pulumi-proxmoxve" },
+    { name = "pulumi-pulumiservice" },
     { name = "pulumi-random" },
     { name = "s3" },
     { name = "svn" },
@@ -492,6 +493,7 @@ requires-dist = [
     { name = "pulumi-minio", specifier = "==0.16.6" },
     { name = "pulumi-onepassword", specifier = "==1.1.3" },
     { name = "pulumi-proxmoxve", specifier = "==7.7.0" },
+    { name = "pulumi-pulumiservice", specifier = ">=0.32.0" },
     { name = "pulumi-random", specifier = "==4.18.4" },
     { name = "s3", editable = "services/s3" },
     { name = "svn", editable = "services/svn" },
@@ -998,6 +1000,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/c6/8b08918bd391b5825efeb999b24a4921cb040a54bf3fc90094c22f40e607/pulumi_proxmoxve-7.7.0.tar.gz", hash = "sha256:f48e91f9aee93031f81d7aef45abfb42b62d3b05a721051330f40ec305f486c8", size = 204408, upload-time = "2025-10-12T08:34:07.816Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/0d/02639a2731686d8a0d5194248e9ee42c9544aaeb10349c719b5e35032172/pulumi_proxmoxve-7.7.0-py3-none-any.whl", hash = "sha256:e7bd7d8a8dd08323dcecae03b3f21cd580d0d5c2f476f46e1a9119baa0f86570", size = 316219, upload-time = "2025-10-12T08:34:06.161Z" },
+]
+
+[[package]]
+name = "pulumi-pulumiservice"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parver" },
+    { name = "pulumi" },
+    { name = "semver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/cf/90e3e152400c41824749ffa3bdca6edbb1fcd38b8218704fad62e0d5d1e7/pulumi_pulumiservice-0.32.0.tar.gz", hash = "sha256:cd7c1c567fd443e55dbce08835695a942ab8be8656090eba2b1b07c15a33355a", size = 42396, upload-time = "2025-10-13T19:10:59.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/3f/02cff5e48af7e1ee3af51fdce823c13172cb0b1adebc8c3df5522bb70072/pulumi_pulumiservice-0.32.0-py3-none-any.whl", hash = "sha256:7eac1f2046346847df83e871483a556637bace645c1bd37f1800325fa81716d9", size = 72109, upload-time = "2025-10-13T19:10:57.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Using stack references can have a significant performance impact
depending on the size of the referenced stack. This is caused by
pulumi fetching the whole stack state in order to extract the
output. Using esc is much more efficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Kubernetes provider initialization across multiple services (backup, immich, ingress, iot, monitoring, n8n, ollama, paperless, svn) using a centralized helper function.
  * Migrated kubeconfig secret handling from direct configuration references to environment-based configuration.
  * Integrated Pulumi Service Provider for improved infrastructure secret management.
  * Updated service configurations to support new environment-based secret references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->