### PR TITLE
Revert "chore(deps): update dependency canonical/microk8s to v1.35"

### DIFF
--- a/services/kubernetes/Pulumi.prod.yaml
+++ b/services/kubernetes/Pulumi.prod.yaml
@@ -31,7 +31,7 @@ config:
       version: v4.12.1
     microk8s:
       # renovate: datasource=github-tags packageName=canonical/microk8s versioning=loose
-      version: "1.35"
+      version: "1.34"
       vlan: 40
       ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFLGX6Nw50R8EGcDgR69SkvAgX/NR71vLHlYuB7lkyoJ
       metallb:

--- a/services/kubernetes/Pulumi.test.yaml
+++ b/services/kubernetes/Pulumi.test.yaml
@@ -23,7 +23,7 @@ config:
       version: v4.12.1
     microk8s:
       # renovate: datasource=github-tags packageName=canonical/microk8s versioning=loose
-      version: "1.35"
+      version: "1.34"
       vlan: 40
       ssh-public-key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFLGX6Nw50R8EGcDgR69SkvAgX/NR71vLHlYuB7lkyoJ
       metallb:


### PR DESCRIPTION
Reverts CrashLoopBackCoffee/th-deploy-homelab#406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded microk8s version from 1.35 to 1.34 in production and test configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->