### PR TITLE
Disable phone home of grafana components

### DIFF
--- a/services/monitoring/assets/mimir/config.yaml
+++ b/services/monitoring/assets/mimir/config.yaml
@@ -57,3 +57,6 @@ limits:
   max_cache_freshness: 10m
   ingestion_rate: 100000
   ingestion_burst_size: 2000000
+
+usage_stats:
+  enabled: false

--- a/services/monitoring/monitoring/grafana.py
+++ b/services/monitoring/monitoring/grafana.py
@@ -19,6 +19,11 @@ def _get_grafana_config(hostname: str):
         cert_key = /etc/grafana/certs/tls.key
         cert_file = /etc/grafana/certs/tls.crt
         protocol = https
+
+        [analytics]
+        check_for_updates = false
+        reporting_enabled = false
+        check_for_plugin_updates = false
         """
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced `usage_stats` configuration setting in Mimir setup, defaulting to disabled
* Added analytics configuration options to Grafana including update checking, reporting, and plugin update controls, all defaulting to disabled

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->