### PR TITLE
feat(monitoring): apply krr resource rightsizing

### DIFF
--- a/.agents/skills/container-rightsizing/SKILL.md
+++ b/.agents/skills/container-rightsizing/SKILL.md
@@ -63,6 +63,18 @@ The `-q` flag suppresses verbose output. krr uses 336 hours of history by defaul
 - **CPU Requests**: 95th percentile of CPU usage
 - **Memory Requests / Limits**: max observed usage + 15% buffer
 
+If the output appears truncated (rows cut off, incomplete table), re-run with CSV output instead:
+
+```bash
+krr simple -p https://mimir.tobiash.net/prometheus -n <namespace> -q -f csv
+```
+
+CSV output is never truncated and is easier to parse programmatically.
+
+> **NEVER use `--format json` / `-f json`** — JSON output includes full time-series data for every
+> container and produces tens of thousands of lines, consuming excessive context and making the
+> output impossible to work with. Always use the default table format or `-f csv`.
+
 If krr returns `?` or "No data" for every workload in a namespace, the namespace is almost
 certainly **wrong**. Go back to Step 1 and re-inspect the service code.
 

--- a/services/monitoring/Pulumi.prod.yaml
+++ b/services/monitoring/Pulumi.prod.yaml
@@ -18,6 +18,9 @@ config:
       # renovate: datasource=github-releases packageName=grafana/alloy versioning=semver
       version: v1.13.1
       hostname: alloy.tobiash.net
+      resources:
+        cpu: 77m
+        memory: 508Mi
     cloudflare:
       email: tobias_henkel@gmx.de
       api-key:
@@ -31,25 +34,47 @@ config:
       # renovate: datasource=github-releases packageName=grafana/grafana versioning=semver
       version: 12.3.3
       hostname: grafana.tobiash.net
+      resources:
+        cpu: 10m
+        memory: 498Mi
     goldilocks:
       # renovate: datasource=helm packageName=goldilocks registryUrl=https://charts.fairwinds.com/stable
       version: 10.2.0
       hostname: goldilocks.tobiash.net
+      resources:
+        controller:
+          cpu: 10m
+          memory: 100Mi
+        dashboard:
+          cpu: 10m
+          memory: 100Mi
     mimir:
       # renovate: datasource=github-releases packageName=grafana/mimir extractVersion=^mimir-(?<version>.*)$ versioning=semver
       version: 3.0.3
+      resources:
+        cpu: 33m
+        memory: 679Mi
     node-exporter:
       # renovate: datasource=github-releases packageName=prometheus/node_exporter versioning=loose
       version: 1.10.2
+      resources:
+        cpu: 10m
+        memory: 100Mi
     kube-state-metrics:
       # renovate: datasource=github-releases packageName=prometheus-community/helm-charts extractVersion=^kube-state-metrics-(?<version>.*)$ versioning=semver
       version: 7.1.0
+      resources:
+        cpu: 10m
+        memory: 100Mi
     prometheus-operator-crds:
       # renovate: datasource=github-releases packageName=prometheus-community/helm-charts extractVersion=^prometheus-operator-crds-(?<version>.*)$ versioning=semver
       version: 27.0.0
     speedtest-exporter:
       # renovate: datasource=github-releases packageName=billimek/prometheus-speedtest-exporter versioning=semver
       version: 1.3.1
+      resources:
+        cpu: 10m
+        memory: 100Mi
     adguard-exporter:
       # renovate: datasource=github-releases packageName=henrywhitaker3/adguard-exporter extractVersion=^v(?<version>.*)$ versioning=semver
       version: 1.2.1
@@ -58,3 +83,6 @@ config:
         ref: op://Pulumi/Adguard Home/username
       password:
         ref: op://Pulumi/Adguard Home/password
+      resources:
+        cpu: 10m
+        memory: 100Mi

--- a/services/monitoring/monitoring/adguard_exporter.py
+++ b/services/monitoring/monitoring/adguard_exporter.py
@@ -88,6 +88,7 @@ class AdGuardExporter(p.ComponentResource):
                                         },
                                     },
                                 ],
+                                'resources': component_config.adguard_exporter.resources.to_resource_requirements(),
                             },
                         ],
                     },

--- a/services/monitoring/monitoring/alloy.py
+++ b/services/monitoring/monitoring/alloy.py
@@ -267,14 +267,7 @@ class Alloy(p.ComponentResource):
                                         'read_only': True,
                                     },
                                 ],
-                                'resources': {
-                                    'requests': {
-                                        'memory': '256Mi',
-                                    },
-                                    'limits': {
-                                        'memory': '512Mi',
-                                    },
-                                },
+                                'resources': component_config.alloy.resources.to_resource_requirements(),
                                 'readiness_probe': {
                                     'http_get': {
                                         'path': '/-/ready',

--- a/services/monitoring/monitoring/config.py
+++ b/services/monitoring/monitoring/config.py
@@ -8,6 +8,7 @@ class AlloyLegacyConfig(utils.model.LocalBaseModel):
 class AlloyConfig(utils.model.LocalBaseModel):
     version: str
     hostname: str | None = None
+    resources: utils.model.ResourcesConfig
 
 
 class GrafanaCloudConfig(utils.model.LocalBaseModel):
@@ -21,16 +22,18 @@ class CAdvisorConfig(utils.model.LocalBaseModel):
 
 class GrafanaConfig(utils.model.LocalBaseModel):
     version: str
-
     hostname: str
+    resources: utils.model.ResourcesConfig
 
 
 class MimirConfig(utils.model.LocalBaseModel):
     version: str
+    resources: utils.model.ResourcesConfig
 
 
 class SpeedtestExporterConfig(utils.model.LocalBaseModel):
     version: str
+    resources: utils.model.ResourcesConfig
 
 
 class AdGuardExporterConfig(utils.model.LocalBaseModel):
@@ -38,23 +41,32 @@ class AdGuardExporterConfig(utils.model.LocalBaseModel):
     server: str
     username: utils.model.OnePasswordRef
     password: utils.model.OnePasswordRef
+    resources: utils.model.ResourcesConfig
 
 
 class PrometheusOperatorCrdsConfig(utils.model.LocalBaseModel):
     version: str
 
 
+class GoldilocksResourcesConfig(utils.model.LocalBaseModel):
+    controller: utils.model.ResourcesConfig
+    dashboard: utils.model.ResourcesConfig
+
+
 class GoldilocksConfig(utils.model.LocalBaseModel):
     version: str
     hostname: str
+    resources: GoldilocksResourcesConfig
 
 
 class NodeExporterConfig(utils.model.LocalBaseModel):
     version: str
+    resources: utils.model.ResourcesConfig
 
 
 class KubeStateMetricsConfig(utils.model.LocalBaseModel):
     version: str
+    resources: utils.model.ResourcesConfig
 
 
 class ComponentConfig(utils.model.LocalBaseModel):

--- a/services/monitoring/monitoring/goldilocks.py
+++ b/services/monitoring/monitoring/goldilocks.py
@@ -29,11 +29,15 @@ class Goldilocks(p.ComponentResource):
             namespace=namespace.metadata.name,
             repository_opts={'repo': 'https://charts.fairwinds.com/stable'},
             values={
+                'controller': {
+                    'resources': component_config.goldilocks.resources.controller.to_resource_requirements(),
+                },
                 'dashboard': {
                     'replicaCount': 1,
                     'flags': {
                         'enable-cost': False,
                     },
+                    'resources': component_config.goldilocks.resources.dashboard.to_resource_requirements(),
                 },
             },
             opts=k8s_opts,

--- a/services/monitoring/monitoring/grafana.py
+++ b/services/monitoring/monitoring/grafana.py
@@ -172,6 +172,7 @@ class Grafana(p.ComponentResource):
                                         'mount_path': '/etc/grafana/certs',
                                     },
                                 ],
+                                'resources': component_config.grafana.resources.to_resource_requirements(),
                             },
                         ],
                         'readiness_probe': {

--- a/services/monitoring/monitoring/kube_state_metrics.py
+++ b/services/monitoring/monitoring/kube_state_metrics.py
@@ -22,5 +22,8 @@ def create_kube_state_metrics(component_config: ComponentConfig, k8s_provider: k
         version=component_config.kube_state_metrics.version,
         namespace=namespace.metadata.name,
         repository_opts={'repo': 'https://prometheus-community.github.io/helm-charts'},
+        values={
+            'resources': component_config.kube_state_metrics.resources.to_resource_requirements(),
+        },
         opts=p.ResourceOptions(provider=k8s_provider, depends_on=[namespace]),
     )

--- a/services/monitoring/monitoring/mimir.py
+++ b/services/monitoring/monitoring/mimir.py
@@ -158,12 +158,7 @@ class Mimir(p.ComponentResource):
                                         'read_only': True,
                                     },
                                 ],
-                                'resources': {
-                                    'requests': {
-                                        'memory': '2Gi',
-                                        'cpu': '500m',
-                                    },
-                                },
+                                'resources': component_config.mimir.resources.to_resource_requirements(),
                                 'security_context': {
                                     'allow_privilege_escalation': False,
                                     'read_only_root_filesystem': True,

--- a/services/monitoring/monitoring/node_exporter.py
+++ b/services/monitoring/monitoring/node_exporter.py
@@ -30,6 +30,7 @@ def create_node_exporter(component_config: ComponentConfig, k8s_provider: k8s.Pr
                 'prometheus.io/scrape': 'true',
                 'prometheus.io/port': '9100',
             },
+            'resources': component_config.node_exporter.resources.to_resource_requirements(),
         },
         opts=p.ResourceOptions(provider=k8s_provider, depends_on=[namespace]),
     )

--- a/services/monitoring/monitoring/speedtest.py
+++ b/services/monitoring/monitoring/speedtest.py
@@ -51,6 +51,7 @@ class SpeedtestExporter(p.ComponentResource):
                                         'container_port': SPEEDTEST_EXPORTER_PORT,
                                     },
                                 ],
+                                'resources': component_config.speedtest_exporter.resources.to_resource_requirements(),
                             },
                         ],
                     },


### PR DESCRIPTION
All monitoring service containers were either unset or had hardcoded resource values that no longer matched real-world usage. Running krr across all eight namespaces revealed significant over-provisioning in mimir and missing resources everywhere else.

krr recommendations (336 hours of history):

```
alloy:               77m CPU, 508Mi memory  (was: unset / 512Mi limit only)
grafana:             10m CPU, 498Mi memory  (was: fully unset)
mimir:               33m CPU, 679Mi memory  (was: 500m CPU / 2Gi — CRITICAL over-provision)
goldilocks:          10m CPU, 100Mi memory  (was: fully unset)
kube-state-metrics:  10m CPU, 100Mi memory  (was: fully unset)
speedtest-exporter:  10m CPU, 100Mi memory  (was: fully unset)
adguard-exporter:    10m CPU, 100Mi memory  (was: fully unset)
node-exporter:       10m CPU, 100Mi memory  (was: fully unset)
```

Each service config class gains a `resources: ResourcesConfig` field (or a nested `GoldilocksResourcesConfig` for the two-component goldilocks chart). Values are stored in Pulumi.prod.yaml as explicit config and passed through `to_resource_requirements()` into deployment/helm values. CPU limits are omitted per repo convention.