### PR TITLE
Set pyrefly interpreter path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ model = "backup.config:PulumiConfigRoot"
 project-includes = ["scripts", "services", "utils", "**/*.py"]
 disable-project-excludes-heuristics = true
 infer-with-first-use = false
+python-interpreter-path = ".venv/bin/python3"
 
 [tool.config-models.immich]
 root = "services/immich"


### PR DESCRIPTION
Might be best practice if the venv is not sourced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration settings for Python environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->