### PR TITLE
Fix cadvisor startup

### DIFF
--- a/services/monitoring/monitoring/cadvisor_legacy.py
+++ b/services/monitoring/monitoring/cadvisor_legacy.py
@@ -17,7 +17,7 @@ def create_cadvisor(
     assert component_config.cadvisor
     image = docker.RemoteImage(
         'cadvisor',
-        name=f'ghcr.io/google/cadvisor:v{component_config.cadvisor.version}',
+        name=f'ghcr.io/google/cadvisor:{component_config.cadvisor.version}',
         keep_locally=True,
         opts=opts,
     )


### PR DESCRIPTION
Recent docker images don't use the leading 'v'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cadvisor container image reference format to use the proper version tag syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->