### PR TITLE
fix(monitoring): add honor_labels=true for kube-state-metrics scrape

### DIFF
--- a/services/monitoring/assets/alloy/collect_prometheus.alloy
+++ b/services/monitoring/assets/alloy/collect_prometheus.alloy
@@ -5,7 +5,6 @@
 prometheus.scrape "default" {
 	targets = array.concat(
 		discovery.relabel.blackbox.output,
-		discovery.relabel.kube_state_metrics.output,
 		discovery.relabel.pods_metrics_with_port.output,
 		discovery.relabel.pods_metrics_without_port.output,
 		discovery.relabel.static.output,
@@ -15,6 +14,17 @@ prometheus.scrape "default" {
 	)
 
 	scrape_interval = "15s"
+	forward_to      = [otelcol.receiver.prometheus.default.receiver]
+}
+
+// kube-state-metrics needs honor_labels = true so that the real pod/resource
+// namespace (e.g. "immich") is preserved instead of being overwritten by the
+// KSM service's own namespace ("kube-state-metrics").
+prometheus.scrape "kube_state_metrics" {
+	targets = discovery.relabel.kube_state_metrics.output
+
+	scrape_interval = "15s"
+	honor_labels    = true
 	forward_to      = [otelcol.receiver.prometheus.default.receiver]
 }
 


### PR DESCRIPTION
KSM metrics carry a namespace label reflecting the actual pod namespace (e.g. `immich`). Without `honor_labels = true`, Prometheus overwrites that label with the KSM service's own namespace (`kube-state-metrics`) and renames the original value to `exported_namespace`.

This breaks any tool that filters kube-state-metrics series by namespace. Most notably, KRR (Kubernetes Resource Recommender) queries `kube_pod_owner{namespace="immich"}` and gets zero results, causing every recommendation to show `?` / "No data":

```
# Before fix – namespace label on all KSM metrics
namespace="kube-state-metrics", exported_namespace="immich"

# After fix – real namespace preserved
namespace="immich"
```

The fix moves kube-state-metrics to its own `prometheus.scrape` block with `honor_labels = true`, leaving all other scrape targets unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Prometheus monitoring configuration for kube-state-metrics collection. Created a dedicated scrape job to improve namespace label preservation during metric collection, with an optimized 15-second scrape interval for enhanced monitoring consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->