### PR TITLE
Manage certs on synology via cert-manager

### DIFF
--- a/services/ingress/Pulumi.prod.yaml
+++ b/services/ingress/Pulumi.prod.yaml
@@ -21,3 +21,18 @@ config:
         # Immich
         - service: http://immich-server.immich:2283
           hostname: immich.tobiash.net
+
+    synology:
+      host: synology.tobiash.net
+      port: 5001
+      scheme: https
+      username:
+        ref: op://Pulumi/Synology cert-manager/username
+      password:
+        ref: op://Pulumi/Synology cert-manager/password
+      certs:
+        - hostname: alloy-legacy.tobiash.net
+        - hostname: minio-console.tobiash.net
+        - hostname: netboot.tobiash.net
+        - hostname: s3.tobiash.net
+        - hostname: synology.tobiash.net

--- a/services/ingress/README.md
+++ b/services/ingress/README.md
@@ -1,0 +1,139 @@
+# Ingress Service
+
+This service manages ingress and certificate deployment for the homelab infrastructure.
+
+## Components
+
+### 1. Cloudflared Tunnels
+
+Manages Cloudflare tunnels for secure ingress to internal services without exposing ports.
+
+### 2. Synology Certificate Deployment
+
+Automatically deploys TLS certificates from cert-manager to Synology DSM.
+
+## Configuration
+
+### Synology Certificate Deployment
+
+To enable automatic certificate deployment to Synology NAS:
+
+```yaml
+config:
+  ingress:config:
+    # ... existing cloudflare/cloudflared config ...
+
+    synology:
+      host: nas.example.com
+      port: 5001  # Optional, defaults to 5000
+      scheme: https  # Optional, defaults to http
+      username:
+        ref: op://Homelab/Synology Cert Updater/username
+      password:
+        ref: op://Homelab/Synology Cert Updater/password
+      certs:
+        - hostname: nas.example.com
+        - hostname: "*.example.com"
+```
+
+### Configuration Fields
+
+#### `synology` (optional)
+
+Main configuration for Synology certificate deployment.
+
+- **`host`** (required): Synology DSM hostname or IP address
+- **`port`** (optional, default: 5000): DSM API port
+- **`scheme`** (optional, default: http): API scheme (`http` or `https`)
+- **`username`** (required): Admin username for DSM (2FA must be disabled for this user) - 1Password reference
+- **`password`** (required): Admin password - 1Password reference
+- **`certs`** (required): List of certificates to deploy
+
+#### `certs[]`
+
+Each certificate entry requires:
+
+- **`hostname`**: The hostname (used as certificate description in DSM)
+
+The Kubernetes secret name is automatically derived from the hostname:
+- `nas.example.com` → secret name: `nas-example-com-tls`
+- `*.example.com` → secret name: `wildcard-example-com-tls`
+
+### Prerequisites
+
+1. **Synology User Account**: Create a dedicated user without 2FA enabled
+2. **Admin Permissions**: User must be in the `administrators` group
+3. **Cert-Manager Secrets**: Each secret must contain `tls.crt` (full chain) and `tls.key`
+
+### How It Works
+
+For each certificate in the configuration:
+
+1. A CronJob is created in the `synology-certs` namespace
+2. The job runs daily at 3 AM
+3. The deployment script:
+   - Authenticates to Synology DSM API
+   - Splits the certificate chain into server cert and intermediates
+   - Uploads/updates the certificate with the hostname as description
+   - Logs out
+
+### Example with Cert-Manager
+
+```yaml
+# cert-manager Certificate resource
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nas-cert
+  namespace: cert-manager  # Or your cert namespace
+spec:
+  secretName: nas-example-com-tls  # Must match derived name
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+  - nas.example.com
+```
+
+Then reference the hostname in your Pulumi configuration:
+
+```yaml
+synology:
+  certs:
+    - hostname: nas.example.com  # Secret name will be: nas-example-com-tls
+```
+
+### Security Considerations
+
+- Store Synology credentials using 1Password references
+- Create a dedicated service account for certificate updates
+- Disable 2FA for the service account (required for API authentication)
+- Use HTTPS (`scheme: https`) when possible
+- Limit network access to DSM API
+
+### Troubleshooting
+
+#### Check CronJob logs:
+
+```bash
+kubectl get cronjobs -n synology-certs
+kubectl get jobs -n synology-certs
+kubectl logs -n synology-certs job/<job-name>
+```
+
+#### Test manually:
+
+```bash
+kubectl create job -n synology-certs test-run --from=cronjob/synology-cert-<hostname>
+kubectl logs -n synology-certs job/test-run -f
+```
+
+#### Enable debug logging:
+
+Edit the CronJob to add:
+
+```yaml
+env:
+  - name: DEBUG
+    value: "1"
+```

--- a/services/ingress/__main__.py
+++ b/services/ingress/__main__.py
@@ -1,6 +1,7 @@
 import pulumi as p
 import pulumi_cloudflare as cloudflare
 
+from ingress.acme import AcmeSynology
 from ingress.cloudflared import create_cloudflared
 from ingress.config import ComponentConfig
 from utils.k8s import get_k8s_provider
@@ -15,4 +16,7 @@ cloudflare_provider = cloudflare.Provider(
 
 k8s_provider = get_k8s_provider()
 
+
 create_cloudflared(component_config, k8s_provider, cloudflare_provider)
+
+AcmeSynology('default', component_config, k8s_provider)

--- a/services/ingress/assets/README.md
+++ b/services/ingress/assets/README.md
@@ -1,0 +1,238 @@
+# Synology DSM Certificate Deployment Script
+
+## Overview
+
+`synology-cert-deploy.sh` is a standalone bash script for deploying TLS certificates to Synology DSM without requiring acme.sh. It's designed to run in Kubernetes cronjobs with certificates mounted as secrets.
+
+## Features
+
+- ✅ Pure bash/curl implementation (no acme.sh dependency)
+- ✅ Simple authentication (no 2FA complexity)
+- ✅ Automatically creates certificate if it doesn't exist
+- ✅ Automatically detects and preserves default certificate status
+- ✅ Comprehensive error handling and logging
+- ✅ Designed for non-interactive Kubernetes cronjob execution
+
+## Prerequisites
+
+- Synology DSM with admin access (2FA must be disabled for the service account)
+- `curl` available in the container
+- TLS certificate files (key, cert, CA chain)
+
+## Environment Variables
+
+### Required Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `SYNO_HOSTNAME` | Synology hostname or IP address | `nas.example.com` or `192.168.1.100` |
+| `SYNO_USERNAME` | Admin username | `cert-updater` |
+| `SYNO_PASSWORD` | Admin password | `SecurePassword123` |
+| `CERT_KEY_FILE` | Path to certificate private key | `/certs/tls.key` |
+| `CERT_CERT_FILE` | Path to certificate file (full chain) | `/certs/tls.crt` |
+
+### Optional Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SYNO_PORT` | DSM API port | `5000` |
+| `SYNO_SCHEME` | API scheme (http/https) | `http` |
+| `SYNO_CERTIFICATE` | Certificate description to update | (empty - updates default) |
+| `CERT_CA_FILE` | Path to separate CA file (if needed) | Uses `CERT_CERT_FILE` |
+| `DEBUG` | Enable verbose logging (`1` to enable) | `0` |
+
+## Kubernetes Usage
+
+### 1. Create Secrets
+
+```yaml
+# Certificate secret (from cert-manager or similar)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: synology-tls-cert
+  namespace: ingress
+type: kubernetes.io/tls
+data:
+  tls.key: <base64-encoded-key>
+  tls.crt: <base64-encoded-full-chain>
+
+---
+# Synology credentials secret
+apiVersion: v1
+kind: Secret
+metadata:
+  name: synology-credentials
+  namespace: ingress
+type: Opaque
+stringData:
+  SYNO_HOSTNAME: "nas.example.com"
+  SYNO_PORT: "5001"
+  SYNO_SCHEME: "https"
+  SYNO_USERNAME: "cert-updater"
+  SYNO_PASSWORD: "your-secure-password"
+  SYNO_CERTIFICATE: "K8s Certificate"
+```
+
+### 2. Create ConfigMap with Script
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: synology-cert-deploy-script
+  namespace: ingress
+data:
+  synology-cert-deploy.sh: |
+    #!/bin/bash
+    # Paste the entire script content here
+```
+
+### 3. Create CronJob
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: synology-cert-updater
+  namespace: ingress
+spec:
+  # Run daily at 3 AM
+  schedule: "0 3 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: cert-updater
+            image: curlimages/curl:latest  # Minimal image with curl
+            command:
+            - /bin/sh
+            - -c
+            - |
+              # Install bash if not available
+              if ! command -v bash >/dev/null 2>&1; then
+                apk add --no-cache bash
+              fi
+              # Run the deployment script
+              bash /scripts/synology-cert-deploy.sh
+            env:
+            # Certificate file paths
+            - name: CERT_KEY_FILE
+              value: "/certs/tls.key"
+            - name: CERT_CERT_FILE
+              value: "/certs/tls.crt"
+            # Import all Synology configuration from secret
+            envFrom:
+            - secretRef:
+                name: synology-credentials
+            volumeMounts:
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+          volumes:
+          - name: certs
+            secret:
+              secretName: synology-tls-cert
+          - name: script
+            configMap:
+              name: synology-cert-deploy-script
+              defaultMode: 0755
+```
+
+## Manual Testing
+
+Test the script manually before deploying to Kubernetes:
+
+```bash
+# Set required environment variables
+export SYNO_HOSTNAME="nas.example.com"
+export SYNO_USERNAME="admin"
+export SYNO_PASSWORD="your-password"
+export SYNO_PORT="5001"
+export SYNO_SCHEME="https"
+export SYNO_CERTIFICATE="Test Certificate"
+
+# Set certificate file paths
+export CERT_KEY_FILE="/path/to/tls.key"
+export CERT_CERT_FILE="/path/to/tls.crt"
+
+# Optional: Enable debug output
+export DEBUG="1"
+
+# Run the script
+./synology-cert-deploy.sh
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Authentication failure |
+| 2 | Certificate file error |
+| 3 | API error |
+| 4 | Configuration error |
+
+## Troubleshooting
+
+### Enable Debug Logging
+```bash
+export DEBUG="1"
+```
+
+### Common Issues
+
+1. **"Authentication failed: 2FA is enabled"**
+   - Solution: Disable 2FA for the service account or create a dedicated user without 2FA
+
+2. **"Insufficient permissions: User must be administrator"**
+   - Solution: Ensure the user is in the administrators group
+
+3. **"Failed to connect to Synology DSM API"**
+   - Check network connectivity
+   - Verify `SYNO_HOSTNAME` and `SYNO_PORT`
+   - Check if firewall allows connections
+
+4. **SSL/TLS errors**
+   - The script uses `-k` (insecure) flag for curl to skip certificate verification
+   - For production, consider using proper CA certificates
+
+## Security Considerations
+
+- Store credentials in Kubernetes Secrets, never in ConfigMaps or code
+- Use RBAC to restrict access to the secrets
+- Consider using external secret management (e.g., Sealed Secrets, External Secrets Operator)
+- Use HTTPS (`SYNO_SCHEME="https"`) when possible
+- Create a dedicated service account without 2FA for certificate updates
+- Limit network access to the Synology DSM API
+
+## Integration with Cert-Manager
+
+If using cert-manager, the certificate secret is automatically updated. The cronjob will detect changes and push them to Synology DSM.
+
+Example cert-manager Certificate resource:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: synology-cert
+  namespace: ingress
+spec:
+  secretName: synology-tls-cert
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+  - nas.example.com
+  - "*.example.com"
+```
+
+The cronjob will automatically pick up the renewed certificate and deploy it to Synology DSM.

--- a/services/ingress/assets/synology-cert-deploy.sh
+++ b/services/ingress/assets/synology-cert-deploy.sh
@@ -1,0 +1,433 @@
+#!/bin/bash
+
+################################################################################
+# Standalone Synology DSM Certificate Deployment Script
+################################################################################
+# A pure bash/curl implementation for uploading certificates to Synology DSM
+# Designed to run in Kubernetes cronjobs without acme.sh dependencies
+#
+# Environment Variables:
+#   Required:
+#     SYNO_HOSTNAME       - Synology hostname or IP
+#     SYNO_USERNAME       - Admin username
+#     SYNO_PASSWORD       - Admin password
+#     CERT_KEY_FILE       - Path to certificate private key
+#     CERT_CERT_FILE      - Path to certificate file (full chain from cert-manager)
+#
+#   Optional:
+#     SYNO_PORT           - API port (default: 5000)
+#     SYNO_SCHEME         - http or https (default: http)
+#     SYNO_CERTIFICATE    - Certificate description to update/create (default: empty)
+#     CERT_CA_FILE        - Path to separate CA file (optional, uses CERT_CERT_FILE if not set)
+#     DEBUG               - Set to "1" for verbose output
+#
+# Exit Codes:
+#   0 - Success
+#   1 - Authentication failure
+#   2 - Certificate file error
+#   3 - API error
+#   4 - Configuration error
+################################################################################
+
+set -eo pipefail
+
+# Color output helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $*" >&2
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $*" >&2
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+log_debug() {
+    if [ "${DEBUG:-0}" = "1" ]; then
+        echo -e "[DEBUG] $*" >&2
+    fi
+}
+
+# URL encode function
+url_encode() {
+    local string="$1"
+    local strlen=${#string}
+    local encoded=""
+    local pos c o
+
+    for (( pos=0 ; pos<strlen ; pos++ )); do
+        c=${string:$pos:1}
+        case "$c" in
+            [-_.~a-zA-Z0-9] ) o="${c}" ;;
+            * ) printf -v o '%%%02x' "'$c"
+        esac
+        encoded+="${o}"
+    done
+    echo "${encoded}"
+}
+
+# Validate required files
+validate_files() {
+    local missing=0
+
+    if [ -z "${CERT_KEY_FILE}" ] || [ ! -f "${CERT_KEY_FILE}" ]; then
+        log_error "Certificate key file not found: ${CERT_KEY_FILE}"
+        missing=1
+    fi
+
+    if [ -z "${CERT_CERT_FILE}" ] || [ ! -f "${CERT_CERT_FILE}" ]; then
+        log_error "Certificate file not found: ${CERT_CERT_FILE}"
+        missing=1
+    fi
+
+    # CA file is optional - if not provided, use the cert file (which should be full chain)
+    if [ -n "${CERT_CA_FILE}" ] && [ ! -f "${CERT_CA_FILE}" ]; then
+        log_error "CA certificate file specified but not found: ${CERT_CA_FILE}"
+        missing=1
+    fi
+
+    if [ $missing -eq 1 ]; then
+        return 2
+    fi
+}
+
+# Validate required configuration
+validate_config() {
+    if [ -z "${SYNO_USERNAME}" ] || [ -z "${SYNO_PASSWORD}" ]; then
+        log_error "SYNO_USERNAME and SYNO_PASSWORD must be set"
+        return 4
+    fi
+
+    if [ -z "${SYNO_HOSTNAME}" ]; then
+        log_error "SYNO_HOSTNAME must be set"
+        return 4
+    fi
+}
+
+# Get API info
+get_api_info() {
+    local base_url="$1"
+    local response
+
+    log_info "Discovering Synology DSM API information..."
+    response=$(curl -sk "${base_url}/webapi/query.cgi?api=SYNO.API.Info&version=1&method=query&query=SYNO.API.Auth" 2>&1)
+
+    if [ $? -ne 0 ]; then
+        log_error "Failed to connect to Synology DSM API"
+        log_debug "Response: ${response}"
+        return 3
+    fi
+
+    api_path=$(echo "${response}" | grep -o '"SYNO.API.Auth"[^}]*' | grep -o '"path":"[^"]*"' | cut -d'"' -f4)
+    api_version=$(echo "${response}" | grep -o '"SYNO.API.Auth"[^}]*' | grep -o '"maxVersion":[0-9]*' | grep -o '[0-9]*')
+
+    log_debug "API Path: ${api_path}"
+    log_debug "API Version: ${api_version}"
+
+    if [ -z "${api_path}" ] || [ -z "${api_version}" ]; then
+        log_error "Failed to discover API information"
+        log_debug "Response: ${response}"
+        return 3
+    fi
+
+    echo "${api_path}|${api_version}"
+}
+
+# Login to DSM
+login() {
+    local base_url="$1"
+    local api_path="$2"
+    local api_version="$3"
+    local encoded_username encoded_password
+    local response error_code
+
+    encoded_username=$(url_encode "${SYNO_USERNAME}")
+    encoded_password=$(url_encode "${SYNO_PASSWORD}")
+
+    log_info "Authenticating to Synology DSM at ${SYNO_HOSTNAME}:${SYNO_PORT}..."
+
+    response=$(curl -sk "${base_url}/webapi/${api_path}?api=SYNO.API.Auth&version=${api_version}&method=login&format=sid&account=${encoded_username}&passwd=${encoded_password}&enable_syno_token=yes" 2>&1)
+
+    log_debug "Login response: ${response}"
+
+    error_code=$(echo "${response}" | grep -o '"code":[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    # Check for errors
+    if [ -n "${error_code}" ]; then
+        case "${error_code}" in
+            400)
+                log_error "Authentication failed: Invalid username or password"
+                ;;
+            401)
+                log_error "Authentication failed: Account does not exist"
+                ;;
+            403)
+                log_error "Authentication failed: 2FA is enabled - please disable 2FA for this account"
+                ;;
+            406)
+                log_error "Authentication failed: 2FA required but not configured"
+                ;;
+            408|409|410)
+                log_error "Authentication failed: Password expired or must be changed"
+                ;;
+            *)
+                log_error "Authentication failed with error code: ${error_code}"
+                ;;
+        esac
+        return 1
+    fi
+
+    # Extract session ID and token
+    local sid token
+    sid=$(echo "${response}" | grep -o '"sid":"[^"]*"' | cut -d'"' -f4)
+    token=$(echo "${response}" | grep -o '"synotoken":"[^"]*"' | cut -d'"' -f4)
+
+    if [ -z "${sid}" ] || [ -z "${token}" ]; then
+        log_error "Failed to obtain session ID and token"
+        log_debug "Response: ${response}"
+        return 1
+    fi
+
+    log_info "Authentication successful"
+    log_debug "Session ID: ${sid}"
+    log_debug "Token: ${token}"
+
+    echo "${sid}|${token}"
+}
+
+# Logout from DSM
+logout() {
+    local base_url="$1"
+    local api_path="$2"
+    local api_version="$3"
+    local sid="$4"
+
+    log_debug "Logging out..."
+    curl -sk "${base_url}/webapi/${api_path}?api=SYNO.API.Auth&version=${api_version}&method=logout&_sid=${sid}" >/dev/null 2>&1 || true
+}
+
+# Get certificate list and find ID
+get_certificate_id() {
+    local base_url="$1"
+    local sid="$2"
+    local token="$3"
+    local cert_desc="$4"
+    local response error_code
+
+    log_info "Fetching certificate list from Synology DSM..."
+    response=$(curl -sk -X POST \
+        -H "X-SYNO-TOKEN: ${token}" \
+        "${base_url}/webapi/entry.cgi" \
+        -d "api=SYNO.Core.Certificate.CRT&method=list&version=1&_sid=${sid}" 2>&1)
+
+    log_debug "Certificate list response: ${response}"
+
+    error_code=$(echo "${response}" | grep -o '"code":[0-9]*' | head -1 | grep -o '[0-9]*')
+
+    if [ -n "${error_code}" ]; then
+        if [ "${error_code}" = "105" ]; then
+            log_error "Insufficient permissions: User must be administrator"
+        else
+            log_error "Failed to fetch certificate list (error code: ${error_code})"
+        fi
+        return 3
+    fi
+
+    # Escape certificate description for grep
+    local escaped_desc
+    escaped_desc=$(echo "${cert_desc}" | sed 's/[]\/$*.^[]/\\&/g' | sed 's/"/\\"/g')
+
+    # Try to find certificate ID by description
+    local cert_id is_default
+    cert_id=$(echo "${response}" | grep -o "\"desc\":\"${escaped_desc}\"[^}]*\"id\":\"[^\"]*\"" | grep -o '"id":"[^"]*"' | cut -d'"' -f4)
+
+    if [ -n "${cert_id}" ]; then
+        log_info "Found existing certificate: ${cert_desc} (ID: ${cert_id})"
+
+        # Check if it's the default certificate
+        is_default=$(echo "${response}" | grep -o "\"desc\":\"${escaped_desc}\"[^}]*\"is_default\":true" || echo "")
+
+        echo "${cert_id}|${is_default}"
+    else
+        log_info "Certificate '${cert_desc}' not found - will create new one"
+        echo "|"
+    fi
+}
+
+# Split certificate chain into server cert and intermediate certs
+split_certificate_chain() {
+    local cert_file="$1"
+    local output_type="$2"  # "server" or "intermediate"
+
+    # Read the full certificate chain
+    local cert_content
+    cert_content=$(cat "${cert_file}")
+
+    if [ "${output_type}" = "server" ]; then
+        # Extract first certificate (server certificate)
+        echo "${cert_content}" | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/ {print; if (/-----END CERTIFICATE-----/) exit}'
+    else
+        # Extract everything after the first certificate (intermediate/CA chain)
+        echo "${cert_content}" | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/ {if (found) print} /-----END CERTIFICATE-----/ {found=1}'
+    fi
+}
+
+# Upload certificate to DSM
+upload_certificate() {
+    local base_url="$1"
+    local sid="$2"
+    local token="$3"
+    local cert_id="$4"
+    local cert_desc="$5"
+    local is_default="$6"
+    local response
+
+    log_info "Preparing certificate upload..."
+
+    # Generate boundary for multipart form data
+    local boundary="----WebKitFormBoundary$(date +%s)$(( RANDOM ))"
+    local nl=$'\r\n'
+
+    # Build multipart form data
+    local form_data=""
+
+    # Add key file
+    form_data+="--${boundary}${nl}"
+    form_data+="Content-Disposition: form-data; name=\"key\"; filename=\"$(basename "${CERT_KEY_FILE}")\"${nl}"
+    form_data+="Content-Type: application/octet-stream${nl}${nl}"
+    form_data+="$(cat "${CERT_KEY_FILE}")${nl}"
+
+    # Split certificate chain and add server certificate
+    local server_cert intermediate_cert
+    if [ -n "${CERT_CA_FILE}" ]; then
+        # If CA file provided separately, use cert file as-is
+        server_cert=$(cat "${CERT_CERT_FILE}")
+        intermediate_cert=$(cat "${CERT_CA_FILE}")
+    else
+        # Split the full chain from cert-manager
+        log_debug "Splitting certificate chain from ${CERT_CERT_FILE}"
+        server_cert=$(split_certificate_chain "${CERT_CERT_FILE}" "server")
+        intermediate_cert=$(split_certificate_chain "${CERT_CERT_FILE}" "intermediate")
+    fi
+
+    # Add server certificate
+    form_data+="--${boundary}${nl}"
+    form_data+="Content-Disposition: form-data; name=\"cert\"; filename=\"cert.pem\"${nl}"
+    form_data+="Content-Type: application/octet-stream${nl}${nl}"
+    form_data+="${server_cert}${nl}"
+
+    # Add intermediate/CA certificates
+    form_data+="--${boundary}${nl}"
+    form_data+="Content-Disposition: form-data; name=\"inter_cert\"; filename=\"chain.pem\"${nl}"
+    form_data+="Content-Type: application/octet-stream${nl}${nl}"
+    form_data+="${intermediate_cert}${nl}"
+
+    # Add certificate ID
+    form_data+="--${boundary}${nl}"
+    form_data+="Content-Disposition: form-data; name=\"id\"${nl}${nl}"
+    form_data+="${cert_id}${nl}"
+
+    # Add certificate description
+    form_data+="--${boundary}${nl}"
+    form_data+="Content-Disposition: form-data; name=\"desc\"${nl}${nl}"
+    form_data+="${cert_desc}${nl}"
+
+    # Add as_default if this was the default certificate
+    if [ -n "${is_default}" ]; then
+        form_data+="--${boundary}${nl}"
+        form_data+="Content-Disposition: form-data; name=\"as_default\"${nl}${nl}"
+        form_data+="true${nl}"
+    fi
+
+    form_data+="--${boundary}--${nl}"
+
+    log_info "Uploading certificate to Synology DSM..."
+    response=$(curl -sk -X POST \
+        -H "X-SYNO-TOKEN: ${token}" \
+        -H "Content-Type: multipart/form-data; boundary=${boundary}" \
+        --data-binary "${form_data}" \
+        "${base_url}/webapi/entry.cgi?api=SYNO.Core.Certificate&method=import&version=1&SynoToken=${token}&_sid=${sid}" 2>&1)
+
+    log_debug "Upload response: ${response}"
+
+    # Check for errors
+    if echo "${response}" | grep -q '"error":'; then
+        log_error "Failed to upload certificate"
+        log_debug "Response: ${response}"
+        return 3
+    fi
+
+    # Check if HTTP services need restart
+    if echo "${response}" | grep -q '"restart_httpd":true'; then
+        log_info "Certificate uploaded successfully - HTTP services will restart"
+    else
+        log_info "Certificate uploaded successfully"
+    fi
+
+    return 0
+}
+
+# Main execution
+main() {
+    log_info "Starting Synology DSM certificate deployment"
+
+    # Set defaults
+    SYNO_SCHEME="${SYNO_SCHEME:-http}"
+    SYNO_HOSTNAME="${SYNO_HOSTNAME:-localhost}"
+    SYNO_PORT="${SYNO_PORT:-5000}"
+    SYNO_CERTIFICATE="${SYNO_CERTIFICATE:-}"
+
+    # Validate configuration
+    validate_config || return $?
+    validate_files || return $?
+
+    # Build base URL
+    local base_url="${SYNO_SCHEME}://${SYNO_HOSTNAME}:${SYNO_PORT}"
+    log_debug "Base URL: ${base_url}"
+
+    # Get API information
+    local api_info api_path api_version
+    api_info=$(get_api_info "${base_url}") || return $?
+    api_path=$(echo "${api_info}" | cut -d'|' -f1)
+    api_version=$(echo "${api_info}" | cut -d'|' -f2)
+
+    # Login
+    local auth_info sid token
+    auth_info=$(login "${base_url}" "${api_path}" "${api_version}") || return $?
+    sid=$(echo "${auth_info}" | cut -d'|' -f1)
+    token=$(echo "${auth_info}" | cut -d'|' -f2)
+
+    # Get certificate ID (if description provided)
+    local cert_id="" is_default=""
+    if [ -n "${SYNO_CERTIFICATE}" ]; then
+        local cert_info
+        cert_info=$(get_certificate_id "${base_url}" "${sid}" "${token}" "${SYNO_CERTIFICATE}")
+        cert_id=$(echo "${cert_info}" | cut -d'|' -f1)
+        is_default=$(echo "${cert_info}" | cut -d'|' -f2)
+    fi
+
+    # Upload certificate (will create if cert_id is empty)
+    upload_certificate "${base_url}" "${sid}" "${token}" "${cert_id}" "${SYNO_CERTIFICATE}" "${is_default}"
+    local upload_result=$?
+
+    # Logout
+    logout "${base_url}" "${api_path}" "${api_version}" "${sid}"
+
+    if [ ${upload_result} -eq 0 ]; then
+        log_info "Certificate deployment completed successfully"
+        return 0
+    else
+        log_error "Certificate deployment failed"
+        return ${upload_result}
+    fi
+}
+
+# Run main function
+main "$@"

--- a/services/ingress/ingress/acme.py
+++ b/services/ingress/ingress/acme.py
@@ -1,0 +1,194 @@
+"""
+Installs acme on synology NAS.
+
+Synology has native support for acme through their DSM interface, but it
+doesn't support DNS-01 challenges which requires to forward port 80 to the
+NAS. This is not acceptable for security reasons.
+"""
+
+import pathlib
+
+import pulumi as p
+import pulumi_kubernetes as k8s
+
+from ingress.config import ComponentConfig
+
+
+class AcmeSynology(p.ComponentResource):
+    @staticmethod
+    def _hostname_to_secret_name(hostname: str) -> str:
+        """Convert hostname to a valid Kubernetes secret name."""
+        # Replace * with wildcard, remove dots
+        return hostname.replace('*', 'wildcard').replace('.', '-') + '-tls'
+
+    def __init__(
+        self,
+        name: str,
+        component_config: ComponentConfig,
+        k8s_provider: k8s.Provider,
+    ):
+        super().__init__(
+            f'lab:ingress:AcmeSynology:{name}', name, opts=p.ResourceOptions(provider=k8s_provider)
+        )
+
+        if not component_config.synology:
+            return
+
+        synology_config = component_config.synology
+
+        # Create namespace
+        namespace = k8s.core.v1.Namespace(
+            'synology-certs-namespace',
+            metadata={'name': 'synology-certs'},
+            opts=p.ResourceOptions(parent=self, provider=k8s_provider),
+        )
+
+        # Read the deployment script
+        script_path = pathlib.Path(__file__).parent.parent / 'assets' / 'synology-cert-deploy.sh'
+        script_content = script_path.read_text()
+
+        # Create ConfigMap with the deployment script
+        script_configmap = k8s.core.v1.ConfigMap(
+            'synology-deploy-script',
+            metadata={
+                'name': 'synology-cert-deploy-script',
+                'namespace': namespace.metadata.name,
+            },
+            data={'synology-cert-deploy.sh': script_content},
+            opts=p.ResourceOptions(parent=namespace, provider=k8s_provider),
+        )
+
+        # Create Secret with Synology credentials
+        credentials_secret = k8s.core.v1.Secret(
+            'synology-credentials',
+            metadata={
+                'name': 'synology-credentials',
+                'namespace': namespace.metadata.name,
+            },
+            string_data={
+                'SYNO_HOSTNAME': synology_config.host,
+                'SYNO_PORT': str(synology_config.port),
+                'SYNO_SCHEME': synology_config.scheme,
+                'SYNO_USERNAME': synology_config.username.value,
+                'SYNO_PASSWORD': synology_config.password.value,
+            },
+            opts=p.ResourceOptions(parent=namespace, provider=k8s_provider),
+        )
+
+        # Create a CronJob for each certificate
+        for cert in synology_config.certs:
+            self._create_cert_cronjob(
+                cert=cert,
+                namespace=namespace,
+                script_configmap=script_configmap,
+                credentials_secret=credentials_secret,
+                k8s_provider=k8s_provider,
+            )
+
+    def _create_cert_cronjob(
+        self,
+        cert,
+        namespace: k8s.core.v1.Namespace,
+        script_configmap: k8s.core.v1.ConfigMap,
+        credentials_secret: k8s.core.v1.Secret,
+        k8s_provider: k8s.Provider,
+    ):
+        """Create a Certificate and CronJob for deploying a single certificate to Synology."""
+        # Sanitize hostname for resource name
+        sanitized_name = cert.hostname.replace('.', '-').replace('*', 'wildcard')
+        secret_name = self._hostname_to_secret_name(cert.hostname)
+
+        # Create cert-manager Certificate resource
+        k8s.apiextensions.CustomResource(
+            f'cert-{sanitized_name}',
+            api_version='cert-manager.io/v1',
+            kind='Certificate',
+            metadata={
+                'name': f'cert-{sanitized_name}',
+                'namespace': namespace.metadata.name,
+            },
+            spec={
+                'secretName': secret_name,
+                'issuerRef': {
+                    'name': 'lets-encrypt',
+                    'kind': 'ClusterIssuer',
+                },
+                'dnsNames': [cert.hostname],
+            },
+            opts=p.ResourceOptions(parent=namespace, provider=k8s_provider),
+        )
+
+        k8s.batch.v1.CronJob(
+            f'synology-cert-{sanitized_name}',
+            metadata={
+                'name': f'synology-cert-{sanitized_name}',
+                'namespace': namespace.metadata.name,
+            },
+            spec={
+                # Run daily at 11:55 PM (before Synology nginx reload at midnight)
+                'schedule': '55 23 * * *',
+                'successful_jobs_history_limit': 3,
+                'failed_jobs_history_limit': 3,
+                'job_template': {
+                    'spec': {
+                        'template': {
+                            'spec': {
+                                'restart_policy': 'OnFailure',
+                                'containers': [
+                                    {
+                                        'name': 'cert-updater',
+                                        'image': 'buildpack-deps:bookworm-curl',
+                                        'command': [
+                                            '/bin/bash',
+                                            '/scripts/synology-cert-deploy.sh',
+                                        ],
+                                        'env': [
+                                            {'name': 'CERT_KEY_FILE', 'value': '/certs/tls.key'},
+                                            {'name': 'CERT_CERT_FILE', 'value': '/certs/tls.crt'},
+                                            {'name': 'SYNO_CERTIFICATE', 'value': cert.hostname},
+                                        ],
+                                        'env_from': [
+                                            {
+                                                'secret_ref': {
+                                                    'name': credentials_secret.metadata.name,
+                                                },
+                                            },
+                                        ],
+                                        'volume_mounts': [
+                                            {
+                                                'name': 'certs',
+                                                'mount_path': '/certs',
+                                                'read_only': True,
+                                            },
+                                            {
+                                                'name': 'script',
+                                                'mount_path': '/scripts',
+                                                'read_only': True,
+                                            },
+                                        ],
+                                    },
+                                ],
+                                'volumes': [
+                                    {
+                                        'name': 'certs',
+                                        'secret': {
+                                            'secret_name': self._hostname_to_secret_name(
+                                                cert.hostname
+                                            )
+                                        },
+                                    },
+                                    {
+                                        'name': 'script',
+                                        'config_map': {
+                                            'name': script_configmap.metadata.name,
+                                            'default_mode': 0o755,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+            opts=p.ResourceOptions(parent=namespace, provider=k8s_provider),
+        )

--- a/services/ingress/ingress/config.py
+++ b/services/ingress/ingress/config.py
@@ -1,6 +1,19 @@
 import utils.model
 
 
+class SynologyCertConfig(utils.model.LocalBaseModel):
+    hostname: str
+
+
+class SynologyConfig(utils.model.LocalBaseModel):
+    host: str
+    port: int = 5000
+    scheme: str = 'http'
+    username: utils.model.OnePasswordRef
+    password: utils.model.OnePasswordRef
+    certs: list[SynologyCertConfig] = []
+
+
 class CloudflareIngressConfig(utils.model.LocalBaseModel):
     service: str
     hostname: str
@@ -15,6 +28,7 @@ class CloudflaredConfig(utils.model.LocalBaseModel):
 class ComponentConfig(utils.model.LocalBaseModel):
     cloudflare: utils.model.CloudflareConfig
     cloudflared: CloudflaredConfig
+    synology: SynologyConfig | None = None
 
 
 class StackConfig(utils.model.LocalBaseModel):


### PR DESCRIPTION
The synology has no built-in support for the DNS-01 challenge and
therefore requires port 80 forwarded to it. This is a serious security
threat so instead we'll manage its certs via the cert-manager which
already is configured for DNS-01 challenge via cloudflare. All we need
is a CronJob which updates the certs using the synology api.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Synology NAS integration with automated daily TLS certificate deployment via Kubernetes CronJob scheduling.

* **Documentation**
  * Complete deployment guides for Synology certificate management, including setup prerequisites, configuration examples, troubleshooting steps, and security considerations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->