### PR TITLE
Scrape by default via ipv4

### DIFF
--- a/services/monitoring/assets/alloy/discovery_blackbox.alloy
+++ b/services/monitoring/assets/alloy/discovery_blackbox.alloy
@@ -21,6 +21,7 @@ prometheus.exporter.blackbox "default" {
 				http: {
 					fail_if_ssl: false,
 					fail_if_not_ssl: true,
+					preferred_ip_protocol: ip4,
 					tls_config: {
 						insecure_skip_verify: false
 					}
@@ -33,6 +34,7 @@ prometheus.exporter.blackbox "default" {
 					valid_status_codes: [303, 304],
 					fail_if_ssl: false,
 					fail_if_not_ssl: true,
+					preferred_ip_protocol: ip4,
 					tls_config: {
 						insecure_skip_verify: false
 					}
@@ -45,6 +47,7 @@ prometheus.exporter.blackbox "default" {
 					valid_status_codes: [403],
 					fail_if_ssl: false,
 					fail_if_not_ssl: true,
+					preferred_ip_protocol: ip4,
 					tls_config: {
 						insecure_skip_verify: false
 					}


### PR DESCRIPTION
The opnsense web ui is not enabled via ipv6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved blackbox monitoring configuration by specifying IPv4 protocol preference for HTTP-based targets, ensuring consistent connectivity and enhanced reliability of health checks across monitored endpoints. All changes are backward compatible with no impact to existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->