### PR TITLE
Add Paperless GPT integration with Ollama LLM support

### DIFF
--- a/services/paperless/Pulumi.prod.yaml
+++ b/services/paperless/Pulumi.prod.yaml
@@ -69,6 +69,12 @@ config:
     gotenberg:
       # renovate: datasource=github-releases packageName=gotenberg/gotenberg versioning=semver
       version: 8.29.0
+    paperless-gpt:
+      # renovate: datasource=github-releases packageName=icereed/paperless-gpt versioning=semver
+      version: 0.7.1
+      llm-model: gemma4
+      api-token:
+        ref: "op://Pulumi/Paperless GPT/api-token"
     resources:
       paperless:
         cpu: 10m
@@ -85,3 +91,6 @@ config:
       restic:
         cpu: 10m
         memory: 100Mi
+      paperless-gpt:
+        cpu: 10m
+        memory: 256Mi

--- a/services/paperless/paperless/config.py
+++ b/services/paperless/paperless/config.py
@@ -2,6 +2,12 @@ import pydantic
 import utils.model
 
 
+class PaperlessGptConfig(utils.model.LocalBaseModel):
+    version: str
+    llm_model: str = pydantic.Field(alias='llm-model', default='gemma4')
+    api_token: utils.model.OnePasswordRef = pydantic.Field(alias='api-token')
+
+
 class EntraIdConfig(utils.model.LocalBaseModel):
     tenant_id: str = 'ac1df362-04cf-4e6e-839b-031c16ada473'
     client_id: str
@@ -79,6 +85,7 @@ class PaperlessResourcesConfig(utils.model.LocalBaseModel):
     tika: utils.model.ResourcesConfig
     gotenberg: utils.model.ResourcesConfig
     restic: utils.model.ResourcesConfig
+    paperless_gpt: utils.model.ResourcesConfig = pydantic.Field(alias='paperless-gpt')
 
 
 class ComponentConfig(utils.model.LocalBaseModel):
@@ -93,6 +100,7 @@ class ComponentConfig(utils.model.LocalBaseModel):
     tika: TikaConfig
     gotenberg: GotenbergConfig
     resources: PaperlessResourcesConfig
+    paperless_gpt: PaperlessGptConfig = pydantic.Field(alias='paperless-gpt')
 
 
 class StackConfig(utils.model.LocalBaseModel):

--- a/services/paperless/paperless/paperless.py
+++ b/services/paperless/paperless/paperless.py
@@ -15,6 +15,8 @@ REDIS_PORT = 6379
 PAPERLESS_PORT = 8000
 TIKA_PORT = 9998
 GOTENBERG_PORT = 3000
+PAPERLESS_GPT_PORT = 8080
+OLLAMA_PORT = 11434
 
 
 class Paperless(p.ComponentResource):
@@ -510,12 +512,13 @@ class Paperless(p.ComponentResource):
         traefic_service = k8s.core.v1.Service.get(
             'traefik-service', 'traefik/traefik', opts=k8s_opts
         )
+        traefik_ip = traefic_service.status.load_balancer.ingress[0].ip
         record = utils.opnsense.unbound.host_override.HostOverride(
             'paperless',
             host='paperless',
             domain=component_config.cloudflare.zone,
             record_type='A',
-            ipaddress=traefic_service.status.load_balancer.ingress[0].ip,
+            ipaddress=traefik_ip,
         )
 
         fqdn = f'paperless.{component_config.cloudflare.zone}'
@@ -554,6 +557,8 @@ class Paperless(p.ComponentResource):
 
         # Create backup CronJob
         create_backup_cronjob(component_config, k8s_opts)
+
+        create_paperless_gpt(component_config, traefik_ip, k8s_opts)
 
         self.register_outputs({})
 
@@ -670,4 +675,109 @@ def create_gotenberg(
             'selector': gotenberg_sts.spec.selector.match_labels,
         },
         opts=opts,
+    )
+
+
+def create_paperless_gpt(
+    component_config: ComponentConfig,
+    traefik_ip: p.Output[str],
+    opts: p.ResourceOptions,
+) -> None:
+    app_labels = {'app': 'paperless-gpt'}
+    deployment = k8s.apps.v1.Deployment(
+        'paperless-gpt',
+        metadata={'name': 'paperless-gpt'},
+        spec={
+            'replicas': 1,
+            'selector': {'match_labels': app_labels},
+            'template': {
+                'metadata': {'labels': app_labels},
+                'spec': {
+                    'containers': [
+                        {
+                            'name': 'paperless-gpt',
+                            'image': f'icereed/paperless-gpt:{component_config.paperless_gpt.version}',
+                            'ports': [{'container_port': PAPERLESS_GPT_PORT}],
+                            'env': [
+                                {
+                                    'name': 'PAPERLESS_BASE_URL',
+                                    'value': f'http://paperless:{PAPERLESS_PORT}',
+                                },
+                                {
+                                    'name': 'PAPERLESS_PUBLIC_URL',
+                                    'value': f'https://paperless.{component_config.cloudflare.zone}',
+                                },
+                                {
+                                    'name': 'PAPERLESS_TOKEN',
+                                    'value': component_config.paperless_gpt.api_token.value,
+                                },
+                                {
+                                    'name': 'LLM_PROVIDER',
+                                    'value': 'ollama',
+                                },
+                                {
+                                    'name': 'OLLAMA_HOST',
+                                    'value': f'http://ollama.ollama.svc.cluster.local:{OLLAMA_PORT}',
+                                },
+                                {
+                                    'name': 'LLM_MODEL',
+                                    'value': component_config.paperless_gpt.llm_model,
+                                },
+                            ],
+                            'resources': component_config.resources.paperless_gpt.to_resource_requirements(),
+                        },
+                    ],
+                },
+            },
+        },
+        opts=opts,
+    )
+
+    service = k8s.core.v1.Service(
+        'paperless-gpt',
+        metadata={'name': 'paperless-gpt'},
+        spec={
+            'ports': [{'port': PAPERLESS_GPT_PORT}],
+            'selector': deployment.spec.selector.match_labels,
+        },
+        opts=opts,
+    )
+
+    record = utils.opnsense.unbound.host_override.HostOverride(
+        'paperless-gpt',
+        host='paperless-gpt',
+        domain=component_config.cloudflare.zone,
+        record_type='A',
+        ipaddress=traefik_ip,
+    )
+
+    fqdn = f'paperless-gpt.{component_config.cloudflare.zone}'
+    k8s.apiextensions.CustomResource(
+        'ingress-paperless-gpt',
+        api_version='traefik.io/v1alpha1',
+        kind='IngressRoute',
+        metadata={'name': 'ingress-paperless-gpt'},
+        spec={
+            'entryPoints': ['websecure'],
+            'routes': [
+                {
+                    'kind': 'Rule',
+                    'match': p.Output.concat('Host(`', fqdn, '`)'),
+                    'services': [
+                        {
+                            'name': service.metadata.name,
+                            'namespace': service.metadata.namespace,
+                            'port': PAPERLESS_GPT_PORT,
+                        },
+                    ],
+                }
+            ],
+            'tls': {},
+        },
+        opts=opts,
+    )
+
+    p.export(
+        'paperless_gpt_url',
+        p.Output.format('https://{}.{}', record.host, record.domain),
     )


### PR DESCRIPTION
## Summary
This PR adds integration with Paperless GPT, an AI-powered document analysis tool for Paperless, configured to use Ollama as the LLM provider.

## Key Changes
- **New port constants**: Added `PAPERLESS_GPT_PORT` (8080) and `OLLAMA_PORT` (11434) for service communication
- **Refactored Traefik IP retrieval**: Extracted `traefik_ip` to a variable for reuse across multiple DNS and ingress configurations
- **New `create_paperless_gpt()` function**: Implements complete Paperless GPT deployment including:
  - Kubernetes Deployment with configurable image version and resource limits
  - Service exposure on port 8080
  - DNS host override via OPNsense Unbound
  - Traefik IngressRoute for HTTPS access
  - Environment variables for Paperless integration, Ollama connectivity, and LLM model selection
- **Configuration schema updates**:
  - New `PaperlessGptConfig` class for version, LLM model, and API token management
  - Extended `PaperlessResourcesConfig` with paperless-gpt resource allocation
  - Extended `ComponentConfig` with paperless-gpt configuration
- **Production config**: Added Paperless GPT configuration with version 0.7.1, gemma4 model, and resource limits (10m CPU, 256Mi memory)

## Implementation Details
- Paperless GPT connects to the local Paperless instance via internal service DNS (`http://paperless:8000`)
- Ollama integration uses cluster-local DNS (`http://ollama.ollama.svc.cluster.local:11434`)
- API token is securely managed via 1Password reference
- Service is exposed via HTTPS through Traefik with DNS resolution via OPNsense

https://claude.ai/code/session_01FEvmHypWR2gXbkXJhFHHNo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Paperless GPT integration with Ollama language model support for AI-powered document processing capabilities
  * Paperless GPT service is now accessible through a dedicated, secure endpoint with full system integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->