### PR TITLE
fix(paperless): reduce concurrency and increase memory to prevent OOM

### DIFF
--- a/services/paperless/Pulumi.prod.yaml
+++ b/services/paperless/Pulumi.prod.yaml
@@ -72,16 +72,16 @@ config:
     resources:
       paperless:
         cpu: 10m
-        memory: 1516Mi
+        memory: 2048Mi
       redis:
         cpu: 10m
         memory: 100Mi
       tika:
-        cpu: 34m
-        memory: 317Mi
+        cpu: 10m
+        memory: 233Mi
       gotenberg:
         cpu: 10m
-        memory: 247Mi
+        memory: 233Mi
       restic:
         cpu: 10m
         memory: 100Mi

--- a/services/paperless/paperless/paperless.py
+++ b/services/paperless/paperless/paperless.py
@@ -57,8 +57,8 @@ class Paperless(p.ComponentResource):
                 REDIS_PORT,
             ),
             'PAPERLESS_CONSUMER_POLLING': '30',
-            'PAPERLESS_TASK_WORKERS': '4',
-            'PAPERLESS_THREADS_PER_WORKER': '4',
+            'PAPERLESS_TASK_WORKERS': '2',
+            'PAPERLESS_THREADS_PER_WORKER': '1',
             # Extend the polling delay to account for HP bitch iteratively updating its PDFs after
             # scanning each page.
             'PAPERLESS_CONSUMER_POLLING_DELAY': '30',
@@ -105,7 +105,7 @@ class Paperless(p.ComponentResource):
                 'http://{}:{}', gotenberg_service.metadata.name, GOTENBERG_PORT
             ),
             'PAPERLESS_GMAIL_OAUTH_CLIENT_ID': component_config.mail.client_id,
-            'PAPERLESS_WEBSERVER_WORKERS': '4',
+            'PAPERLESS_WEBSERVER_WORKERS': '2',
         }
 
         config_secret = k8s.core.v1.Secret(


### PR DESCRIPTION
Paperless was repeatedly OOMKilled under normal document processing load — the pod restarted twice in under two minutes during a routine scanner upload session.

The root cause was high concurrency settings. With `PAPERLESS_TASK_WORKERS=4` and `PAPERLESS_THREADS_PER_WORKER=4`, paperless could run up to 16 concurrent OCR tasks plus 4 web server workers. When the scanner deposits several PDFs at once (which it does as each page finishes), all documents get queued simultaneously and OCR processes stack up:

```
[09:30:05] Adding tobi/20260403_083418.pdf to the task queue.
[09:30:05] Adding tobi/20260403_083443.pdf to the task queue.
[09:30:05] Adding dani/20260403_083457.pdf to the task queue.
[09:30:10] Start processing 4 pages concurrently   ← per document
```

Each OCR task (Tesseract + ocrmypdf) is memory-hungry on its own. Three documents × 4-page concurrent OCR, all running at the same time, easily breaches any reasonable memory ceiling.

**Two changes to fix this:**

Reduce concurrency so at most 2 OCR tasks run simultaneously:

```
PAPERLESS_TASK_WORKERS:       4 → 2
PAPERLESS_THREADS_PER_WORKER: 4 → 1   # 16 concurrent tasks → 2
PAPERLESS_WEBSERVER_WORKERS:  4 → 2
```

Increase the memory limit from 1516Mi to 2048Mi. The previous krr-recommended value of 1743Mi was still insufficient because the 336-hour usage history used by krr included many periods without heavy concurrent OCR — so the observed max didn't reflect burst behaviour.

Also applies fresh krr recommendations for tika (317Mi → 233Mi, cpu 34m → 10m) and gotenberg (247Mi → 233Mi).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Kubernetes resource allocation for Paperless services: increased primary service memory allocation while optimizing resource requests for supporting services.
  * Updated runtime concurrency configuration for improved performance stability across worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->