### PR TITLE
Fix garmin credential path

### DIFF
--- a/services/strava-sensor/strava_sensor/strava_sensor.py
+++ b/services/strava-sensor/strava_sensor/strava_sensor.py
@@ -8,7 +8,7 @@ STRAVA_SENSOR_STATE_PATH = '/app/local_state'
 STRAVA_SENSOR_LAST_ACTIVITY_METADATA_PATH = (
     f'{STRAVA_SENSOR_STATE_PATH}/strava_sensor_last_activity.json'
 )
-GARMIN_TOKENS_PATH = f'{STRAVA_SENSOR_STATE_PATH}/garminconnect'
+GARMIN_TOKENS_PATH = f'{STRAVA_SENSOR_STATE_PATH}/.garminconnect'
 ALLOY_OTEL_GRPC_ENDPOINT = 'http://alloy.alloy.cluster.svc.local:4317'
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Garmin token storage path to use a hidden configuration directory, ensuring proper token file organization and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->