### PR TITLE
Drop non-running pods only for metrics

### DIFF
--- a/services/monitoring/assets/alloy/discovery_k8s_pods.alloy
+++ b/services/monitoring/assets/alloy/discovery_k8s_pods.alloy
@@ -11,13 +11,6 @@ discovery.kubernetes "pods" {
 discovery.relabel "pods_common" {
 	targets = discovery.kubernetes.pods.targets
 
-	// Filter by phase
-	rule {
-		source_labels = ["__meta_kubernetes_pod_phase"]
-		regex         = "Pending|Succeeded|Failed|Unknown"
-		action        = "drop"
-	}
-
 	// Drop empty container targets
 	rule {
 		source_labels = ["__meta_kubernetes_pod_container_name"]
@@ -90,6 +83,13 @@ discovery.relabel "pods_logs" {
 //-----------------------------------------------------------
 discovery.relabel "pods_metrics_common" {
 	targets = discovery.relabel.pods_common.output
+
+	// Filter by phase
+	rule {
+		source_labels = ["__meta_kubernetes_pod_phase"]
+		regex         = "Pending|Succeeded|Failed|Unknown"
+		action        = "drop"
+	}
 
 	// Keep only pods that explicitly opt-in
 	rule {


### PR DESCRIPTION
We definitely need logs of pods in error state etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Kubernetes pod filtering in monitoring systems. Pods with Pending, Succeeded, Failed, and Unknown phases are now filtered earlier in the metric collection pipeline, improving processing efficiency and ensuring only metrics from active pods are collected for analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->