### PR TITLE
Install cloudnative-pg image catalogs

### DIFF
--- a/.github/workflows/update-cloudnativepg-catalogs.yml
+++ b/.github/workflows/update-cloudnativepg-catalogs.yml
@@ -1,0 +1,62 @@
+name: Update CloudNativePG Image Catalogs
+
+on:
+  schedule:
+    # Run nightly at 2:00 AM UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-catalogs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run update script
+        run: |
+          (cd services/kubernetes/assets/image-catalogs && bash update-catalogs.sh)
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            chore: Update CloudNativePG image catalogs
+
+            Automated update from cloudnative-pg/artifacts repository.
+          branch: automated/update-cloudnativepg-catalogs
+          delete-branch: true
+          title: "chore: Update CloudNativePG image catalogs"
+          body: |
+            ## Automated Update: CloudNativePG Image Catalogs
+
+            This PR updates the CloudNativePG image catalog files from the upstream repository.
+
+            ### Changes
+            - Updated image catalog files from [cloudnative-pg/artifacts](https://github.com/cloudnative-pg/artifacts/tree/main/image-catalogs)
+
+            ### Files Updated
+            - `catalog-minimal-bookworm.yaml`
+            - `catalog-minimal-bullseye.yaml`
+            - `catalog-minimal-trixie.yaml`
+            - `catalog-standard-bookworm.yaml`
+            - `catalog-standard-bullseye.yaml`
+            - `catalog-standard-trixie.yaml`
+            - `catalog-system-bookworm.yaml`
+            - `catalog-system-bullseye.yaml`
+            - `catalog-system-trixie.yaml`
+
+            ### Notes
+            - These catalogs define available PostgreSQL versions for CloudNativePG
+            - Review changes to ensure compatibility with current CloudNativePG version
+
+            ---
+            *This PR was automatically created by the Update CloudNativePG Catalogs workflow.*
+          labels: |
+            dependencies
+            automated

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@ extends: default
 ignore: |
   .git
   .venv
+  services/kubernetes/assets/image-catalogs/*.yaml
   services/monitoring/assets/snmp/snmp.yml
 
 rules:

--- a/services/kubernetes/assets/image-catalogs/catalog-minimal-bookworm.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-minimal-bookworm.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-minimal-bookworm
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: minimal
+    images.cnpg.io/os: bookworm
+    images.cnpg.io/date: '20251104'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511030807-minimal-bookworm@sha256:9ddc0467590233bbe5562004b040b980adbbd68fcbf82fef1b0ad530a1e837d4
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202511030807-minimal-bookworm@sha256:375d72650608b16b9c3e950a41dbc94e395e9099771373eddf051254b868fef9
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202511030807-minimal-bookworm@sha256:0aeb0294064664cf1568a62e84f23ccd4c9ddd9fac965c8f038f8c348e363338
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202511030807-minimal-bookworm@sha256:4a0fd1b411a39185c9198a18a7de892d565ef302e084fc1a765b0befdee4bf40
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202511030807-minimal-bookworm@sha256:866e01a91af874374f2b14e5c0556d3a9704160c64c2aee2dccc06cb58a2fcce
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202511030807-minimal-bookworm@sha256:3933cdea2a795b97b479231aeffb7d193e1bd682e06ea9e5c61093ce5ef5aef5

--- a/services/kubernetes/assets/image-catalogs/catalog-minimal-bullseye.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-minimal-bullseye.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-minimal-bullseye
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: minimal
+    images.cnpg.io/os: bullseye
+    images.cnpg.io/date: '20251104'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511030807-minimal-bullseye@sha256:dbc70c5b030c1276d0d3d44f0f2308cf710475c94b5c71ce1a93ca9a6ed6ea62
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202511030807-minimal-bullseye@sha256:aadb0c5e102cb632fe0e97bb0cf558200cd9db5b10161b4179c3b14de0be559a
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202511030807-minimal-bullseye@sha256:412691665df19013e52ea85a1549070d6e5c8208904e702131351bd04abdde13
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202511030807-minimal-bullseye@sha256:94272c8d231b24ffb35872d67ce8811b921c83f0acd5b3a939098bbe99db848d
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202511030807-minimal-bullseye@sha256:b082c4ec5c7a5e7763f7b2ab420bdd45895c5700b8670d609ef0a0b87202c7b9
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202511030807-minimal-bullseye@sha256:be692363b65bd790394f048ccf6523bf99175abcd0b83be5be515e833e1d4d8b

--- a/services/kubernetes/assets/image-catalogs/catalog-minimal-trixie.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-minimal-trixie.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-minimal-trixie
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: minimal
+    images.cnpg.io/os: trixie
+    images.cnpg.io/date: '20251104'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511030807-minimal-trixie@sha256:2a9f3b7de8b72473baaef49e5d8a9f95052c11419821268651831fbd67a37e75
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202511030807-minimal-trixie@sha256:1aea747bfcd1f64fa635cbd1ceea0708913d76aba8294dcf732aed136838a41a
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202511030807-minimal-trixie@sha256:2ffbe871ebbdb598a07bdf4f4c011aed9cda17f1b70c6a1bd89a2225132be038
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202511030807-minimal-trixie@sha256:dffdac56d04024549512f1a8f7ed7d6787ef9b40ac699e911ac911a7b5daac9e
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202511030807-minimal-trixie@sha256:70ab2b8385f67ccd399a8d5f43cb37dc3d16f0ce41de98386ed155b50e1326a2
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202511030807-minimal-trixie@sha256:b5049f6187822761e6766e1135e224046eff09ee11aa5552976d2056c85a8806

--- a/services/kubernetes/assets/image-catalogs/catalog-standard-bookworm.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-standard-bookworm.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-standard-bookworm
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: standard
+    images.cnpg.io/os: bookworm
+    images.cnpg.io/date: '20251104'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511030807-standard-bookworm@sha256:b2c2f603c39158100e3ef50cb474dd7bb52cce4991725e4f264f812c043e0aad
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202511030807-standard-bookworm@sha256:ab3a59e2904e6ba9da71fa77e287ebbd938726f4ed6fe93221344c1b88bf0d8a
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202511030807-standard-bookworm@sha256:9943ec9bfc527b294e9097da05ae6422ead506c26459873a381708e278afd727
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202511030807-standard-bookworm@sha256:ad83708ae8c20f36419be5f2b10d5097ca1a7420257f2fe40ac47f0947304286
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202511030807-standard-bookworm@sha256:de94ee3c8b01defe1d641a37a70d421740c7f90681604352f1b7c4039e94d313
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202511030807-standard-bookworm@sha256:1c74a947039eb6a2de44cdeb4f4225dd2ff6ae1c2f28f476967e17e352c84293

--- a/services/kubernetes/assets/image-catalogs/catalog-standard-bullseye.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-standard-bullseye.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-standard-bullseye
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: standard
+    images.cnpg.io/os: bullseye
+    images.cnpg.io/date: '20251104'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511030807-standard-bullseye@sha256:5797321f8a522215b34f31b02e10be955823f8f43dc1e508d3f6ff76c0ee93e3
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202511030807-standard-bullseye@sha256:4188b5dca22f20d7a81eee0b5d0ffc4d793c2e4035173d8ce5536974e6b7ae5e
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202511030807-standard-bullseye@sha256:c763df9142d8a1df9a71955a5906ec6822448ea60efe0c35894976b6be8344b6
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202511030807-standard-bullseye@sha256:632a0cbe1595503b04248c30c1ef633ada4bb956e6d42bf4d281e368261213d1
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202511030807-standard-bullseye@sha256:29c57786e7d5116084311fd6e3a73c957e5df169db674a9830312d002d4eb4bf
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202511030807-standard-bullseye@sha256:984f50e3b9e331e9c520b5d725135cae243e4b923af43a79052f00aebce3756f

--- a/services/kubernetes/assets/image-catalogs/catalog-standard-trixie.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-standard-trixie.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-standard-trixie
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: standard
+    images.cnpg.io/os: trixie
+    images.cnpg.io/date: '20251027'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202510270807-standard-trixie@sha256:922b4074e0cd5bde91d8241279cb75fdf7cb0cfa99e50b6233c730365140cf8f
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202510270807-standard-trixie@sha256:9c72be80669fbc476f052e5826eed1546c4300c649ef32df904db9677c387cf3
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202510270807-standard-trixie@sha256:072c4314800724f145f46a569607afb9513046849b93f7d586dc1142c7b8e427
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202510270807-standard-trixie@sha256:4533a01abd184cd469ed53379dc2de9b24d484760a8e3780a8f9eca90e840afe
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202510270807-standard-trixie@sha256:bb4860068c6149d8eb7a65942702678cf3486a1327e6c627bf58920a502419aa
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202510270807-standard-trixie@sha256:72e4fffaa516d0bc6325235ea16c556eb1aabde8ec07a70d5f6aaf0bf02ceef3

--- a/services/kubernetes/assets/image-catalogs/catalog-system-bookworm.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-system-bookworm.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-system-bookworm
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: system
+    images.cnpg.io/os: bookworm
+    images.cnpg.io/date: '20251104'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511030807-system-bookworm@sha256:ef8985aeb2b4a1e6aff865108e812748e3ba401fca5e7e23b7d955e8dd3284db
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202511030807-system-bookworm@sha256:c454c115305ae91776e93ae5f225b6debb6ac637faa5c6fa67b0ccf0c85bf233
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202511030807-system-bookworm@sha256:1fddae6821c911a128d7bd7e81e3177c6b3c3abda324d57042ff8580e0613124
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202511030807-system-bookworm@sha256:2ed5202825bafb0ff0f585d256d45383db8deb04a86c23286d8b789ee961a1fa
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202511030807-system-bookworm@sha256:c8577c03ba86f40719cb840ee88245e34fa0ab2bff5c330186b44a5877988d96
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202511030807-system-bookworm@sha256:4ee9d49bb71e0cb7c9cc9c0f36db48bdb7228ea3926553374e6658b91816b670

--- a/services/kubernetes/assets/image-catalogs/catalog-system-bullseye.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-system-bullseye.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-system-bullseye
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: system
+    images.cnpg.io/os: bullseye
+    images.cnpg.io/date: '20251104'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511030807-system-bullseye@sha256:a277fa2b1acee2b3c05d329eb277d94d0ee57fec3a7bc8a6887238f835bb0afe
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202511030807-system-bullseye@sha256:4be85e17083d2d4e7a72b3e21589e2755154d5a95ca0c814a9e88696f2731996
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202511030807-system-bullseye@sha256:3dfa1cd4b2ea13470c103b5417e0be3fd1f60f9fcc81935fac9f9965349a6762
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202511030807-system-bullseye@sha256:5a0fadda518f766688123a5fcf7d79381f1e1362a571f022827617016aa48db3
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202511030807-system-bullseye@sha256:fabacad3b63ef8c83117d43b9083aba00a95ae8e42ad5f74c6a10e5e5b057ecf
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202511030807-system-bullseye@sha256:94582762716f62588f3a4e9ca0dea2d73acf4c3f8b1686aa185c35f542c951db

--- a/services/kubernetes/assets/image-catalogs/catalog-system-trixie.yaml
+++ b/services/kubernetes/assets/image-catalogs/catalog-system-trixie.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-system-trixie
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: system
+    images.cnpg.io/os: trixie
+    images.cnpg.io/date: '20251104'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511030807-system-trixie@sha256:dfe6ef7e7bd6cf271146e520883110b8551f07bf825dd76f4683661ba27c0eaf
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.19-202511030807-system-trixie@sha256:cb9b2ae60854cf524a98276062c938786db9f9fc899d14bc1c8d1971d464d221
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.14-202511030807-system-trixie@sha256:6dca708702331ac92f621d3aac5a09dd6bdd109a73e9d6b2c7570b161a2c5950
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.10-202511030807-system-trixie@sha256:87b4b35dbd596c08565e1179589daa5816db6e9d7b77a28176f25378393088f4
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.6-202511030807-system-trixie@sha256:def80964ed3e0f9beb25589825ee9bcffe3851fbf0204cb18b696b25934f975a
+  - major: 18
+    image: ghcr.io/cloudnative-pg/postgresql:18.0-202511030807-system-trixie@sha256:35c80d13fe374f17a96016744654a4f4386cf889854b72da0658d8be9b70fdb5

--- a/services/kubernetes/assets/image-catalogs/update-catalogs.sh
+++ b/services/kubernetes/assets/image-catalogs/update-catalogs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASEURL="https://raw.githubusercontent.com/cloudnative-pg/artifacts/refs/heads/main/image-catalogs"
+
+CATALOG_FILES=(
+    "catalog-minimal-bookworm.yaml"
+    "catalog-minimal-bullseye.yaml"
+    "catalog-minimal-trixie.yaml"
+    "catalog-standard-bookworm.yaml"
+    "catalog-standard-bullseye.yaml"
+    "catalog-standard-trixie.yaml"
+    "catalog-system-bookworm.yaml"
+    "catalog-system-bullseye.yaml"
+    "catalog-system-trixie.yaml"
+)
+
+for FILE in "${CATALOG_FILES[@]}"; do
+    curl -fSL "${BASEURL}/${FILE}" -o "./${FILE}"
+done

--- a/services/kubernetes/kubernetes/cloudnativepg.py
+++ b/services/kubernetes/kubernetes/cloudnativepg.py
@@ -4,6 +4,7 @@ import pulumi_pulumiservice as pulumiservice
 import yaml
 
 from kubernetes.config import ComponentConfig
+from kubernetes.utils import get_assets_path
 
 
 def create_cloudnative_pg(component_config: ComponentConfig, k8s_provider: k8s.Provider):
@@ -101,6 +102,16 @@ def create_cloudnative_pg(component_config: ComponentConfig, k8s_provider: k8s.P
                 },
             ],
         },
+        opts=k8s_opts,
+    )
+
+    # Install image catalogs
+    k8s.yaml.ConfigGroup(
+        'image-catalogs',
+        yaml=[
+            catalog_file.read_text()
+            for catalog_file in (get_assets_path() / 'image-catalogs').glob('*.yaml')
+        ],
         opts=k8s_opts,
     )
 

--- a/services/kubernetes/kubernetes/utils.py
+++ b/services/kubernetes/kubernetes/utils.py
@@ -1,0 +1,12 @@
+"""
+This module contains utility functions.
+"""
+
+from pathlib import Path
+
+
+def get_assets_path() -> Path:
+    """
+    Returns the path to the assets folder.
+    """
+    return Path(__file__).parent.parent / 'assets'


### PR DESCRIPTION
This also includes a nightly running github action which regularly
fetches the latest image catalogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CloudNativePG image catalogs supporting PostgreSQL 13–18 across multiple OS variants (Bookworm, Bullseye, Trixie) and image types (minimal, standard, system).
  * Implemented automated nightly catalog updates with manual trigger support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->