### PR TITLE
Configure postgres updates for major versions only

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -67,6 +67,20 @@
       additionalBranchPrefix: "{{parentDir}}-",
       commitMessageSuffix: "({{parentDir}})",
     },
+    {
+      // PostgreSQL except immich should track only <major> versions (disable minor/patch)
+      matchPackageNames: [
+        'postgresql',
+      ],
+      matchFileNames: [
+        '!services/immich/Pulumi.prod.yaml',
+      ],
+      matchUpdateTypes: [
+        'minor',
+        'patch'
+      ],
+      enabled: false,
+    },
   ],
   prHourlyLimit: 10,
   rangeStrategy: 'replace',

--- a/services/immich/Pulumi.prod.yaml
+++ b/services/immich/Pulumi.prod.yaml
@@ -32,7 +32,7 @@ config:
           size: "10Gi"
     postgres:
       # renovate: datasource=endoflife-date packageName=postgresql versioning=loose
-      version: "18.0"
+      version: "17.6"
       # renovate: datasource=github-releases packageName=tensorchord/VectorChord versioning=loose
       vectorchord-version: "0.5.3"
       backup:

--- a/services/paperless/Pulumi.prod.yaml
+++ b/services/paperless/Pulumi.prod.yaml
@@ -59,7 +59,7 @@ config:
         ref: "op://Pulumi/IDrive e2 Paperless/Secret Access Key"
     postgres:
       # renovate: datasource=endoflife-date packageName=postgresql versioning=loose
-      version: 18
+      version: 17
     redis:
       # renovate: datasource=github-releases packageName=redis/redis versioning=semver
       version: 8.2.3

--- a/services/tandoor/Pulumi.prod.yaml
+++ b/services/tandoor/Pulumi.prod.yaml
@@ -15,6 +15,6 @@ config:
       hostname: tandoor.tobiash.net
     postgres:
       # renovate: datasource=endoflife-date packageName=postgresql versioning=loose
-      version: 18
+      version: 17
       backup:
         cron-schedule: "0 0 0 * * *"


### PR DESCRIPTION
This is needed as reference for the cluster image catalogs. But we
need to keep the current versioning on immich.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded PostgreSQL versions to 17 series across multiple services.
  * Added dependency management configuration for PostgreSQL to control automatic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->