### PR TITLE
Revert "chore(deps): update dependency postgresql to v18.1 (immich)"

### DIFF
--- a/services/immich/Pulumi.prod.yaml
+++ b/services/immich/Pulumi.prod.yaml
@@ -33,7 +33,7 @@ config:
       preload-model: ViT-SO400M-16-SigLIP2-384__webli
     postgres:
       # renovate: datasource=endoflife-date packageName=postgresql versioning=loose
-      version: "18.1"
+      version: "18.0"
       # renovate: datasource=github-releases packageName=tensorchord/VectorChord versioning=loose
       vectorchord-version: "0.5.3"
       backup:


### PR DESCRIPTION
Reverts CrashLoopBackCoffee/th-deploy-homelab#351

Immich is not compatible yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL version in production configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->