### PR TITLE
Downgrade immich postgres to 18.0

### DIFF
--- a/services/immich/Pulumi.prod.yaml
+++ b/services/immich/Pulumi.prod.yaml
@@ -32,7 +32,7 @@ config:
           size: "10Gi"
     postgres:
       # renovate: datasource=endoflife-date packageName=postgresql versioning=loose
-      version: "18.1"
+      version: "18.0"
       # renovate: datasource=github-releases packageName=tensorchord/VectorChord versioning=loose
       vectorchord-version: "0.5.3"
       backup:


### PR DESCRIPTION
Vectorchord images using 18.1 are not yet available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend database service configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->