### PR TITLE
Add k8s api to blackbox exporter

### DIFF
--- a/services/kubernetes/README.md
+++ b/services/kubernetes/README.md
@@ -1,0 +1,14 @@
+# Microk8s
+
+The kubernetes service is provided by [MicroK8s](https://microk8s.io/), a lightweight, single-package Kubernetes distribution developed by Canonical.
+
+## Refresh server certificates
+
+```
+# Check server certificates:
+sudo microk8s refresh-certs -c
+
+# Refresh specific certificates as needed:
+sudo microk8s refresh-certs -e server.crt
+sudo microk8s refresh-certs -e front-proxy-client.crt
+```

--- a/services/monitoring/assets/alloy/discovery_blackbox.alloy
+++ b/services/monitoring/assets/alloy/discovery_blackbox.alloy
@@ -53,6 +53,17 @@ prometheus.exporter.blackbox "default" {
 					}
 				}
 			},
+			https_k8s_api: {
+				prober: http,
+				timeout: 5s,
+				http: {
+					preferred_ip_protocol: ip4,
+					tls_config: {
+						ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+					},
+					bearer_token_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+				}
+			},
 			tls_connect: {
 				prober: tcp,
 				timeout: 5s,
@@ -206,6 +217,13 @@ prometheus.exporter.blackbox "default" {
 		name    = "mosquitto"
 		address = "mqtt.tobiash.net:8883"
 		module  = "tls_connect"
+	}
+
+	// Kubernetes API
+	target {
+		name    = "kubernetes-api"
+		address = "https://kubernetes.default.svc/readyz"
+		module  = "https_k8s_api"
 	}
 }
 


### PR DESCRIPTION
The server cert expires every year so that must be monitored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Kubernetes provider documentation with server certificate refresh procedures.

* **New Features**
  * Added Kubernetes API health monitoring with secure TLS verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->