### PR TITLE
Use esc for s3 credentials

### DIFF
--- a/services/monitoring/Pulumi.prod.yaml
+++ b/services/monitoring/Pulumi.prod.yaml
@@ -1,5 +1,6 @@
 environment:
   - kubernetes/kubeconfig-prod
+  - s3/s3-prod
 
 config:
   monitoring:config:

--- a/services/monitoring/monitoring/main_legacy.py
+++ b/services/monitoring/monitoring/main_legacy.py
@@ -14,10 +14,6 @@ from monitoring.mimir_legacy import create_mimir_legacy
 def main_legacy():
     component_config = ComponentConfig.model_validate(p.Config().get_object('config'))
 
-    stack = p.get_stack()
-    org = p.get_organization()
-    minio_stack_ref = p.StackReference(f'{org}/s3/{stack}')
-
     assert component_config.target
     docker_provider = utils.docker.get_provider(component_config.target)
 
@@ -32,6 +28,4 @@ def main_legacy():
     # Create node-exporter container
     create_cadvisor_legacy(component_config, network, docker_opts)
     create_alloy_legacy(component_config, network, cloudflare_provider, docker_opts)
-    create_mimir_legacy(
-        component_config, network, cloudflare_provider, minio_stack_ref, docker_opts
-    )
+    create_mimir_legacy(component_config, network, cloudflare_provider, docker_opts)


### PR DESCRIPTION
This is the new canonical way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined monitoring service configuration by centralizing S3 settings through configuration management, reducing cross-service dependencies and simplifying deployment setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->